### PR TITLE
fix crusher updates when out of energy

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityCrusher.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityCrusher.java
@@ -138,7 +138,12 @@ public class TileEntityCrusher extends TileEntityMultiblockPart implements IEner
 					int consumed = this.energyStorage.extractEnergy(power, false);
 					if(consumed>0){
 						process -= consumed;
-					} else {
+						if(!active)
+						{
+							active = true;
+							update = true;
+						}
+					} else if(active) {
 						active = false;
 						update = true;
 					}


### PR DESCRIPTION
Only change `active` state of the crusher when it needs to be changed, avoiding unnecessary updates. (`else if(active)` part)
Also resume processing instead of just consuming energy and starting processing for the same item again. (`if(!active)` part)