### PR TITLE
getRandomMineral is actually random

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/tool/ExcavatorHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/tool/ExcavatorHandler.java
@@ -62,8 +62,7 @@ public class ExcavatorHandler
 		int query = (int) ((seed+((chunkX*chunkX*71862)+(chunkZ*chunkZ*31261)))^seed);
 		if(empty)
 			return null;
-		int weight = query%totalWeight;
-
+		int weight = Math.abs(query%totalWeight);
 		for(Map.Entry<MineralMix, Integer> e : mineralList.entrySet())
 		{
 			weight -= e.getValue();


### PR DESCRIPTION
before fix: http://ideone.com/KWhkBc
after fix: http://ideone.com/C2xmaQ

If "weight" is smaller then 0, then I can find only Iron, because Iron is first on mineral list.