### PR TITLE
only grow Hemp from the first block, close #430

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/BlockIECrop.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/BlockIECrop.java
@@ -208,7 +208,7 @@ public class BlockIECrop extends BlockBush implements IGrowable
 				world.setBlockMetadataWithNotify(x, y, z, newMeta, 0x3);
 			meta = newMeta;
 		}
-		if(meta>3 && world.isAirBlock(x, y+1, z))
+		if(meta==4 && world.isAirBlock(x, y+1, z))
 			world.setBlock(x, y+1, z, this, meta+1, 0x3);
 	}
 }


### PR DESCRIPTION
Some mods don't check func_149852_a before calling func_149853_b,
causing invalid metadata and endless growth.