### PR TITLE
fix connection offsets for floodlight and lantern

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityElectricLantern.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityElectricLantern.java
@@ -67,6 +67,7 @@ public class TileEntityElectricLantern extends TileEntityImmersiveConnectable im
 	@Override
 	public void readCustomNBT(NBTTagCompound nbt, boolean descPacket)
 	{
+		super.readCustomNBT(nbt, descPacket);
 		active = nbt.getBoolean("active");
 		energyStorage = nbt.getInteger("energyStorage");
 	}
@@ -74,6 +75,7 @@ public class TileEntityElectricLantern extends TileEntityImmersiveConnectable im
 	@Override
 	public void writeCustomNBT(NBTTagCompound nbt, boolean descPacket)
 	{
+		super.writeCustomNBT(nbt, descPacket);
 		nbt.setBoolean("active",active);
 		nbt.setInteger("energyStorage",energyStorage);
 	}
@@ -115,13 +117,12 @@ public class TileEntityElectricLantern extends TileEntityImmersiveConnectable im
 	{
 		int xDif = xCoord - ((TileEntity)link).xCoord;
 		int zDif = zCoord - ((TileEntity)link).zCoord;
-		int h = ((TileEntity)link).yCoord>yCoord?1:0;
 		if(xDif==0&&zDif==0)
-			return Vec3.createVectorHelper(.5, h, .5);
+			return Vec3.createVectorHelper(.5, .0625, .5);
 		else if(Math.abs(xDif)>=Math.abs(zDif))
-			return Vec3.createVectorHelper(xDif>0?.125:.875, h, .5);
+			return Vec3.createVectorHelper(xDif<0?.25:xDif>0?.75:.5, .0625, .5);
 		else
-			return Vec3.createVectorHelper(.5, h, zDif>0?.125:.875);
+			return Vec3.createVectorHelper(.5, .0625, zDif<0?.25:zDif>0?.75:.5);
 	}
 	@Override
 	public Vec3 getConnectionOffset(Connection con)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
@@ -198,6 +198,7 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable
 	@Override
 	public void readCustomNBT(NBTTagCompound nbt, boolean descPacket)
 	{
+		super.readCustomNBT(nbt, descPacket);
 		active = nbt.getBoolean("active");
 		energyStorage = nbt.getInteger("energy");
 		facing = nbt.getInteger("facing");
@@ -217,6 +218,7 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable
 	@Override
 	public void writeCustomNBT(NBTTagCompound nbt, boolean descPacket)
 	{
+		super.writeCustomNBT(nbt, descPacket);
 		nbt.setBoolean("active",active);
 		nbt.setInteger("energyStorage",energyStorage);
 		nbt.setInteger("facing",facing);
@@ -267,15 +269,35 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable
 	@Override
 	public Vec3 getRaytraceOffset(IImmersiveConnectable link)
 	{
-		int xDif = xCoord - ((TileEntity)link).xCoord;
-		int zDif = zCoord - ((TileEntity)link).zCoord;
-		int h = ((TileEntity)link).yCoord>yCoord?1:0;
-		if(xDif==0&&zDif==0)
-			return Vec3.createVectorHelper(.5, h, .5);
-		else if(Math.abs(xDif)>=Math.abs(zDif))
-			return Vec3.createVectorHelper(xDif>0?0:1, h, .5);
-		else
-			return Vec3.createVectorHelper(.5, h, zDif>0?0:1);
+		int xDif = ((TileEntity)link).xCoord-xCoord;
+		int yDif = ((TileEntity)link).yCoord-yCoord;
+		int zDif = ((TileEntity)link).zCoord-zCoord;
+		double x, y, z;
+
+		switch(side)
+		{
+			case 0:
+			case 1:
+				x = (Math.abs(xDif)>=Math.abs(zDif))? (xDif>=0)?.9375: .0625: .5;
+				y = (side==0)?.9375: .0625;
+				z = (Math.abs(zDif)>Math.abs(xDif))? (zDif>=0)?.9375: .0625: .5;
+				break;
+			case 2:
+			case 3:
+				x = (Math.abs(xDif)>=Math.abs(yDif))? (xDif>=0)?.9375: .0625: .5;
+				y = (Math.abs(yDif)>Math.abs(xDif))? (yDif>=0)?.9375: .0625: .5;
+				z = (side==2)?.9375: .0625;
+				break;
+			case 4:
+			case 5:
+			default:
+				x = (side==4)?.9375: .0625;
+				y = (Math.abs(yDif)>=Math.abs(zDif))? (yDif>=0)?.9375: .0625: .5;
+				z = (Math.abs(zDif)>Math.abs(yDif))? (zDif>=0)?.9375: .0625: .5;
+				break;
+		}
+
+		return Vec3.createVectorHelper(x,y,z);
 	}
 	@Override
 	public Vec3 getConnectionOffset(Connection con)
@@ -283,16 +305,30 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable
 		int xDif = (con==null||con.start==null||con.end==null)?0: (con.start.equals(Utils.toCC(this))&&con.end!=null)? con.end.posX-xCoord: (con.end.equals(Utils.toCC(this))&& con.start!=null)?con.start.posX-xCoord: 0;
 		int yDif = (con==null||con.start==null||con.end==null)?0: (con.start.equals(Utils.toCC(this))&&con.end!=null)? con.end.posY-yCoord: (con.end.equals(Utils.toCC(this))&& con.start!=null)?con.start.posY-yCoord: 0;
 		int zDif = (con==null||con.start==null||con.end==null)?0: (con.start.equals(Utils.toCC(this))&&con.end!=null)? con.end.posZ-zCoord: (con.end.equals(Utils.toCC(this))&& con.start!=null)?con.start.posZ-zCoord: 0;
-		double x = side==4?.9375: side==5?.0625: .5;
-		double y = side==0?.9375: side==1?.0625: .5;
-		double z = side==2?.9375: side==3?.0625: .5;
+		double x, y, z;
 
-		if(x==.5 && Math.abs(xDif)>=Math.abs(zDif) && Math.abs(xDif)>=Math.abs(yDif))
-			x = xDif<0?.0625:.9375;
-		else if(z==.5 && Math.abs(zDif)>=Math.abs(xDif) && Math.abs(zDif)>=Math.abs(yDif))
-			z = zDif<0?.0625:.9375;
-		else if(y==.5 && Math.abs(yDif)>=Math.abs(xDif) && Math.abs(yDif)>=Math.abs(zDif))
-			y = yDif<0?.0625:.9375;
+		switch(side)
+		{
+			case 0:
+			case 1:
+				x = (Math.abs(xDif)>=Math.abs(zDif))? (xDif>=0)?.9375: .0625: .5;
+				y = (side==0)?.9375: .0625;
+				z = (Math.abs(zDif)>Math.abs(xDif))? (zDif>=0)?.9375: .0625: .5;
+				break;
+			case 2:
+			case 3:
+				x = (Math.abs(xDif)>=Math.abs(yDif))? (xDif>=0)?.9375: .0625: .5;
+				y = (Math.abs(yDif)>Math.abs(xDif))? (yDif>=0)?.9375: .0625: .5;
+				z = (side==2)?.9375: .0625;
+				break;
+			case 4:
+			case 5:
+			default:
+				x = (side==4)?.9375: .0625;
+				y = (Math.abs(yDif)>=Math.abs(zDif))? (yDif>=0)?.9375: .0625: .5;
+				z = (Math.abs(zDif)>Math.abs(yDif))? (zDif>=0)?.9375: .0625: .5;
+				break;
+		}
 		return Vec3.createVectorHelper(x,y,z);
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/BlockWoodenDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/BlockWoodenDevices.java
@@ -190,6 +190,7 @@ public class BlockWoodenDevices extends BlockIEBase implements blusunrize.aquatw
 				te = world.getTileEntity(x+rot0.offsetX,y+rot0.offsetY,z+rot0.offsetZ);
 				if(te instanceof TileEntityWoodenPost && ((TileEntityWoodenPost)te).type-2==rot0.ordinal())
 					return false;
+				te = world.getTileEntity(x+rot1.offsetX,y+rot1.offsetY,z+rot1.offsetZ);
 				if(te instanceof TileEntityWoodenPost && ((TileEntityWoodenPost)te).type-2==rot1.ordinal())
 					return false;
 				world.setBlock(x+fd.offsetX, y, z+fd.offsetZ, this, 0, 0x3);


### PR DESCRIPTION
second part of #551, respects the orientation of the floodlight base, makes wiring through the empty space of fences, posts and slabs possible, just like other connectors. Uses the same coordinates for raytracing and rendering now that the raytracer can ignore the starting blocks.

Also adds calls to super methods for writing/reading custom NBT data.

before:
![](https://cloud.githubusercontent.com/assets/163331/11078484/9141086e-8806-11e5-89c6-cbd731245c0b.png)
![](https://cloud.githubusercontent.com/assets/163331/11078499/a381b190-8806-11e5-87ce-0d0cdf027b10.png)

after:
![](https://cloud.githubusercontent.com/assets/163331/11078628/6e3f118e-8807-11e5-8cf2-5a81b02caa81.png)

Note: the raytracer has a bug and hits blocks outside of the area it should check, so some connections might still fail until this is fixed.