### PR TITLE
remove only arms of the wooden post being broken

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/BlockWoodenDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/BlockWoodenDevices.java
@@ -379,7 +379,7 @@ public class BlockWoodenDevices extends BlockIEBase implements blusunrize.aquatw
 				world.setBlockToAir(x,yy+i,z);
 				if(i==3)
 					for(ForgeDirection fd : new ForgeDirection[]{ForgeDirection.NORTH,ForgeDirection.SOUTH,ForgeDirection.EAST,ForgeDirection.WEST})
-						if(world.getTileEntity(x+fd.offsetX,yy+i,z+fd.offsetZ) instanceof TileEntityWoodenPost && ((TileEntityWoodenPost)world.getTileEntity(x+fd.offsetX,yy+i,z+fd.offsetZ)).type>3)
+						if(world.getTileEntity(x+fd.offsetX,yy+i,z+fd.offsetZ) instanceof TileEntityWoodenPost && ((TileEntityWoodenPost)world.getTileEntity(x+fd.offsetX,yy+i,z+fd.offsetZ)).type==(2+fd.ordinal()))
 							world.setBlockToAir(x+fd.offsetX,yy+i,z+fd.offsetZ);
 			}
 			if(type==0 && !world.isRemote && world.getGameRules().getGameRuleBooleanValue("doTileDrops") && !world.restoringBlockSnapshots)


### PR DESCRIPTION
This commit adds a check to make sure only the arms of the wooden post being broken are being removed. Without this check all arms around the post's top block would get broken, no matter which post they were attached to.
Example of a situation where this happend: ![](https://cloud.githubusercontent.com/assets/163331/9977368/d11d46b2-5f04-11e5-9b57-99c20efca373.png)
Breaking the right post broke the arm of the left post, dropping the HV relay.

Using `fd.ordinal()` is somewhat hacky, but Forge doesn't offer a method to convert a ForgeDirection back to a 'side' int. It's the same way `type` is set when adding the arms, so it shouldn't matter and I didn't want to rewrite the whole code touching this field.