### PR TITLE
Correct Alignment of MT Support

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/CokeOven.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/CokeOven.java
@@ -15,7 +15,7 @@ import stanhebben.zenscript.annotations.ZenMethod;
 public class CokeOven
 {
 	@ZenMethod
-	public static void addRecipe(IItemStack output, IIngredient input, int time, int fuelOutput)
+	public static void addRecipe(IItemStack output, int fuelOutput, IIngredient input, int time)
 	{
 		Object oInput = MTHelper.toObject(input);
 		if(oInput==null)

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Fermenter.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Fermenter.java
@@ -20,7 +20,7 @@ import blusunrize.immersiveengineering.api.DieselHandler.FermenterRecipe;
 public class Fermenter
 {
 	@ZenMethod
-	public static void addRecipe(IIngredient input, IItemStack output, int time, ILiquidStack fluid)
+	public static void addRecipe(IItemStack output, ILiquidStack fluid, IIngredient input, int time)
 	{
 		if(MTHelper.toObject(input)==null)
 			return;
@@ -76,7 +76,7 @@ public class Fermenter
 	}
 
 	@ZenMethod
-	public static void removeRecipeForFluid(ILiquidStack fluid)
+	public static void removeFluidRecipe(ILiquidStack fluid)
 	{
 		if(MTHelper.toFluidStack(fluid)!=null)
 			MineTweakerAPI.apply(new RemoveFluid(MTHelper.toFluidStack(fluid)));
@@ -134,7 +134,7 @@ public class Fermenter
 	}
 	
 	@ZenMethod
-	public static void removeRecipeForStack(IItemStack stack)
+	public static void removeItemRecipe(IItemStack stack)
 	{
 		if(MTHelper.toStack(stack)!=null)
 			MineTweakerAPI.apply(new RemoveStack(MTHelper.toStack(stack)));

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Refinery.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Refinery.java
@@ -16,7 +16,7 @@ import blusunrize.immersiveengineering.api.DieselHandler.RefineryRecipe;
 public class Refinery
 {
 	@ZenMethod
-	public static void addRecipe(ILiquidStack input0, ILiquidStack input1, ILiquidStack output)
+	public static void addRecipe(ILiquidStack output, ILiquidStack input0, ILiquidStack input1)
 	{
 		if(MTHelper.toFluidStack(input0)==null||MTHelper.toFluidStack(input0).getFluid()==null)
 			return;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Squeezer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Squeezer.java
@@ -20,7 +20,7 @@ import blusunrize.immersiveengineering.api.DieselHandler.SqueezerRecipe;
 public class Squeezer
 {
 	@ZenMethod
-	public static void addRecipe(IIngredient input, IItemStack output, int time, ILiquidStack fluid)
+	public static void addRecipe(IItemStack output, ILiquidStack fluid, IIngredient input, int time)
 	{
 		if(MTHelper.toObject(input)==null)
 			return;
@@ -76,7 +76,7 @@ public class Squeezer
 	}
 
 	@ZenMethod
-	public static void removeRecipeForFluid(ILiquidStack fluid)
+	public static void removeFluidRecipe(ILiquidStack fluid)
 	{
 		if(MTHelper.toFluidStack(fluid)!=null)
 			MineTweakerAPI.apply(new RemoveFluid(MTHelper.toFluidStack(fluid)));
@@ -134,7 +134,7 @@ public class Squeezer
 	}
 	
 	@ZenMethod
-	public static void removeRecipeForStack(IItemStack stack)
+	public static void removeItemStack(IItemStack stack)
 	{
 		if(MTHelper.toStack(stack)!=null)
 			MineTweakerAPI.apply(new RemoveStack(MTHelper.toStack(stack)));


### PR DESCRIPTION
**What has been changed:**
 - Output before Input as Minetweaker does it like that as well
 - Fluid before Input as Blu wants it like that ,_,
 - Simplify some names of the ZenMethods because those were kind of complicated and now they're easier for the user to understand
 - Now with 100% less API conflicts

