### PR TITLE
Restart connection raytracing

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices.java
@@ -417,7 +417,7 @@ public class BlockMetalDevices extends BlockIEBase implements blusunrize.aquatwe
 	{
 		if(world.getTileEntity(x, y, z) instanceof TileEntityConnectorLV)
 		{
-			float length = world.getTileEntity(x, y, z) instanceof TileEntityRelayHV?.875f: world.getTileEntity(x, y, z) instanceof TileEntityConnectorHV?.75f: .5f;
+			float length = world.getTileEntity(x, y, z) instanceof TileEntityRelayHV?.875f: world.getTileEntity(x, y, z) instanceof TileEntityConnectorHV?.75f: world.getTileEntity(x, y, z) instanceof TileEntityConnectorMV?.5625f: .5f;
 
 			switch(((TileEntityConnectorLV)world.getTileEntity(x, y, z)).facing )
 			{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorMV.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorMV.java
@@ -1,5 +1,6 @@
 package blusunrize.immersiveengineering.common.blocks.metal;
 
+import blusunrize.immersiveengineering.api.energy.IImmersiveConnectable;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
 import blusunrize.immersiveengineering.api.energy.WireType;
@@ -17,7 +18,13 @@ public class TileEntityConnectorMV extends TileEntityConnectorLV
 	{
 		return false;
 	}
-	
+
+	@Override
+	public Vec3 getRaytraceOffset(IImmersiveConnectable link)
+	{
+		ForgeDirection fd = ForgeDirection.getOrientation(facing).getOpposite();
+		return Vec3.createVectorHelper(.5+fd.offsetX*.125, .5+fd.offsetY*.125, .5+fd.offsetZ*.125);
+	}
 	@Override
 	public Vec3 getConnectionOffset(Connection con)
 	{


### PR DESCRIPTION
This should remove nearly all unexpected "connection obstructed" messages due to failed connection validation, see #392. The only exception are blocks with an irregular model like wall mounts - we can only check for bounding boxes, not visible models.

ToDo before or after merging: remove debug logging and threshold variable