### PR TITLE
Work with all Forestry versions, using API. Add Forestry to gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,13 @@ buildscript {
     }
 }
 
+repositories {
+    maven {
+        name = "forestry"
+        url = "http://maven.ic2.player.to/"
+    }
+}
+
 apply plugin: 'forge'
 
 version = "0.6.0"
@@ -25,13 +32,14 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 minecraft {
-    version = "1.7.10-10.13.4.1448-1.7.10"
+    version = project.version_mc + "-" + project.version_forge
 	replace '${version}', project.version
     runDir = "eclipse"
 }
 
 dependencies {
-
+    compile "net.sengir.forestry:forestry_${project.version_mc}:${project.version_forestry}:api"
+    runtime "net.sengir.forestry:forestry_${project.version_mc}:${project.version_forestry}:dev"
 }
 
 processResources

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+version_mc=1.7.10
+version_forge=10.13.4.1448-1.7.10
+
+version_forestry=4.1.1.46

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/ForestryHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/ForestryHelper.java
@@ -7,12 +7,15 @@ import net.minecraftforge.fluids.FluidStack;
 import blusunrize.immersiveengineering.api.energy.DieselHandler;
 import blusunrize.immersiveengineering.common.IEContent;
 import cpw.mods.fml.common.registry.GameRegistry;
+
+import forestry.api.core.ForestryAPI;
 import forestry.api.fuels.EngineBronzeFuel;
 import forestry.api.fuels.FuelManager;
-import forestry.core.config.GameMode;
 
 public class ForestryHelper extends IECompatModule
 {
+	private static final int ENGINE_CYCLE_DURATION_BIOMASS = 2500;
+
 	@Override
 	public void preInit()
 	{
@@ -34,6 +37,8 @@ public class ForestryHelper extends IECompatModule
 			DieselHandler.addSqueezerRecipe("dropHoneydew", 80, new FluidStack(fluidHoney,100), null);
 		}
 
-		FuelManager.bronzeEngineFuel.put(IEContent.fluidBiodiesel, new EngineBronzeFuel(IEContent.fluidBiodiesel, 50, (int)(2500*GameMode.getGameMode().getFloatSetting("fuel.biomass.biogas")), 1));
+		int burnDuration = (int) (ENGINE_CYCLE_DURATION_BIOMASS * ForestryAPI.activeMode.getFloatSetting("fuel.biomass.biogas"));
+		EngineBronzeFuel engineBronzeFuel = new EngineBronzeFuel(IEContent.fluidBiodiesel, 50, burnDuration, 1);
+		FuelManager.bronzeEngineFuel.put(IEContent.fluidBiodiesel, engineBronzeFuel);
 	}
 }


### PR DESCRIPTION
This should work with Forestry 3 and 4.

I added Forestry to gradle since it's convenient to have once it's there, and I knew exactly how to add it since I've done it before heh.
If you're not using gradle or something you can just keep `ForestryHelper.java`