### PR TITLE
fix refinery process, squeezer/fermenter fluid i/o

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFermenter.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFermenter.java
@@ -25,6 +25,8 @@ import blusunrize.immersiveengineering.common.util.Utils;
 import cofh.api.energy.EnergyStorage;
 import cofh.api.energy.IEnergyReceiver;
 
+import java.util.*;
+
 public class TileEntityFermenter extends TileEntityMultiblockPart implements IFluidHandler, ISidedInventory, IEnergyReceiver
 {
 	public int facing = 2;
@@ -105,7 +107,7 @@ public class TileEntityFermenter extends TileEntityMultiblockPart implements IFl
 								int outLimit = recipe.output==null?9: ((64-(inventory[11]!=null?inventory[11].stackSize:0))/recipe.output.stackSize);
 								int fluidLimit = recipe.fluid==null?9: ((tank.getCapacity()-tank.getFluidAmount())/recipe.fluid.amount);
 								int taken = Math.min(Math.min(inputs,stack.stackSize/recipeInputSize), Math.min(outLimit,fluidLimit));
-								//								
+
 								if(taken>0)
 								{
 									this.decrStackSize(i, taken*recipeInputSize);
@@ -121,21 +123,6 @@ public class TileEntityFermenter extends TileEntityMultiblockPart implements IFl
 								}
 							}
 
-							//							int f = DieselHandler.getPlantoilOutput(stack);
-							//							if(f>0)
-							//							{
-							//								int fSpace = tank.getCapacity()-tank.getFluidAmount();
-							//								int taken = Math.min(inputs, Math.min(stack.stackSize, fSpace/f));
-							//								if(taken>0)
-							//								{
-							//									tank.fill(new FluidStack(IEContent.fluidPlantoil,f*taken), true);
-							//									this.decrStackSize(i, taken);
-							//									inputs-=taken;
-							//									update = true;
-							//								}
-							//								else
-							//									continue;
-							//							}
 							if(inputs<=0 || tank.getFluidAmount()>=tank.getCapacity())
 								break;
 						}
@@ -158,26 +145,33 @@ public class TileEntityFermenter extends TileEntityMultiblockPart implements IFl
 					update = true;
 				}
 
-				if(tank.getFluidAmount()>0 && tank.getFluid()!=null)
+				if(tank.getFluid()!=null && tank.getFluidAmount()>0)
 				{
-					int connected=0;
+					HashMap<ForgeDirection, IFluidHandler> targets = new HashMap<>(4);
+					ForgeDirection direction;
+					TileEntity te;
 					for(int f=2; f<6; f++)
 					{
-						TileEntity te = worldObj.getTileEntity(xCoord+(f==4?-2:f==5?2:0),yCoord-1,zCoord+(f==2?-2:f==3?2:0));
-						if(te!=null && te instanceof IFluidHandler && ((IFluidHandler)te).canFill(ForgeDirection.getOrientation(f).getOpposite(), this.tank.getFluid().getFluid()))
-							connected++;
+						direction = ForgeDirection.getOrientation(f);
+						te = Utils.getExistingTileEntity(worldObj, xCoord+direction.offsetX*2, yCoord-1, zCoord+direction.offsetZ*2);
+						if(te instanceof IFluidHandler && ((IFluidHandler)te).canFill(direction.getOpposite(), this.tank.getFluid().getFluid()))
+							targets.put(direction, (IFluidHandler) te);
 					}
-					if(connected!=0)
+					if(targets.size()>0)
 					{
-						int out = Math.min(144,tank.getFluidAmount())/connected;
-						for(int f=2; f<6; f++)
+						int out = (int) Math.ceil(Math.min(144, tank.getFluidAmount()) / (float) targets.size());
+						IFluidHandler fluidHandler;
+						for(ForgeDirection targetDirection: targets.keySet())
 						{
-							TileEntity te = worldObj.getTileEntity(xCoord+(f==4?-2:f==5?2:0),yCoord-1,zCoord+(f==2?-2:f==3?2:0));
-							if(te!=null && te instanceof IFluidHandler && this.tank.getFluid()!=null && ((IFluidHandler)te).canFill(ForgeDirection.getOrientation(f).getOpposite(), this.tank.getFluid().getFluid()))
+							if(tank.getFluid()==null || tank.getFluidAmount()<1)
+								break;
+
+							fluidHandler = targets.get(targetDirection);
+							int accepted = fluidHandler.fill(targetDirection.getOpposite(), new FluidStack(this.tank.getFluid().getFluid(), out), false);
+							if(accepted>0)
 							{
-								int accepted = ((IFluidHandler)te).fill(ForgeDirection.getOrientation(f).getOpposite(), new FluidStack(this.tank.getFluid().getFluid(),out), false);
 								FluidStack drained = this.tank.drain(accepted, true);
-								((IFluidHandler)te).fill(ForgeDirection.getOrientation(f).getOpposite(), drained, true);
+								fluidHandler.fill(targetDirection.getOpposite(), drained, true);
 								update = true;
 							}
 						}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRefinery.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRefinery.java
@@ -125,13 +125,16 @@ public class TileEntityRefinery extends TileEntityMultiblockPart implements IFlu
 					int consumed = Config.getInt("refinery_consumption");
 					if(energyStorage.extractEnergy(consumed, true)==consumed && tank2.fill(recipe.output.copy(), false)==recipe.output.amount)
 					{
-						energyStorage.extractEnergy(consumed, false);
 						int drain0 = tank0.getFluid().isFluidEqual(recipe.input0)?recipe.input0.amount: recipe.input1.amount;
 						int drain1 = tank0.getFluid().isFluidEqual(recipe.input0)?recipe.input1.amount: recipe.input0.amount;
-						tank0.drain(drain0, true);
-						tank1.drain(drain1, true);
-						tank2.fill(recipe.output.copy(), true);
-						update = true;
+						if(tank0.getFluidAmount()>=drain0 && tank1.getFluidAmount()>=drain1)
+						{
+							energyStorage.extractEnergy(consumed, false);
+							tank0.drain(drain0, true);
+							tank1.drain(drain1, true);
+							tank2.fill(recipe.output.copy(), true);
+							update = true;
+						}
 					}
 				}
 			}
@@ -151,8 +154,8 @@ public class TileEntityRefinery extends TileEntityMultiblockPart implements IFlu
 				{
 					ForgeDirection f = ForgeDirection.getOrientation(facing);
 					int out = Math.min(144,tank2.getFluidAmount());
-					TileEntity te = worldObj.getTileEntity(xCoord+f.offsetX*2,yCoord,zCoord+f.offsetZ*2);
-					if(te!=null && te instanceof IFluidHandler && ((IFluidHandler)te).canFill(f.getOpposite(), tank2.getFluid().getFluid()))
+					TileEntity te = Utils.getExistingTileEntity(worldObj, xCoord+f.offsetX*2, yCoord, zCoord+f.offsetZ*2);
+					if(te instanceof IFluidHandler && ((IFluidHandler) te).canFill(f.getOpposite(), tank2.getFluid().getFluid()))
 					{
 						int accepted = ((IFluidHandler)te).fill(f.getOpposite(), new FluidStack(tank2.getFluid().getFluid(),out), false);
 						FluidStack drained = this.tank2.drain(accepted, true);

--- a/src/main/java/blusunrize/immersiveengineering/common/util/Utils.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/Utils.java
@@ -955,4 +955,15 @@ public class Utils
 		}
 		return ret;
 	}
+
+	/**
+	 * get tile entity without loading currently unloaded chunks
+	 * @return return value of {@link net.minecraft.world.IBlockAccess#getTileEntity(int, int, int)} or always null if chunk is not loaded
+	 */
+	public static TileEntity getExistingTileEntity(World world, int x, int y, int z)
+	{
+		if(world.blockExists(x, y, z))
+			return world.getTileEntity(x, y, z);
+		return null;
+	}
 }


### PR DESCRIPTION
- fix diesel dupe bug and check for sufficient amounts of ingredients
  before producing output, close #759
- fix fluid output for very small amounts in squeezer and fermenter,
  related to #759
- reduce number of getTileEntity calls, cache results
- add wrapper method for getTileEntity to avoid ghost-loading currently
  unloaded chunks
- fix potential ghost-loading with refinery, squeezer, fermenter