### PR TITLE
Fixes for the energynet, round 2

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/energy/ImmersiveNetHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/energy/ImmersiveNetHandler.java
@@ -307,13 +307,7 @@ public class ImmersiveNetHandler
 			return indirectConnections.get(node);
 
 		List<IImmersiveConnectable> openList = new ArrayList<IImmersiveConnectable>();
-		ConcurrentSkipListSet<AbstractConnection> closedList = new ConcurrentSkipListSet<AbstractConnection>(new Comparator<AbstractConnection>() {
-			@Override
-			public int compare(AbstractConnection c0, AbstractConnection c1)
-			{
-				return c0.compareTo(c1);
-			}
-		});
+		ConcurrentSkipListSet<AbstractConnection> closedList = new ConcurrentSkipListSet<AbstractConnection>();
 		List<ChunkCoordinates> checked = new ArrayList<ChunkCoordinates>();
 		HashMap<ChunkCoordinates,ChunkCoordinates> backtracker = new HashMap<ChunkCoordinates,ChunkCoordinates>();
 
@@ -460,8 +454,9 @@ public class ImmersiveNetHandler
 
 		@Override
 		public int compareTo(Connection o) {
-			if (equals(o))
-				return 0;
+			//this is not consistant with equals any more, but saving to nbt does not work otherwise
+//			if (equals(o))
+//				return 0;
 			int distComp = Integer.compare(length, o.length);
 			int cableComp = -1*Integer.compare(cableType.getTransferRate(), o.cableType.getTransferRate());
 			if(cableComp!=0)
@@ -479,8 +474,7 @@ public class ImmersiveNetHandler
 			if (end.posY!=o.end.posY)
 				return end.posY>o.end.posY?1:-1;
 			if (end.posZ!=o.end.posZ)
-				return end.posZ>o.end.posZ?1:-1;	
-			//This should not happen, since equals(o) is true in this case
+				return end.posZ>o.end.posZ?1:-1;
 			return 0;
 		}
 	}

--- a/src/main/java/blusunrize/immersiveengineering/api/energy/ImmersiveNetHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/energy/ImmersiveNetHandler.java
@@ -311,7 +311,7 @@ public class ImmersiveNetHandler
 			@Override
 			public int compare(AbstractConnection c0, AbstractConnection c1)
 			{
-				return c0.compare(c1);
+				return c0.compareTo(c1);
 			}
 		});
 		List<ChunkCoordinates> checked = new ArrayList<ChunkCoordinates>();
@@ -457,21 +457,17 @@ public class ImmersiveNetHandler
 				return new Connection(start,end, type, tag.getInteger("length"));
 			return null;
 		}
-		public int compare(Connection con)
-		{
-			if(con==null||con.cableType==null||cableType==null)
-				return 0;
-			int distComp = Integer.compare(length, con.length);
-			int cableComp = -1*Integer.compare(cableType.getTransferRate(), con.cableType.getTransferRate());
-			if(distComp==0)
-				return cableComp;
-			return distComp;
-		}
 
 		@Override
 		public int compareTo(Connection o) {
 			if (equals(o))
 				return 0;
+			int distComp = Integer.compare(length, o.length);
+			int cableComp = -1*Integer.compare(cableType.getTransferRate(), o.cableType.getTransferRate());
+			if(cableComp!=0)
+				return cableComp;
+			if (distComp!=0)
+				return distComp;
 			if (start.posX!=o.start.posX)
 				return start.posX>o.start.posX?1:-1;
 			if (start.posY!=o.start.posY)

--- a/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
@@ -95,7 +95,7 @@ public class EventHandler
 	{
 		if(event.phase==TickEvent.Phase.END && FMLCommonHandler.instance().getEffectiveSide()==Side.SERVER)
 		{
-			for(Map.Entry<Connection, Integer> e : ImmersiveNetHandler.INSTANCE.transferPerTick.entrySet())
+			for(Map.Entry<Connection, Integer> e : ImmersiveNetHandler.INSTANCE.getTransferedRates(event.world.provider.dimensionId).entrySet())
 				if(e.getValue()>e.getKey().cableType.getTransferRate())
 				{
 					if(event.world instanceof WorldServer)
@@ -103,7 +103,7 @@ public class EventHandler
 							((WorldServer)event.world).func_147487_a("flame", vec.xCoord,vec.yCoord,vec.zCoord, 0, 0,.02,0, 1);
 					ImmersiveNetHandler.INSTANCE.removeConnection(event.world, e.getKey());
 				}
-			ImmersiveNetHandler.INSTANCE.transferPerTick.clear();
+			ImmersiveNetHandler.INSTANCE.getTransferedRates(event.world.provider.dimensionId).clear();
 		}
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorLV.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorLV.java
@@ -224,7 +224,7 @@ public class TileEntityConnectorLV extends TileEntityImmersiveConnectable implem
 						for(Connection sub : con.subConnections)
 						{
 							IELogger.debug("Sub Con"+sub.start+" to "+sub.end);
-							int transferredPerCon = ImmersiveNetHandler.INSTANCE.transferPerTick.containsKey(sub)?ImmersiveNetHandler.INSTANCE.transferPerTick.get(sub):0;
+							int transferredPerCon = ImmersiveNetHandler.INSTANCE.getTransferedRates(worldObj.provider.dimensionId).containsKey(sub)?ImmersiveNetHandler.INSTANCE.getTransferedRates(worldObj.provider.dimensionId).get(sub):0;
 							IELogger.debug("old t "+transferredPerCon);
 							transferredPerCon += r;
 							IELogger.debug("new t "+transferredPerCon);
@@ -233,7 +233,7 @@ public class TileEntityConnectorLV extends TileEntityImmersiveConnectable implem
 								IELogger.debug("Okay, this wire is HAWT.");
 								IELogger.debug("Or at least hotter than "+sub.cableType.getTransferRate());
 							}
-							ImmersiveNetHandler.INSTANCE.transferPerTick.put(sub,transferredPerCon);
+							ImmersiveNetHandler.INSTANCE.getTransferedRates(worldObj.provider.dimensionId).put(sub,transferredPerCon);
 						}
 						received += r;
 						powerLeft -= r;

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/EntitySkycrate.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/EntitySkycrate.java
@@ -106,7 +106,7 @@ public class EntitySkycrate extends EntitySkylineHook
 			vec = vec.normalize();
 			Connection line = null;
 			for(Connection c : outputs)
-				if(c!=null && !c.equals(this.connection))
+				if(c!=null && !c.hasSameConnectors(this.connection))
 				{
 					if(line==null)
 						line = c;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/SkylineHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/SkylineHelper.java
@@ -28,8 +28,7 @@ public class SkylineHelper
 			vec = vec.normalize();
 			Connection line = null;
 			for(Connection c : outputs)
-				if(c!=null && !c.equals(invalidCon))
-				{
+				if(c!=null && !c.hasSameConnectors(invalidCon))				{
 					if(line==null)
 						line = c;
 					else


### PR DESCRIPTION
fixed some indirect connections not being used due to being considered equal to other connections without being so
fixed connections only being saved to nbt in one direction because they were considered equal to their reverse connection by `compareTo` and `equals`
fixed wires only burning in the "lowest" loaded dimension (this fix was found independently by @marcin212 as well)
this does create a merge conflict, for further information, see [here](https://help.github.com/articles/resolving-a-merge-conflict-from-the-command-line/)