### PR TITLE
fix rendering for mirrored multiblocks

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/render/TileRenderArcFurnace.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/TileRenderArcFurnace.java
@@ -41,7 +41,8 @@ public class TileRenderArcFurnace extends TileRenderIE
 		TileEntityArcFurnace arc = (TileEntityArcFurnace)tile;
 
 		translationMatrix.translate(.5, .5, .5);
-		rotationMatrix.rotate(Math.toRadians(arc.facing==2?180: arc.facing==4?-90: arc.facing==5?90: 0), 0,1,0);
+		int f = (arc.mirrored)?3:2;
+		rotationMatrix.rotate(Math.toRadians(arc.facing==f?180: arc.facing==4?-90: arc.facing==5?90: 0), 0,1,0);
 		if(arc.mirrored)
 			translationMatrix.scale(new Vertex(1,1,-1));
 

--- a/src/main/java/blusunrize/immersiveengineering/client/render/TileRenderCrusher.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/TileRenderCrusher.java
@@ -31,7 +31,8 @@ public class TileRenderCrusher extends TileRenderIE
 		TileEntityCrusher crusher = (TileEntityCrusher)tile;
 		
 		translationMatrix.translate(.5, 1.5, .5);
-		rotationMatrix.rotate(Math.toRadians(crusher.facing==3?180: crusher.facing==4?-90: crusher.facing==5?90: 0), 0,1,0);
+		int f = crusher.mirrored?3:2;
+		rotationMatrix.rotate(Math.toRadians(crusher.facing==f?180: crusher.facing==4?-90: crusher.facing==5?90: 0), 0,1,0);
 		if(crusher.mirrored)
 			translationMatrix.scale(new Vertex(1,1,-1));
 

--- a/src/main/java/blusunrize/immersiveengineering/client/render/TileRenderDieselGenerator.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/TileRenderDieselGenerator.java
@@ -31,7 +31,8 @@ public class TileRenderDieselGenerator extends TileRenderIE
 	{
 		TileEntityDieselGenerator gen = (TileEntityDieselGenerator)tile;
 		translationMatrix.translate(.5, .5, .5);
-		rotationMatrix.rotate(Math.toRadians(gen.facing==3?180: gen.facing==4?90: gen.facing==5?-90: 0), 0,1,0);
+		int f = gen.mirrored?2:3;
+		rotationMatrix.rotate(Math.toRadians(gen.facing==f?180: gen.facing==4?90: gen.facing==5?-90: 0), 0,1,0);
 		if(gen.mirrored)
 			translationMatrix.scale(new Vertex(1,1,-1));
 		model.render(tile, tes, translationMatrix, rotationMatrix, 0, gen.mirrored, "base");


### PR DESCRIPTION
These three multiblock structures weren't rendered correctly when mirrored and oriented in north/south direction (affecting 2 out of 8 possible orientation/mirrored states).

Technically, the same problem exists for the assembler and the refinery, but these two cannot (yet?) be rotated. The rest of the multiblocks works fine - yes, I've built them all 8 times.

Most obvious when looking at invisible blocks or clipping into the model, besides parts being in the wrong place or the model facing the wrong direction:
![](https://cloud.githubusercontent.com/assets/163331/10419761/7c7966fc-7081-11e5-8468-1587aeec5701.png)
![](https://cloud.githubusercontent.com/assets/163331/10419763/8459ea0e-7081-11e5-96ad-e0cefe07b9a2.png)
![](https://cloud.githubusercontent.com/assets/163331/10419764/8b1dadb2-7081-11e5-8725-cf29ff664869.png)
