### PR TITLE
Allow addons to add blocks that transformers can 'attach' to

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/IPostBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/IPostBlock.java
@@ -1,0 +1,14 @@
+package blusunrize.immersiveengineering.api;
+
+import net.minecraft.world.IBlockAccess;
+
+/**
+ * Implemented on blocks that can have a transformer 'attached' to them (for example, wooden post).
+ */
+public interface IPostBlock
+{
+  /**
+   * Returns true if a transformer should render attached to this post
+   */
+  boolean canConnectTransformer(IBlockAccess world, int x, int y, int z);
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices.java
@@ -3,6 +3,7 @@ package blusunrize.immersiveengineering.common.blocks.metal;
 import java.util.ArrayList;
 import java.util.List;
 
+import blusunrize.immersiveengineering.api.IPostBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -31,7 +32,6 @@ import blusunrize.immersiveengineering.client.render.BlockRenderMetalDevices;
 import blusunrize.immersiveengineering.common.Config;
 import blusunrize.immersiveengineering.common.IEContent;
 import blusunrize.immersiveengineering.common.blocks.BlockIEBase;
-import blusunrize.immersiveengineering.common.blocks.wooden.TileEntityWoodenPost;
 import blusunrize.immersiveengineering.common.util.ItemNBTHelper;
 import blusunrize.immersiveengineering.common.util.Lib;
 import blusunrize.immersiveengineering.common.util.Utils;
@@ -589,7 +589,10 @@ public class BlockMetalDevices extends BlockIEBase implements blusunrize.aquatwe
 		if(te instanceof TileEntityTransformer)
 		{
 			TileEntityTransformer transf = (TileEntityTransformer)te;
-			if(transf.postAttached>0 && !(world.getTileEntity(x+(transf.postAttached==4?1: transf.postAttached==5?-1: 0), y, z+(transf.postAttached==2?1: transf.postAttached==3?-1: 0)) instanceof TileEntityWoodenPost ))
+			int postX = x+(transf.postAttached==4?1: transf.postAttached==5?-1: 0);
+			int postZ = z+(transf.postAttached==2?1: transf.postAttached==3?-1: 0);
+			Block blockPost = world.getBlock(postX, y, postZ);
+			if(transf.postAttached>0 && !(blockPost instanceof IPostBlock && ((IPostBlock)blockPost).canConnectTransformer(world, postX, y, postZ)))
 			{
 				this.dropBlockAsItem(world, x, y, z, new ItemStack(this,1,world.getBlockMetadata(x, y, z)));
 				world.setBlockToAir(x, y, z);

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/ItemBlockMetalDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/ItemBlockMetalDevices.java
@@ -2,6 +2,7 @@ package blusunrize.immersiveengineering.common.blocks.metal;
 
 import java.util.List;
 
+import blusunrize.immersiveengineering.api.IPostBlock;
 import net.minecraft.block.Block;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
@@ -14,7 +15,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import blusunrize.immersiveengineering.common.blocks.BlockIEBase;
 import blusunrize.immersiveengineering.common.blocks.ItemBlockIEBase;
-import blusunrize.immersiveengineering.common.blocks.wooden.TileEntityWoodenPost;
 import blusunrize.immersiveengineering.common.util.ItemNBTHelper;
 
 public class ItemBlockMetalDevices extends ItemBlockIEBase
@@ -56,8 +56,10 @@ public class ItemBlockMetalDevices extends ItemBlockIEBase
 		int f = playerViewQuarter==0 ? 2:playerViewQuarter==1 ? 5:playerViewQuarter==2 ? 3: 4;
 		if(meta==BlockMetalDevices.META_transformer||meta==BlockMetalDevices.META_transformerHV)
 		{
-			TileEntity te = world.getTileEntity(x+(side==4?1: side==5?-1: 0), y, z+(side==2?1: side==3?-1: 0));
-			if((meta!=BlockMetalDevices.META_transformer||!(te instanceof TileEntityWoodenPost)||((TileEntityWoodenPost) te).type<=0)&&!world.isAirBlock(x, y+1, z))
+			int postX = x+(side==4?1: side==5?-1: 0);
+			int postZ = z+(side==2?1: side==3?-1: 0);
+			Block blockPost = world.getBlock(postX, y, postZ);
+			if((meta!=BlockMetalDevices.META_transformer||!(blockPost instanceof IPostBlock && ((IPostBlock) blockPost).canConnectTransformer(world, postX, y, postZ)))&&!world.isAirBlock(x, y+1, z))
 				return false;
 		}
 		if(meta==BlockMetalDevices.META_sampleDrill && (!world.isAirBlock(x,y+1,z)||!world.isAirBlock(x,y+2,z)))
@@ -114,8 +116,10 @@ public class ItemBlockMetalDevices extends ItemBlockIEBase
 			((TileEntityConnectorLV)tileEntity).facing = ForgeDirection.getOrientation(side).getOpposite().ordinal();
 		else if(tileEntity instanceof TileEntityTransformer)
 		{
-			TileEntity tileEntityWoodenPost = world.getTileEntity(x+(side==4?1: side==5?-1: 0), y, z+(side==2?1: side==3?-1: 0));
-			if(meta==4 && tileEntityWoodenPost instanceof TileEntityWoodenPost && ((TileEntityWoodenPost)tileEntityWoodenPost).type>0 )
+			int postX = x+(side==4?1: side==5?-1: 0);
+			int postZ = z+(side==2?1: side==3?-1: 0);
+			Block blockPost = world.getBlock(postX, y, postZ);
+			if(meta==4 && blockPost instanceof IPostBlock && ((IPostBlock)blockPost).canConnectTransformer(world, postX, y, postZ) )
 			{
 				((TileEntityTransformer) tileEntity).postAttached = side;
 				((TileEntityTransformer)tileEntity).facing=side;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/BlockWoodenDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/BlockWoodenDevices.java
@@ -3,6 +3,7 @@ package blusunrize.immersiveengineering.common.blocks.wooden;
 import java.util.ArrayList;
 import java.util.List;
 
+import blusunrize.immersiveengineering.api.IPostBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -33,7 +34,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @Optional.Interface(iface = "blusunrize.aquatweaks.api.IAquaConnectable", modid = "AquaTweaks")
-public class BlockWoodenDevices extends BlockIEBase implements blusunrize.aquatweaks.api.IAquaConnectable
+public class BlockWoodenDevices extends BlockIEBase implements IPostBlock, blusunrize.aquatweaks.api.IAquaConnectable
 {
 	IIcon[] iconBarrel = new IIcon[3];
 
@@ -497,6 +498,13 @@ public class BlockWoodenDevices extends BlockIEBase implements blusunrize.aquatw
 			return new TileEntityWoodenBarrel();
 		}
 		return null;
+	}
+
+	@Override
+	public boolean canConnectTransformer(IBlockAccess world, int x, int y, int z)
+	{
+		TileEntity tileEntity = world.getTileEntity(x, y, z);
+		return tileEntity instanceof TileEntityWoodenPost && ((TileEntityWoodenPost) tileEntity).type > 0;
 	}
 
 	@Optional.Method(modid = "AquaTweaks")


### PR DESCRIPTION
Added IPostBlock to the api and adjusted checking of wooden post accordingly

I opted to implement this on blocks rather than TileEntity as I don't want to force tile entities on simple blocks.