### PR TITLE
yet another bugfix collection

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/TileEntityIESlab.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/TileEntityIESlab.java
@@ -15,6 +15,8 @@ public class TileEntityIESlab extends TileEntityIEBase
 	public void readCustomNBT(NBTTagCompound nbt, boolean descPacket)
 	{
 		slabType = nbt.getInteger("slabType");
+		if(descPacket)
+			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
 	@Override
 	public void writeCustomNBT(NBTTagCompound nbt, boolean descPacket)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/TileEntityImmersiveConnectable.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/TileEntityImmersiveConnectable.java
@@ -145,7 +145,7 @@ public abstract class TileEntityImmersiveConnectable extends TileEntityIEBase im
 	@Override
 	public boolean receiveClientEvent(int id, int arg)
 	{
-		if(id==-1)
+		if(id==-1||id==255)
 		{
 			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 			return true;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices.java
@@ -321,35 +321,41 @@ public class BlockMetalDevices extends BlockIEBase implements blusunrize.aquatwe
 		}
 		if(te instanceof TileEntityDynamo && Utils.isHammer(player.getCurrentEquippedItem()))
 		{
-			int f = ((TileEntityDynamo)te).facing;
-			f = ForgeDirection.ROTATION_MATRIX[player.isSneaking()?1:0][f];
-			((TileEntityDynamo)te).facing = f;
-			te.markDirty();
-			world.func_147451_t(x, y, z);
-			world.markBlockForUpdate(x, y, z);
-			world.playSoundEffect(x+.5,y+.5,z+.5, "random.door_open", .5f,2f);
-			return !world.isRemote;
+			if(!world.isRemote)
+			{
+				int f = ((TileEntityDynamo) te).facing;
+				f = ForgeDirection.ROTATION_MATRIX[player.isSneaking()? 1: 0][f];
+				((TileEntityDynamo) te).facing = f;
+				te.markDirty();
+				world.func_147451_t(x, y, z);
+				world.markBlockForUpdate(x, y, z);
+				world.playSoundEffect(x+.5, y+.5, z+.5, "random.door_open", .5f, 2f);
+			}
+			return true;
 		}
 		if(te instanceof TileEntityConveyorBelt && Utils.isHammer(player.getCurrentEquippedItem()))
 		{
-			TileEntityConveyorBelt tile = (TileEntityConveyorBelt)te;
-			if(player.isSneaking())
+			if(!world.isRemote)
 			{
-				if(tile.transportUp)
+				TileEntityConveyorBelt tile = (TileEntityConveyorBelt) te;
+				if(player.isSneaking())
 				{
-					tile.transportUp=false;
-					tile.transportDown=true;
-				}
-				else if(tile.transportDown)
-				{
-					tile.transportDown=false;
+					if(tile.transportUp)
+					{
+						tile.transportUp = false;
+						tile.transportDown = true;
+					}
+					else if(tile.transportDown)
+					{
+						tile.transportDown = false;
+					}
+					else
+						tile.transportUp = true;
 				}
 				else
-					tile.transportUp=true;
+					tile.facing = ForgeDirection.ROTATION_MATRIX[1][tile.facing];
+				world.markBlockForUpdate(x, y, z);
 			}
-			else
-				tile.facing = ForgeDirection.ROTATION_MATRIX[1][tile.facing];
-			world.markBlockForUpdate(x, y, z);
 			return true;
 		}
 		if(te instanceof TileEntityFurnaceHeater && Utils.isHammer(player.getCurrentEquippedItem()))

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices2.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices2.java
@@ -21,6 +21,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.Explosion;
+import net.minecraft.world.GameRules;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -267,7 +268,7 @@ public class BlockMetalDevices2 extends BlockIEBase implements ICustomBoundingbo
 					}
 				}
 			}
-			else
+			else if(player.getCurrentEquippedItem()!=null)
 			{
 				TileEntityFluidPipe tile = ((TileEntityFluidPipe)te);
 				for(ItemStack valid : TileEntityFluidPipe.validScaffoldCoverings)
@@ -275,7 +276,7 @@ public class BlockMetalDevices2 extends BlockIEBase implements ICustomBoundingbo
 					{
 						if(!OreDictionary.itemMatches(tile.scaffoldCovering, player.getCurrentEquippedItem(), true))
 						{
-							if(!world.isRemote && tile.scaffoldCovering!=null)
+							if(!world.isRemote && tile.scaffoldCovering!=null && world.getGameRules().getGameRuleBooleanValue("doTileDrops"))
 							{
 								EntityItem entityitem = player.dropPlayerItemWithRandomChoice(tile.scaffoldCovering.copy(), false);
 								entityitem.delayBeforeCanPickup = 0;
@@ -284,9 +285,29 @@ public class BlockMetalDevices2 extends BlockIEBase implements ICustomBoundingbo
 							if(!player.capabilities.isCreativeMode)
 								player.inventory.decrStackSize(player.inventory.currentItem, 1);
 							world.markBlockForUpdate(x, y, z);
+							world.addBlockEvent(x, y, z, tile.getBlockType(), 0, 0);
 							return true;
 						}
 					}
+			}
+			else if(player.isSneaking() && player.getCurrentEquippedItem()==null)
+			{
+				TileEntityFluidPipe pipe = (TileEntityFluidPipe)te;
+				if(pipe.scaffoldCovering!=null)
+				{
+					if(!world.isRemote)
+					{
+						if(world.getGameRules().getGameRuleBooleanValue("doTileDrops"))
+						{
+							EntityItem entityitem = player.dropPlayerItemWithRandomChoice(pipe.scaffoldCovering.copy(), false);
+							entityitem.delayBeforeCanPickup = 0;
+						}
+						pipe.scaffoldCovering = null;
+						world.markBlockForUpdate(x, y, z);
+						world.addBlockEvent(x, y, z, pipe.getBlockType(), 0, 0);
+					}
+					return true;
+				}
 			}
 		}
 		else if(te instanceof TileEntityWoodenBarrel)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices2.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices2.java
@@ -213,20 +213,24 @@ public class BlockMetalDevices2 extends BlockIEBase implements ICustomBoundingbo
 		}
 		else if(Utils.isHammer(player.getCurrentEquippedItem()) && te instanceof TileEntityFloodlight)
 		{
-			if(side==((TileEntityFloodlight)te).side || ForgeDirection.OPPOSITES[side]==((TileEntityFloodlight)te).side)
+			if(!world.isRemote)
 			{
-				((TileEntityFloodlight)te).rotY+=player.isSneaking()?-11.25:11.25;
-				((TileEntityFloodlight)te).rotY%=360;
+				if(side==((TileEntityFloodlight) te).side || ForgeDirection.OPPOSITES[side]==((TileEntityFloodlight) te).side)
+				{
+					((TileEntityFloodlight) te).rotY += player.isSneaking()? -11.25: 11.25;
+					((TileEntityFloodlight) te).rotY %= 360;
+				}
+				else
+				{
+					float newX = (((TileEntityFloodlight) te).rotX+(player.isSneaking()? -11.25f: 11.25f))%360;
+					if(newX>=-11.25 && newX<=191.25)
+						((TileEntityFloodlight) te).rotX = newX;
+				}
+				((TileEntityFloodlight) te).updateFakeLights(true, ((TileEntityFloodlight) te).active);
+				te.markDirty();
+				world.markBlockForUpdate(x, y, z);
 			}
-			else
-			{
-				float newX = (((TileEntityFloodlight)te).rotX+(player.isSneaking()?-11.25f:11.25f))%360;
-				if(newX>=-11.25 && newX<=191.25)
-					((TileEntityFloodlight)te).rotX=newX;
-			}
-			((TileEntityFloodlight)te).updateFakeLights(true,((TileEntityFloodlight)te).active);
-			te.markDirty();
-			world.markBlockForUpdate(x, y, z);
+			return true;
 		}
 		else if(Utils.isHammer(player.getCurrentEquippedItem()) && te instanceof TileEntityFluidPump)
 		{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorStructural.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorStructural.java
@@ -1,5 +1,7 @@
 package blusunrize.immersiveengineering.common.blocks.metal;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -38,6 +40,8 @@ public class TileEntityConnectorStructural extends TileEntityConnectorLV
 	{
 		super.readCustomNBT(nbt, descPacket);
 		rotation = nbt.getFloat("rotation");
+		if(FMLCommonHandler.instance().getEffectiveSide()==Side.CLIENT)
+			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConveyorBelt.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConveyorBelt.java
@@ -26,6 +26,8 @@ public class TileEntityConveyorBelt extends TileEntityIEBase implements ISidedIn
 		transportUp = nbt.getBoolean("transportUp");
 		transportDown = nbt.getBoolean("transportDown");
 		facing = nbt.getInteger("facing");
+		if(descPacket)
+			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityDynamo.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityDynamo.java
@@ -38,6 +38,8 @@ public class TileEntityDynamo extends TileEntityIEBase implements IEnergyConnect
 	public void readCustomNBT(NBTTagCompound nbt, boolean descPacket)
 	{
 		facing = nbt.getInteger("facing");
+		if(descPacket)
+			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
 	@Override
 	public void writeCustomNBT(NBTTagCompound nbt, boolean descPacket)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
@@ -209,6 +211,8 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable
 			int[] icc = nbt.getIntArray("fakeLight_"+i);
 			fakeLights.add(new ChunkCoordinates(icc[0],icc[1],icc[2]));
 		}
+		if(FMLCommonHandler.instance().getEffectiveSide()==Side.CLIENT)
+			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntitySheetmetalTank.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntitySheetmetalTank.java
@@ -76,6 +76,7 @@ public class TileEntitySheetmetalTank extends TileEntityMultiblockPart implement
 						int accepted = ((IFluidHandler)te).fill(f.getOpposite(), new FluidStack(tank.getFluid().getFluid(),out), false);
 						FluidStack drained = this.tank.drain(accepted, true);
 						((IFluidHandler)te).fill(f.getOpposite(), drained, true);
+						worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 						updateComparatorValuesPart2();
 					}
 				}

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemWireCoil.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemWireCoil.java
@@ -130,8 +130,10 @@ public class ItemWireCoil extends ItemIEBase implements IWireCoil
 								if(!player.capabilities.isCreativeMode)
 									stack.stackSize--;
 								((TileEntity)nodeHere).markDirty();
+								world.addBlockEvent(x, y, z, ((TileEntity) nodeHere).getBlockType(), -1, 0);
 								world.markBlockForUpdate(x, y, z);
 								((TileEntity)nodeLink).markDirty();
+								world.addBlockEvent(pos[1], pos[2], pos[3], ((TileEntity) nodeLink).getBlockType(), -1, 0);
 								world.markBlockForUpdate(pos[1], pos[2], pos[3]);
 							}
 							else


### PR DESCRIPTION
this will fix some known and even more unreported bugs, mainly blocks not getting rerendered omn their own after changing them for other players on the same server. Example: placing another slab on top of an existing one to form a full block was only visible to the player doing this until placing another block.

Unrelated bugs found, but not fixed:
- items in the workbench aren't rendered for other players, block updates don't help.
- the sorter will always tell you "oreDict disabled" even when it is enabled. Exception: you're the player who just set it and you haven't unloaded it. Logging out and in again (or unloading the chunk, I guess) will reset the text overlay, but not the behaviour. I didn't change anything on the sorter.

Note: as any IImmersiveConnectables have their own packet handler, I haven't used the descPacket detection of the the other blocks here (wouldn't work, is always false) but the FML side detection by thread name.