### PR TITLE
Add a config option for EE3 compat

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/Config.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/Config.java
@@ -64,7 +64,14 @@ public class Config
 		setBoolean("ic2compat", config.get("General", "IC2 Compatability", true, "Set this to false to prevent wires from accepting and outputting EU").getBoolean());
 		setBoolean("gregtechcompat", config.get("General", "GregTech Compatability", true, "Set this to false to prevent wires from outputting GregTech EU").getBoolean());
 		setInt("euConversion", config.get("General", "EU Conversion", 4, "The amount of RF that equal 1 EU. 4 by default, so 4RF == 1EU and .25EU == 1RF").getInt());
-
+		int ee3 = config.get("General", "EE3 integration mode", 2, "How EE3 EMC values will be registered. 0 means they will not be registered at all, 1 means that they are registered as \"post\"-values and 2 means that they will be registered as \"pre\"-values. \"post\"-values may cause less problems with DynEMC, however items that are crafted using the registered materials will not have an EMC value").getInt();
+		if (ee3<0||ee3>2)
+		{
+			IELogger.warn("The EE3 integration mode has to be an integer between 0 and 2, "+ee3+" is not a valid value. Defaulting to 2");
+			ee3 = 2;
+		}
+		setInt("ee3mode", ee3);
+		
 		setInt("villager_engineer", config.get("General", "Villager ID: Engineer", 512, "The villager ID for the Engineer Villager. Change if it conflicts").getInt());
 
 		setInt("capacitorLV_storage", config.get("Machines", "Capacitor LV: RF Storage", 100000, "The maximum amount of RF that can be stored in a low-voltage capacitor").getInt());
@@ -121,7 +128,7 @@ public class Config
 		setDouble("BulletDamage-Wolfpack", config.get("Tools", "BulletDamage-Wolfpack", 6d, "The amount of base damage a Wolfpack Cartridge inflicts").getDouble());
 		setDouble("BulletDamage-WolfpackPart", config.get("Tools", "BulletDamage-WolfpackPart", 4d, "The amount of damage the sub-projectiles of the Wolfpack Cartridge inflict").getDouble());
 		setDouble("BulletDamage-Silver", config.get("Tools", "BulletDamage-Silver", 7d, "The amount of damage a silver bullet inflicts").getDouble());
-
+		
 		config.save();
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/EE3Helper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/EE3Helper.java
@@ -18,46 +18,49 @@ public class EE3Helper extends IECompatModule
 	@Override
 	public void postInit()
 	{
-		addValue(new ItemStack(IEContent.itemMetal,1,0), 128);//Copper
-		addValue(new ItemStack(IEContent.itemMetal,1,1), 192);//Aluminium
-		addValue(new ItemStack(IEContent.itemMetal,1,2), 512);//Lead
-		addValue(new ItemStack(IEContent.itemMetal,1,3), 512);//Silver
-		addValue(new ItemStack(IEContent.itemMetal,1,4), 1024);//Nickel
-		addValue(new ItemStack(IEContent.itemMetal,1,5), 576);//Constantan
+		int mode = Config.getInt("ee3mode");
+		if (mode==0)
+			return;
+		addValue(new ItemStack(IEContent.itemMetal,1,0), 128, mode==2);//Copper
+		addValue(new ItemStack(IEContent.itemMetal,1,1), 192, mode==2);//Aluminium
+		addValue(new ItemStack(IEContent.itemMetal,1,2), 512, mode==2);//Lead
+		addValue(new ItemStack(IEContent.itemMetal,1,3), 512, mode==2);//Silver
+		addValue(new ItemStack(IEContent.itemMetal,1,4), 1024, mode==2);//Nickel
+		addValue(new ItemStack(IEContent.itemMetal,1,5), 576, mode==2);//Constantan
 		AbilityRegistryProxy.setAsNotLearnable(new ItemStack(IEContent.itemMetal,1,5));
-		addValue(new ItemStack(IEContent.itemMetal,1,6), 1280);//Electrum
+		addValue(new ItemStack(IEContent.itemMetal,1,6), 1280, mode==2);//Electrum
 		AbilityRegistryProxy.setAsNotLearnable(new ItemStack(IEContent.itemMetal,1,6));
-		addValue(new ItemStack(IEContent.itemMetal,1,7), 320);//Steel
-		addValue(new ItemStack(IEContent.itemMetal,1,20), 384);//Graphite
+		addValue(new ItemStack(IEContent.itemMetal,1,7), 320, mode==2);//Steel
+		addValue(new ItemStack(IEContent.itemMetal,1,20), 384, mode==2);//Graphite
 		AbilityRegistryProxy.setAsNotLearnable(new ItemStack(IEContent.itemMetal,1,20));
 
-		addValue(IEContent.itemSeeds, 24);//Hemp Seeds
-		addValue(new ItemStack(IEContent.itemMaterial,1,3), 12);//HempFiber
-		addValue(new ItemStack(IEContent.itemMaterial,1,6), 48);//Coke
-		addValue(new ItemStack(IEContent.itemMaterial,1,13), 1);//Slag
+		addValue(IEContent.itemSeeds, 24, mode==2);//Hemp Seeds
+		addValue(new ItemStack(IEContent.itemMaterial,1,3), 12, mode==2);//HempFiber
+		addValue(new ItemStack(IEContent.itemMaterial,1,6), 48, mode==2);//Coke
+		addValue(new ItemStack(IEContent.itemMaterial,1,13), 1, mode==2);//Slag
 
-		addValue(new ItemStack(IEContent.blockTreatedWood,1,OreDictionary.WILDCARD_VALUE), 24);
-		addValue(new ItemStack(IEContent.blockStoneDevice,1,4), 265);//Insulated Glass
+		addValue(new ItemStack(IEContent.blockTreatedWood,1,OreDictionary.WILDCARD_VALUE), 24, mode==2);
+		addValue(new ItemStack(IEContent.blockStoneDevice,1,4), 265, mode==2);//Insulated Glass
 
-		addValue(new ItemStack(IEContent.itemBullet,1,0), 213);//Casing
-		addValue(new ItemStack(IEContent.itemBullet,1,1), 96);//Shell
+		addValue(new ItemStack(IEContent.itemBullet,1,0), 213, mode==2);//Casing
+		addValue(new ItemStack(IEContent.itemBullet,1,1), 96, mode==2);//Shell
 		//All these recipes use gunpowder and casings/shells
-		addValue(new ItemStack(IEContent.itemBullet,1,2), 213+192 +getBulletMetal(512));//lead
-		addValue(new ItemStack(IEContent.itemBullet,1,3), 213+192 +getBulletMetal(320)+getBulletMetal(576));//2 steel+constantan nuggets
-		addValue(new ItemStack(IEContent.itemBullet,1,4), 96 +192 +256);//1 iron dust
-		addValue(new ItemStack(IEContent.itemBullet,1,5), 213+192 +964);//1 TNT
-		addValue(new ItemStack(IEContent.itemBullet,1,6), 96 +192 +192*2);// 2 aluminium dust
+		addValue(new ItemStack(IEContent.itemBullet,1,2), 213+192 +getBulletMetal(512), mode==2);//lead
+		addValue(new ItemStack(IEContent.itemBullet,1,3), 213+192 +getBulletMetal(320)+getBulletMetal(576), mode==2);//2 steel+constantan nuggets
+		addValue(new ItemStack(IEContent.itemBullet,1,4), 96 +192 +256, mode==2);//1 iron dust
+		addValue(new ItemStack(IEContent.itemBullet,1,5), 213+192 +964, mode==2);//1 TNT
+		addValue(new ItemStack(IEContent.itemBullet,1,6), 96 +192 +192*2, mode==2);// 2 aluminium dust
 		int homingVal = 213+192 + getBulletMetal(10496);//going by 10496 for Terrasteel
-		addValue(new ItemStack(IEContent.itemBullet,1,7), homingVal);
-		addValue(new ItemStack(IEContent.itemBullet,1,8), 96 +192 +homingVal*4);
+		addValue(new ItemStack(IEContent.itemBullet,1,7), homingVal, mode==2);
+		addValue(new ItemStack(IEContent.itemBullet,1,8), 96 +192 +homingVal*4, mode==2);
 		float silverNugget = (512/9f);
-		addValue(new ItemStack(IEContent.itemBullet,1,9), 213+192 +getBulletMetal(512)+(int)(silverNugget*(Config.getBoolean("hardmodeBulletRecipes")?3:1)));
-		addValue(new ItemStack(IEContent.itemBullet,1,10),213+192 +256+1);//Quartz+Glass
+		addValue(new ItemStack(IEContent.itemBullet,1,9), 213+192 +getBulletMetal(512)+(int)(silverNugget*(Config.getBoolean("hardmodeBulletRecipes")?3:1)), mode==2);
+		addValue(new ItemStack(IEContent.itemBullet,1,10),213+192 +256+1, mode==2);//Quartz+Glass
 
-		addValue(IEContent.fluidCreosote, 128);
-		addValue(IEContent.fluidEthanol, 400);
-		addValue(IEContent.fluidPlantoil, 200);
-		addValue(IEContent.fluidBiodiesel, 600);
+		addValue(IEContent.fluidCreosote, 128, mode==2);
+		addValue(IEContent.fluidEthanol, 400, mode==2);
+		addValue(IEContent.fluidPlantoil, 200, mode==2);
+		addValue(IEContent.fluidBiodiesel, 600, mode==2);
 
 	}
 
@@ -70,8 +73,11 @@ public class EE3Helper extends IECompatModule
 			return (int)((ingot/9f)*2);
 	}
 
-	static void addValue(Object o, int val)
+	static void addValue(Object o, int val, boolean pre)
 	{
-		EnergyValueRegistryProxy.addPreAssignedEnergyValue(o,val);
+		if (pre)
+			EnergyValueRegistryProxy.addPreAssignedEnergyValue(o,val);
+		else
+			EnergyValueRegistryProxy.addPostAssignedEnergyValue(o,val);
 	}
 }


### PR DESCRIPTION
This is mostly for cases in which DynEMC breaks for no apparent reason. It allows changing between pre, post and not-at-all registered values for IE items.
I experienced the disconnect described in Pahimar/Equivalent-Exchange-3#967 when trying to use 0.6-pre in a modpack on a dedicated server, this was fixed by switching to post-values. In a different setup pre registered values broke DynEMC resulting in only base items having an EMC value, this was also fixed by pos-values.