### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ config.cfg
 GregTech.cfg
 GregTech.lang
 minetweaker.log
+.DS_Store


### PR DESCRIPTION
This is so mac users like me can send pull requests without the .DS_Store file that are auto-generatored by OS X, since most people don't those. See: http://en.wikipedia.org/wiki/.DS_Store