### PR TITLE
Fix #428 cables being removed from wrong world.

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/energy/ImmersiveNetHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/energy/ImmersiveNetHandler.java
@@ -31,7 +31,14 @@ public class ImmersiveNetHandler
 	public static ImmersiveNetHandler INSTANCE;
 	public ConcurrentHashMap<Integer, ConcurrentHashMap<ChunkCoordinates, ConcurrentSkipListSet<Connection>>> directConnections = new ConcurrentHashMap<Integer, ConcurrentHashMap<ChunkCoordinates, ConcurrentSkipListSet<Connection>>>();
 	public ConcurrentHashMap<ChunkCoordinates, ConcurrentSkipListSet<AbstractConnection>> indirectConnections = new ConcurrentHashMap<ChunkCoordinates, ConcurrentSkipListSet<AbstractConnection>>();
-	public HashMap<Connection, Integer> transferPerTick = new HashMap<Connection, Integer>();
+	private HashMap<Integer, HashMap<Connection, Integer>> transferPerTick = new HashMap<Integer, HashMap<Connection, Integer>>();
+	
+	public HashMap<Connection, Integer> getTransferPerTick(int dimension){
+		if(!transferPerTick.containsKey(dimension)){
+			transferPerTick.put(dimension, new HashMap<Connection, Integer>());
+		}
+		return transferPerTick.get(dimension);
+	}
 
 	private ConcurrentHashMap<ChunkCoordinates, ConcurrentSkipListSet<Connection>> getMultimap(int dimension)
 	{
@@ -94,10 +101,10 @@ public class ImmersiveNetHandler
 						world.addBlockEvent(itCon.end.posX, itCon.end.posY, itCon.end.posZ, world.getBlock(itCon.end.posX,itCon.end.posY,itCon.end.posZ),-1,0);
 				}
 			}
-			if(FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER)
-				indirectConnections.clear();
-			IESaveData.setDirty(world.provider.dimensionId);
 		}
+		if(FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER)
+			indirectConnections.clear();
+		IESaveData.setDirty(world.provider.dimensionId);
 	}
 	public Set<Integer> getRelevantDimensions()
 	{

--- a/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
@@ -93,9 +93,9 @@ public class EventHandler
 	@SubscribeEvent
 	public void onWorldTick(WorldTickEvent event)
 	{
-		if(event.phase==TickEvent.Phase.END && FMLCommonHandler.instance().getEffectiveSide()==Side.SERVER)
+		if(event.phase==TickEvent.Phase.START && FMLCommonHandler.instance().getEffectiveSide()==Side.SERVER)
 		{
-			for(Map.Entry<Connection, Integer> e : ImmersiveNetHandler.INSTANCE.transferPerTick.entrySet())
+			for(Map.Entry<Connection, Integer> e : ImmersiveNetHandler.INSTANCE.getTransferPerTick(event.world.provider.dimensionId).entrySet())
 				if(e.getValue()>e.getKey().cableType.getTransferRate())
 				{
 					if(event.world instanceof WorldServer)
@@ -103,7 +103,7 @@ public class EventHandler
 							((WorldServer)event.world).func_147487_a("flame", vec.xCoord,vec.yCoord,vec.zCoord, 0, 0,.02,0, 1);
 					ImmersiveNetHandler.INSTANCE.removeConnection(event.world, e.getKey());
 				}
-			ImmersiveNetHandler.INSTANCE.transferPerTick.clear();
+			ImmersiveNetHandler.INSTANCE.getTransferPerTick(event.world.provider.dimensionId).clear();
 		}
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorLV.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorLV.java
@@ -224,7 +224,8 @@ public class TileEntityConnectorLV extends TileEntityImmersiveConnectable implem
 						for(Connection sub : con.subConnections)
 						{
 							IELogger.debug("Sub Con"+sub.start+" to "+sub.end);
-							int transferredPerCon = ImmersiveNetHandler.INSTANCE.transferPerTick.containsKey(sub)?ImmersiveNetHandler.INSTANCE.transferPerTick.get(sub):0;
+							int transferredPerCon = ImmersiveNetHandler.INSTANCE.getTransferPerTick(this.worldObj.provider.dimensionId).containsKey(sub)?
+									ImmersiveNetHandler.INSTANCE.getTransferPerTick(this.worldObj.provider.dimensionId).get(sub):0;
 							IELogger.debug("old t "+transferredPerCon);
 							transferredPerCon += r;
 							IELogger.debug("new t "+transferredPerCon);
@@ -234,7 +235,7 @@ public class TileEntityConnectorLV extends TileEntityImmersiveConnectable implem
 								IELogger.debug("Or at least hotter than "+sub.cableType.getTransferRate());
 							}
 							if(!simulate)
-								ImmersiveNetHandler.INSTANCE.transferPerTick.put(sub,transferredPerCon);
+								ImmersiveNetHandler.INSTANCE.getTransferPerTick(this.worldObj.provider.dimensionId).put(sub,transferredPerCon);
 						}
 						received += r;
 						powerLeft -= r;


### PR DESCRIPTION
Connections has been removed from first ticked dimension, which doesn't happen to be the right way to do things.