### PR TITLE
avoid NPE in voltmeter rendering, close #777

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/render/ItemRenderVoltmeter.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/ItemRenderVoltmeter.java
@@ -80,14 +80,17 @@ public class ItemRenderVoltmeter implements IItemRenderer
 		if(type==ItemRenderType.EQUIPPED_FIRST_PERSON)
 		{
 			MovingObjectPosition mop = ClientUtils.mc().objectMouseOver;
-			TileEntity tileEntity = ClientUtils.mc().thePlayer.worldObj.getTileEntity(mop.blockX, mop.blockY, mop.blockZ);
-			if(tileEntity instanceof IEnergyReceiver)
+			if(mop!=null)
 			{
-				ForgeDirection fd = ForgeDirection.getOrientation(mop.sideHit);
-				int maxStorage = ((IEnergyReceiver)tileEntity).getMaxEnergyStored(fd);
-				int storage = ((IEnergyReceiver)tileEntity).getEnergyStored(fd);
-				if(maxStorage>0)
-					angle = storage/(float)maxStorage*60;
+				TileEntity tileEntity = ClientUtils.mc().thePlayer.worldObj.getTileEntity(mop.blockX, mop.blockY, mop.blockZ);
+				if(tileEntity instanceof IEnergyReceiver)
+				{
+					ForgeDirection fd = ForgeDirection.getOrientation(mop.sideHit);
+					int maxStorage = ((IEnergyReceiver) tileEntity).getMaxEnergyStored(fd);
+					int storage = ((IEnergyReceiver) tileEntity).getEnergyStored(fd);
+					if(maxStorage>0)
+						angle = storage/(float) maxStorage*60;
+				}
 			}
 		}
 		GL11.glRotatef(-angle, 0.0F, 0.0F, 1.0F);


### PR DESCRIPTION
a vanilla bug seems to cause mop to be null sometimes