### PR TITLE
Improved build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,21 @@ buildscript {
     }
 }
 
+repositories {
+    maven { // The repo from which to get ChickenBones' stuff, like CCLib and NEI
+        name 'CB Maven FS'
+        url "http://chickenbones.net/maven/"
+    }
+    maven { // The repo from which to get waila
+        name "Mobius Repo"
+        url "http://mobiusstrip.eu/maven"
+    }
+	maven { // The repo from which to get IC2
+		name = "ic2"
+		url = "http://maven.ic2.player.to/"
+	}
+}
+
 apply plugin: 'forge'
 
 version = "0.4.4"
@@ -28,8 +43,14 @@ minecraft {
 }
 
 dependencies {
-
+	compile "codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev"
+    compile "codechicken:NotEnoughItems:1.7.10-1.0.5.111:dev"
+	compile "com.pahimar.ee3:EquivalentExchange3:1.7.10-0.3.507:dev"
+	compile 'net.industrial-craft:industrialcraft-2:2.2.757-experimental:api'
 }
+
+// You should download deobfuscated JARs of these mods and put them into a folder named "libs" to make this compile:
+// AquaTweaks, MineFactoryReloaded, MineTweaker
 
 processResources
 {

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/BlockIECrop.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/BlockIECrop.java
@@ -116,7 +116,7 @@ public class BlockIECrop extends BlockBush implements IGrowable
 	{
 		this.checkAndDropBlock(world, x, y, z);
 		int light = world.getBlockLightValue(x, y, z);
-		if(light >= 9)
+		if(light >= 12)
 		{
 			int meta = world.getBlockMetadata(x, y, z);
 			if(meta>4)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/BlockIECrop.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/BlockIECrop.java
@@ -116,7 +116,7 @@ public class BlockIECrop extends BlockBush implements IGrowable
 	{
 		this.checkAndDropBlock(world, x, y, z);
 		int light = world.getBlockLightValue(x, y, z);
-		if(light >= 12)
+		if(light >= 9)
 		{
 			int meta = world.getBlockMetadata(x, y, z);
 			if(meta>4)


### PR DESCRIPTION
Several dependencies are now automagically obtained through maven repos,
meaning you only need 3 deobf jars in your libs folder: AquaTweaks,
MineFactoryReloaded, and MineTweaker. This makes compiling the mod a lot
easier, as you don't need to run around the internet grabbing deobf jars
for a ton of mods this depends on, based on errors in the build log.
Though ideally, you'd break out version numbers into variables stored in
a build.properties file...

There was another change, but I scrubbed it out.