### PR TITLE
Fix for the cme with mobspawning, closes #577, closes #567

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
@@ -165,29 +165,31 @@ public class EventHandler
 	{
 		if(event.entityLiving.isCreatureType(EnumCreatureType.monster, false))
 		{
-			Iterator<ISpawnInterdiction> it = interdictionTiles.iterator();
-			while(it.hasNext())
-			{
-				ISpawnInterdiction interdictor = it.next();
-				if(interdictor instanceof TileEntity)
+			synchronized (interdictionTiles) {
+				Iterator<ISpawnInterdiction> it = interdictionTiles.iterator();
+				while(it.hasNext())
 				{
-					if(((TileEntity)interdictor).isInvalid())
+					ISpawnInterdiction interdictor = it.next();
+					if(interdictor instanceof TileEntity)
 					{
-						it.remove();
-						continue;
+						if(((TileEntity)interdictor).isInvalid())
+						{
+							it.remove();
+							continue;
+						}
+						else if( ((TileEntity)interdictor).getWorldObj().provider.dimensionId==event.entity.worldObj.provider.dimensionId && ((TileEntity)interdictor).getDistanceFrom(event.entity.posX, event.entity.posY, event.entity.posZ)<=interdictor.getInterdictionRangeSquared())
+							event.setResult(Event.Result.DENY);
 					}
-					else if( ((TileEntity)interdictor).getWorldObj().provider.dimensionId==event.entity.worldObj.provider.dimensionId && ((TileEntity)interdictor).getDistanceFrom(event.entity.posX, event.entity.posY, event.entity.posZ)<=interdictor.getInterdictionRangeSquared())
-						event.setResult(Event.Result.DENY);
-				}
-				else if(interdictor instanceof Entity)
-				{
-					if(((Entity)interdictor).isDead)
+					else if(interdictor instanceof Entity)
 					{
-						it.remove();
-						continue;
+						if(((Entity)interdictor).isDead)
+						{
+							it.remove();
+							continue;
+						}
+						else if(((Entity)interdictor).worldObj.provider.dimensionId==event.entity.worldObj.provider.dimensionId && ((Entity)interdictor).getDistanceSqToEntity(event.entity)<=interdictor.getInterdictionRangeSquared())
+							event.setResult(Event.Result.DENY);
 					}
-					else if(((Entity)interdictor).worldObj.provider.dimensionId==event.entity.worldObj.provider.dimensionId && ((Entity)interdictor).getDistanceSqToEntity(event.entity)<=interdictor.getInterdictionRangeSquared())
-						event.setResult(Event.Result.DENY);
 				}
 			}
 		}
@@ -195,33 +197,35 @@ public class EventHandler
 	@SubscribeEvent
 	public void onEntitySpawnCheck(LivingSpawnEvent.CheckSpawn event)
 	{
-		if(event.getResult() == Event.Result.ALLOW)
+		if(event.getResult() == Event.Result.ALLOW||event.getResult() == Event.Result.DENY)
 			return;
 		if(event.entityLiving.isCreatureType(EnumCreatureType.monster, false))
 		{
-			Iterator<ISpawnInterdiction> it = interdictionTiles.iterator();
-			while(it.hasNext())
-			{
-				ISpawnInterdiction interdictor = it.next();
-				if(interdictor instanceof TileEntity)
+			synchronized (interdictionTiles) {
+				Iterator<ISpawnInterdiction> it = interdictionTiles.iterator();
+				while(it.hasNext())
 				{
-					if(((TileEntity)interdictor).isInvalid())
+					ISpawnInterdiction interdictor = it.next();
+					if(interdictor instanceof TileEntity)
 					{
-						it.remove();
-						continue;
+						if(((TileEntity)interdictor).isInvalid())
+						{
+							it.remove();
+							continue;
+						}
+						else if( ((TileEntity)interdictor).getWorldObj().provider.dimensionId==event.entity.worldObj.provider.dimensionId && ((TileEntity)interdictor).getDistanceFrom(event.entity.posX, event.entity.posY, event.entity.posZ)<=interdictor.getInterdictionRangeSquared())
+							event.setResult(Event.Result.DENY);
 					}
-					else if( ((TileEntity)interdictor).getWorldObj().provider.dimensionId==event.entity.worldObj.provider.dimensionId && ((TileEntity)interdictor).getDistanceFrom(event.entity.posX, event.entity.posY, event.entity.posZ)<=interdictor.getInterdictionRangeSquared())
-						event.setResult(Event.Result.DENY);
-				}
-				else if(interdictor instanceof Entity)
-				{
-					if(((Entity)interdictor).isDead)
+					else if(interdictor instanceof Entity)
 					{
-						it.remove();
-						continue;
+						if(((Entity)interdictor).isDead)
+						{
+							it.remove();
+							continue;
+						}
+						else if(((Entity)interdictor).worldObj.provider.dimensionId==event.entity.worldObj.provider.dimensionId && ((Entity)interdictor).getDistanceSqToEntity(event.entity)<=interdictor.getInterdictionRangeSquared())
+							event.setResult(Event.Result.DENY);
 					}
-					else if(((Entity)interdictor).worldObj.provider.dimensionId==event.entity.worldObj.provider.dimensionId && ((Entity)interdictor).getDistanceSqToEntity(event.entity)<=interdictor.getInterdictionRangeSquared())
-						event.setResult(Event.Result.DENY);
 				}
 			}
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockFakeLight.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockFakeLight.java
@@ -110,8 +110,10 @@ public class BlockFakeLight extends BlockIEBase
 		public int[] floodlightCoords = {-1,-1,-1};
 		public TileEntityFakeLight()
 		{
-			if(!EventHandler.interdictionTiles.contains(this))
-				EventHandler.interdictionTiles.add(this);
+			synchronized (EventHandler.interdictionTiles) {
+				if (!EventHandler.interdictionTiles.contains(this))
+					EventHandler.interdictionTiles.add(this);
+			}
 		}
 		@Override
 		public void updateEntity()
@@ -140,8 +142,10 @@ public class BlockFakeLight extends BlockIEBase
 		@Override
 		public void invalidate()
 		{
-			if(EventHandler.interdictionTiles.contains(this))
-				EventHandler.interdictionTiles.remove(this);
+			synchronized (EventHandler.interdictionTiles) {
+				if (EventHandler.interdictionTiles.contains(this))
+					EventHandler.interdictionTiles.remove(this);
+			}
 			super.invalidate();
 		}
 		@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityElectricLantern.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityElectricLantern.java
@@ -24,8 +24,10 @@ public class TileEntityElectricLantern extends TileEntityImmersiveConnectable im
 			return;
 		if(!interdictionList)
 		{
-			if(!EventHandler.interdictionTiles.contains(this))
-				EventHandler.interdictionTiles.add(this);
+			synchronized (EventHandler.interdictionTiles) {
+				if (!EventHandler.interdictionTiles.contains(this))
+					EventHandler.interdictionTiles.add(this);
+			}
 			interdictionList=true;
 		}
 		boolean b = active;
@@ -55,8 +57,10 @@ public class TileEntityElectricLantern extends TileEntityImmersiveConnectable im
 	@Override
 	public void invalidate()
 	{
-		if(EventHandler.interdictionTiles.contains(this))
-			EventHandler.interdictionTiles.remove(this);
+		synchronized (EventHandler.interdictionTiles) {
+			if (EventHandler.interdictionTiles.contains(this))
+				EventHandler.interdictionTiles.remove(this);
+		}
 		super.invalidate();
 	}
 	

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
@@ -61,8 +61,9 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable
 			{
 				ChunkCoordinates cc = it.next();
 				worldObj.setBlock(cc.posX,cc.posY,cc.posZ, IEContent.blockFakeLight,0, 2);
-
-				((TileEntityFakeLight)worldObj.getTileEntity(cc.posX,cc.posY,cc.posZ)).floodlightCoords = new int[]{xCoord,yCoord,zCoord};
+				TileEntity te = worldObj.getTileEntity(cc.posX,cc.posY,cc.posZ);
+				if (te instanceof TileEntityFakeLight)
+					((TileEntityFakeLight)te).floodlightCoords = new int[]{xCoord,yCoord,zCoord};
 
 				fakeLights.add(cc);
 				it.remove();
@@ -172,6 +173,8 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable
 			double dist = (vec.xCoord*i*vec.xCoord*i)+(vec.yCoord*i*vec.yCoord*i)+(vec.zCoord*i*vec.zCoord*i);
 			if(dist>maxDistance)
 				break;
+			if (yy>255||yy<0)
+				continue;
 			//&&worldObj.getBlockLightValue(xx,yy,zz)<12 using this makes it not work in daylight .-.
 			if((xx!=xCoord||yy!=yCoord||zz!=zCoord)&&worldObj.isAirBlock(xx,yy,zz))
 			{


### PR DESCRIPTION
fixes the cme by making all access synchronized. This will, as @mindforger noted, increase lag. Also fixes an NPE that is caused by floodlights trying to place lights below the world. This is (in most cases) more of a workaround than a fix, since the vanilla raytrace method is broken. I will try to implement my own, not sure how well that will work.