### PR TITLE
fix fluid pipe directional output check

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices2.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices2.java
@@ -227,6 +227,8 @@ public class BlockMetalDevices2 extends BlockIEBase implements ICustomBoundingbo
 			{
 				if (!world.isRemote)
 				{
+					if(player.isSneaking())
+						side = ForgeDirection.OPPOSITES[side];
 					pump.toggleSide(side);
 					world.markBlockForUpdate(x, y, z);
 				}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalMultiblocks.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalMultiblocks.java
@@ -293,30 +293,27 @@ public class BlockMetalMultiblocks extends BlockIEBase implements ICustomBoundin
 		}
 		else if(!player.isSneaking() && curr instanceof TileEntitySheetmetalTank)
 		{
-			if(!world.isRemote)
+			TileEntitySheetmetalTank tank = (TileEntitySheetmetalTank)curr;
+			TileEntitySheetmetalTank master = tank.master();
+			if(master==null)
+				master = tank;
+			if(Utils.fillFluidHandlerWithPlayerItem(world, master, player))
 			{
-				TileEntitySheetmetalTank tank = (TileEntitySheetmetalTank)curr;
-				TileEntitySheetmetalTank master = tank.master();
-				if(master==null)
-					master = tank;
-				if(Utils.fillFluidHandlerWithPlayerItem(world, master, player))
-				{
-					master.markDirty();
-					world.markBlockForUpdate(master.xCoord,master.yCoord,master.zCoord);
-					return true;
-				}
-				if(Utils.fillPlayerItemFromFluidHandler(world, master, player, master.tank.getFluid()))
-				{
-					master.markDirty();
-					world.markBlockForUpdate(master.xCoord,master.yCoord,master.zCoord);
-					return true;
-				}
-				if(player.getCurrentEquippedItem()!=null && player.getCurrentEquippedItem().getItem() instanceof IFluidContainerItem)
-				{
-					master.markDirty();
-					world.markBlockForUpdate(master.xCoord,master.yCoord,master.zCoord);
-					return true;
-				}
+				master.markDirty();
+				world.markBlockForUpdate(master.xCoord,master.yCoord,master.zCoord);
+				return true;
+			}
+			if(Utils.fillPlayerItemFromFluidHandler(world, master, player, master.tank.getFluid()))
+			{
+				master.markDirty();
+				world.markBlockForUpdate(master.xCoord,master.yCoord,master.zCoord);
+				return true;
+			}
+			if(player.getCurrentEquippedItem()!=null && player.getCurrentEquippedItem().getItem() instanceof IFluidContainerItem)
+			{
+				master.markDirty();
+				world.markBlockForUpdate(master.xCoord,master.yCoord,master.zCoord);
+				return true;
 			}
 		}
 		else if(curr instanceof TileEntityAssembler)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFluidPipe.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFluidPipe.java
@@ -133,7 +133,7 @@ public class TileEntityFluidPipe extends TileEntityIEBase implements IFluidHandl
 		int sum = 0;
 		HashMap<DirectionalFluidOutput,Integer> sorting = new HashMap<DirectionalFluidOutput,Integer>();
 		for(DirectionalFluidOutput output : outputList)
-			if(!Utils.toCC(output.output).equals(ccFrom) && output.output.canFill(output.direction, resource.getFluid()))
+			if(!Utils.toCC(output.output).equals(ccFrom) && output.output.canFill(output.direction.getOpposite(), resource.getFluid()))
 			{
 				int temp = output.output.fill(output.direction.getOpposite(), Utils.copyFluidStackWithAmount(resource, fluidForSort,true), false);
 				if(temp>0)

--- a/src/main/java/blusunrize/immersiveengineering/common/util/Utils.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/Utils.java
@@ -678,6 +678,9 @@ public class Utils
 			FluidStack fluid = FluidContainerRegistry.getFluidForFilledItem(filledStack);
 			if(fluid==null || filledStack==null)
 				return false;
+			if(world.isRemote)
+				return true;
+
 			if(!player.capabilities.isCreativeMode)
 				if(equipped.stackSize == 1)
 				{
@@ -688,17 +691,9 @@ public class Utils
 				}
 				else 
 				{
-					if(equipped.stackSize==1)
-					{
-						player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
-						player.inventory.addItemStackToInventory(filledStack);
-					}
-					else
-					{
-						equipped.stackSize -= 1;
-						if(filledStack!=null && !player.inventory.addItemStackToInventory(filledStack))
-							player.func_146097_a(filledStack, false, true);
-					}
+					equipped.stackSize -= 1;
+					if(!player.inventory.addItemStackToInventory(filledStack))
+						player.func_146097_a(filledStack, false, true);
 					player.openContainer.detectAndSendChanges();
 					((EntityPlayerMP) player).sendContainerAndContentsToPlayer(player.openContainer, player.openContainer.getInventory());
 				}
@@ -710,6 +705,9 @@ public class Utils
 			IFluidContainerItem container = (IFluidContainerItem)equipped.getItem();
 			if(container.fill(equipped, tankFluid, false)>0)
 			{
+				if(world.isRemote)
+					return true;
+
 				int fill = container.fill(equipped, tankFluid, true);
 				handler.drain(ForgeDirection.UNKNOWN, fill, true);
 				player.openContainer.detectAndSendChanges();
@@ -730,6 +728,9 @@ public class Utils
 		{
 			if(handler.fill(ForgeDirection.UNKNOWN, fluid, false) == fluid.amount || player.capabilities.isCreativeMode)
 			{
+				if(world.isRemote)
+					return true;
+
 				ItemStack filledStack = FluidContainerRegistry.drainFluidContainer(equipped);
 				if (!player.capabilities.isCreativeMode)
 				{
@@ -757,6 +758,9 @@ public class Utils
 			fluid = container.getFluid(equipped);
 			if(handler.fill(ForgeDirection.UNKNOWN, fluid, false)>0)
 			{
+				if(world.isRemote)
+					return true;
+
 				int fill = handler.fill(ForgeDirection.UNKNOWN, fluid, true);
 				container.drain(equipped, fill, true);
 				player.openContainer.detectAndSendChanges();


### PR DESCRIPTION
Check the same direction we're outputting to.

This will fix setups like this one
![](https://cloud.githubusercontent.com/assets/163331/10872536/46cf668a-8104-11e5-8c3d-a79019f51e8b.png)

Also put another critical fix in this one, fixing a fluid dupe bug when rightclicking IE tanks with buckets with placable fluids in them.
And a minor improvement: use sneak-rightclick with the hammer on the pump to change the mode of the opposite side. Very useful for pumping out of full-size and multiblock tanks.