### PR TITLE
Optional Annotation for some ZenMethods

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/ArcFurnace.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/ArcFurnace.java
@@ -7,6 +7,7 @@ import minetweaker.MineTweakerAPI;
 import minetweaker.api.item.IIngredient;
 import minetweaker.api.item.IItemStack;
 import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import blusunrize.immersiveengineering.api.crafting.ArcFurnaceRecipe;
@@ -15,7 +16,7 @@ import blusunrize.immersiveengineering.api.crafting.ArcFurnaceRecipe;
 public class ArcFurnace
 {
 	@ZenMethod
-	public static void addRecipe(IItemStack output, IIngredient input, IItemStack slag, int time, int energyPerTick, IIngredient[] additives)
+	public static void addRecipe(IItemStack output, IIngredient input, IItemStack slag, int time, int energyPerTick, @Optional IIngredient[] additives)
 	{
 		Object oInput = MTHelper.toObject(input);
 		if(oInput==null)

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Crusher.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Crusher.java
@@ -7,6 +7,7 @@ import minetweaker.MineTweakerAPI;
 import minetweaker.api.item.IIngredient;
 import minetweaker.api.item.IItemStack;
 import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import blusunrize.immersiveengineering.api.crafting.CrusherRecipe;
@@ -15,7 +16,7 @@ import blusunrize.immersiveengineering.api.crafting.CrusherRecipe;
 public class Crusher
 {
 	@ZenMethod
-	public static void addRecipe(IItemStack output, IIngredient input, int energy, IItemStack secondaryOutput, double secondaryChance)
+	public static void addRecipe(IItemStack output, IIngredient input, int energy, @Optional IItemStack secondaryOutput, @Optional double secondaryChance)
 	{
 		Object oInput = MTHelper.toObject(input);
 		if(oInput==null)

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Refinery.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Refinery.java
@@ -7,7 +7,6 @@ import minetweaker.IUndoableAction;
 import minetweaker.MineTweakerAPI;
 import minetweaker.api.liquid.ILiquidStack;
 import net.minecraftforge.fluids.FluidStack;
-import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import blusunrize.immersiveengineering.api.energy.DieselHandler;
@@ -17,7 +16,7 @@ import blusunrize.immersiveengineering.api.energy.DieselHandler.RefineryRecipe;
 public class Refinery
 {
 	@ZenMethod
-	public static void addRecipe(ILiquidStack output, ILiquidStack input0, @Optional ILiquidStack input1)
+	public static void addRecipe(ILiquidStack output, ILiquidStack input0, ILiquidStack input1)
 	{
 		if(MTHelper.toFluidStack(input0)==null||MTHelper.toFluidStack(input0).getFluid()==null)
 			return;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Refinery.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/Refinery.java
@@ -7,6 +7,7 @@ import minetweaker.IUndoableAction;
 import minetweaker.MineTweakerAPI;
 import minetweaker.api.liquid.ILiquidStack;
 import net.minecraftforge.fluids.FluidStack;
+import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import blusunrize.immersiveengineering.api.energy.DieselHandler;
@@ -16,7 +17,7 @@ import blusunrize.immersiveengineering.api.energy.DieselHandler.RefineryRecipe;
 public class Refinery
 {
 	@ZenMethod
-	public static void addRecipe(ILiquidStack output, ILiquidStack input0, ILiquidStack input1)
+	public static void addRecipe(ILiquidStack output, ILiquidStack input0, @Optional ILiquidStack input1)
 	{
 		if(MTHelper.toFluidStack(input0)==null||MTHelper.toFluidStack(input0).getFluid()==null)
 			return;


### PR DESCRIPTION
Usually something with more than one Input/Output (unless it's an Array)
should have an @'Optional annotation. This is because you do not have to
type out every single parameter with "null" or "0", making the code
cleaner.

I am kind of unsure whether or not the Optional annotation for the
AdditiveArray is fitting because I'm not sure whether how essential the
Additives are to the Arc Furnace. I can remove it if you think it does
not fit :)