### PR TITLE
Fix HV Wire Relays, close #288

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRelayHV.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRelayHV.java
@@ -22,6 +22,14 @@ public class TileEntityRelayHV extends TileEntityConnectorHV
 			return false;
 		return limitType==null||limitType==cableType;
 	}
+
+	@Override
+	public Vec3 getRaytraceOffset()
+	{
+		ForgeDirection fd = ForgeDirection.getOrientation(facing).getOpposite();
+		return Vec3.createVectorHelper(.5+fd.offsetX*.4375, .5+fd.offsetY*.4375, .5+fd.offsetZ*.4375);
+	}
+
 	@Override
 	public boolean isEnergyOutput()
 	{


### PR DESCRIPTION
I simply added a missing method override with the values calculated the same way as for the other connector types. Maybe there could be a more elegant solution, but I know you hate constants :p