### PR TITLE
Add support for `specialRecipeType` to the Arc Furnace's MineTweaker functionality

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/ArcFurnace.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/ArcFurnace.java
@@ -16,7 +16,8 @@ import blusunrize.immersiveengineering.api.crafting.ArcFurnaceRecipe;
 public class ArcFurnace
 {
 	@ZenMethod
-	public static void addRecipe(IItemStack output, IIngredient input, IItemStack slag, int time, int energyPerTick, @Optional IIngredient[] additives)
+//	public static void addRecipe(IItemStack output, IIngredient input, IItemStack slag, int time, int energyPerTick, @Optional IIngredient[] additives)
+	public static void addRecipe(IItemStack output, IIngredient input, IItemStack slag, int time, int energyPerTick, @Optional IIngredient[] additives, @Optional String specialRecipeType)
 	{
 		Object oInput = MTHelper.toObject(input);
 		if(oInput==null)
@@ -25,8 +26,9 @@ public class ArcFurnace
 		Object[] adds = new Object[additives.length];
 		for(int i=0; i<additives.length; i++)
 			adds[i] = MTHelper.toObject(additives[i]);
-		
+
 		ArcFurnaceRecipe r = new ArcFurnaceRecipe(MTHelper.toStack(output), oInput, MTHelper.toStack(slag), time, energyPerTick, adds);
+		r.setSpecialRecipeType(specialRecipeType);
 		MineTweakerAPI.apply(new Add(r));
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/ArcFurnace.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/minetweaker/ArcFurnace.java
@@ -16,7 +16,6 @@ import blusunrize.immersiveengineering.api.crafting.ArcFurnaceRecipe;
 public class ArcFurnace
 {
 	@ZenMethod
-//	public static void addRecipe(IItemStack output, IIngredient input, IItemStack slag, int time, int energyPerTick, @Optional IIngredient[] additives)
 	public static void addRecipe(IItemStack output, IIngredient input, IItemStack slag, int time, int energyPerTick, @Optional IIngredient[] additives, @Optional String specialRecipeType)
 	{
 		Object oInput = MTHelper.toObject(input);


### PR DESCRIPTION
This works for adding a recipe to an existing `specialRecipeType`. After a quick read of the code, I'm not sure why it doesn't work for an arbitrary recipe type, but perhaps this can serve as a starting point for that addition.

See issue #820.