### PR TITLE
Fixes loading access transformers in Deobf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ processResources
 task deobfJar(type: Jar) {
 	from sourceSets.main.output
 	classifier = 'deobf'
+	manifest {
+		attributes 'FMLAT': 'ImmersiveEngineering_at.cfg'
+	}
 }
 
 task apiZip(type: Zip) {


### PR DESCRIPTION
Adds Missing FMLAT entry in the manifest for the Deobf jar.
fixes loading IE's access transformers in deobf.