### PR TITLE
Capacitors for computers and fixes for #902 and #903

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/crafting/MetalPressRecipe.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/crafting/MetalPressRecipe.java
@@ -48,14 +48,14 @@ public class MetalPressRecipe
 		recipeList.put(r.mold, r);
 		return r;
 	}
-	public static MetalPressRecipe findRecipe(ItemStack mould, ItemStack input)
+	public static MetalPressRecipe findRecipe(ItemStack mould, ItemStack input, boolean checkStackSize)
 	{
 		if(mould==null || input==null)
 			return null;
 		ComparableItemStack comp = ApiUtils.createComparableItemStack(mould);
 		List<MetalPressRecipe> list = recipeList.get(comp);
 		for(MetalPressRecipe recipe : list)
-			if(ApiUtils.stackMatchesObject(input, recipe.input) && (input.stackSize>=recipe.inputSize))
+			if(ApiUtils.stackMatchesObject(input, recipe.input) && (!checkStackSize||input.stackSize>=recipe.inputSize))
 				return recipe;
 		return null;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/api/tool/ITool.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/tool/ITool.java
@@ -1,0 +1,8 @@
+package blusunrize.immersiveengineering.api.tool;
+
+import net.minecraft.item.ItemStack;
+
+public interface ITool
+{
+	public boolean isTool(ItemStack item);
+}

--- a/src/main/java/blusunrize/immersiveengineering/client/IEManualInstance.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/IEManualInstance.java
@@ -169,6 +169,9 @@ public class IEManualInstance extends ManualInstance
 	@Override
 	public boolean showEntryInList(ManualEntry entry)
 	{
+		if (entry==null||entry.getCategory()==null)
+			return false;
+		
 		if(entry.getCategory().equalsIgnoreCase(ManualHelper.CAT_UPDATE))
 			return Config.getBoolean("showUpdateNews");
 

--- a/src/main/java/blusunrize/immersiveengineering/client/nei/NEIBlastFurnaceHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/nei/NEIBlastFurnaceHandler.java
@@ -37,7 +37,8 @@ public class NEIBlastFurnaceHandler extends TemplateRecipeHandler
 				in = OreDictionary.getOres((String)in);
 			input = new PositionedStack(in, 47, 9);
 			output = new PositionedStack(recipe.output, 107,9);
-			slag = new PositionedStack(recipe.slag, 107,45);
+			if (recipe.slag!=null)
+				slag = new PositionedStack(recipe.slag, 107,45);
 			time = recipe.time;
 
 			for(Object fuel : BlastFurnaceRecipe.blastFuels.keySet())
@@ -46,8 +47,11 @@ public class NEIBlastFurnaceHandler extends TemplateRecipeHandler
 		@Override
 		public List<PositionedStack> getOtherStacks()
 		{
-			return Arrays.asList(fuels.get((NEIBlastFurnaceHandler.this.cycleticks/20)%fuels.size()),
-					slag);
+			if (slag!=null)
+				return Arrays.asList(fuels.get((NEIBlastFurnaceHandler.this.cycleticks/20)%fuels.size()),
+						slag);
+			else
+				return Arrays.asList(fuels.get((NEIBlastFurnaceHandler.this.cycleticks/20)%fuels.size()));
 		}
 		@Override
 		public PositionedStack getIngredient()

--- a/src/main/java/blusunrize/immersiveengineering/client/nei/NEIMetalPressHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/nei/NEIMetalPressHandler.java
@@ -33,9 +33,11 @@ public class NEIMetalPressHandler extends TemplateRecipeHandler
 			if(in instanceof String)
 				in = OreDictionary.getOres((String)in);
 			if(in instanceof List)
+			{
 				in = new ArrayList<ItemStack>((List)in);
-			for(ItemStack s : (ArrayList<ItemStack>)in)
-				s.stackSize = recipe.inputSize;
+				for(ItemStack s : (ArrayList<ItemStack>)in)
+					s.stackSize = recipe.inputSize;
+			}
 			input = new PositionedStack(in, 44, 9);
 			mould = new PositionedStack(recipe.mold.oreID!=-1?OreDictionary.getOres(OreDictionary.getOreName(recipe.mold.oreID)):recipe.mold.stack, 75, 9);
 			output = new PositionedStack(recipe.output, 107,9);
@@ -121,32 +123,32 @@ public class NEIMetalPressHandler extends TemplateRecipeHandler
 		{
 			try{
 
-			GL11.glColor4f(1, 1, 1, 1);
+				GL11.glColor4f(1, 1, 1, 1);
 
-			GL11.glPushMatrix();
-			GL11.glTranslatef(32, 25, 100);
-			GL11.glRotatef(-25, 1, 0, 0);
-			GL11.glRotatef(-120, 0, 1, 0);
-			GL11.glScalef(12, -12, 12);
-			TileEntityMetalPress tile = new TileEntityMetalPress();
-			tile.pos=4;
-			tile.formed=true;
-			ClientUtils.bindAtlas(0);
-			ClientUtils.tes().startDrawingQuads();
-			ClientUtils.handleStaticTileRenderer(tile, false);
-			ClientUtils.tes().draw();
-			TileEntityRendererDispatcher.instance.renderTileEntityAt(tile, 0.0D, 0.0D, 0.0D, 0.0F);
-			GL11.glPopMatrix();
+				GL11.glPushMatrix();
+				GL11.glTranslatef(32, 25, 100);
+				GL11.glRotatef(-25, 1, 0, 0);
+				GL11.glRotatef(-120, 0, 1, 0);
+				GL11.glScalef(12, -12, 12);
+				TileEntityMetalPress tile = new TileEntityMetalPress();
+				tile.pos=4;
+				tile.formed=true;
+				ClientUtils.bindAtlas(0);
+				ClientUtils.tes().startDrawingQuads();
+				ClientUtils.handleStaticTileRenderer(tile, false);
+				ClientUtils.tes().draw();
+				TileEntityRendererDispatcher.instance.renderTileEntityAt(tile, 0.0D, 0.0D, 0.0D, 0.0F);
+				GL11.glPopMatrix();
 
-			ClientUtils.drawSlot(r.input.relx,r.input.rely, 16,16);
-			ClientUtils.drawSlot(r.mould.relx,r.mould.rely,16,16);
-			ClientUtils.drawSlot(r.output.relx,r.output.rely, 20,20);
+				ClientUtils.drawSlot(r.input.relx,r.input.rely, 16,16);
+				ClientUtils.drawSlot(r.mould.relx,r.mould.rely,16,16);
+				ClientUtils.drawSlot(r.output.relx,r.output.rely, 20,20);
 			}catch(Exception e)
 			{
 				e.printStackTrace();
 			}
 		}
-	
+
 	}
 
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/Config.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/Config.java
@@ -184,7 +184,8 @@ public class Config
 		setInt("chemthrower_consumption", config.get("tools", "ChemThrower: Consumed", 10, "The mb of fluid the Chemical Thrower will consume per tick of usage").getInt());
 		
 		setInt("railgun_consumption", config.get("tools", "Railgun: Consumed", 800, "The base amount of RF consumed per shot by the Railgun").getInt());
-
+		setDouble("railgun_damage_multiplier", config.get("tools", "Railgun: Damage multiplier", 1D, "When something is hurt by a railgun, the default damage for the used projectile is multiplied by this value").getDouble());
+		
 		for(String key : IECompatModule.moduleClasses.keySet())
 			setBoolean("compat_"+key, config.get("compatability", "Enable Compatmodule: "+key, true, "Set this to false to disable IE's built in compatability with "+key).getBoolean());
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices2.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevices2.java
@@ -694,6 +694,8 @@ public class BlockMetalDevices2 extends BlockIEBase implements ICustomBoundingbo
 			TileEntity te = world.getTileEntity(x, y, z);
 			return te instanceof TileEntityEnergyMeter&&((TileEntityEnergyMeter)te).dummy;
 		}
+		else if (meta==META_capacitorCreative)
+			return true;
 		return false;
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityArcFurnace.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityArcFurnace.java
@@ -133,6 +133,7 @@ public class TileEntityArcFurnace extends TileEntityMultiblockPart implements IE
 					if(recipe!=null)
 					{
 						int[] outputSlots = null;
+						ItemStack[] outUpToNow = new ItemStack[6];
 						ItemStack[] outputs = recipe.getOutputs(this.getStackInSlot(i),additives);
 						if(outputs!=null && outputs.length>0)
 						{
@@ -144,12 +145,35 @@ public class TileEntityArcFurnace extends TileEntityMultiblockPart implements IE
 								ItemStack out = outputs[iOut];
 								boolean b0 = false;
 								for(int j=16; j<22; j++)
-									if(inventory[j]==null || (OreDictionary.itemMatches(inventory[j],out,false) && inventory[j].stackSize+out.stackSize<=inventory[j].getMaxStackSize()) )
+								{
+									int outSize = out.stackSize;
+									int maxSize = out.getMaxStackSize(); 
+									if (inventory[j]!=null)
+									{
+										outSize+=inventory[j].stackSize;
+										maxSize = Math.min(maxSize, inventory[j].getMaxStackSize());
+									}
+									if (outUpToNow[j-16]!=null)
+									{
+										outSize+=outUpToNow[j-16].stackSize;
+										maxSize = Math.min(maxSize, outUpToNow[j-16].getMaxStackSize());
+									}
+									boolean matches = true;
+									if (inventory[j]!=null&&!OreDictionary.itemMatches(inventory[j],out,false))
+										matches = false;
+									else if (outUpToNow[j-16]!=null&&!OreDictionary.itemMatches(outUpToNow[j-16],out,false))
+										matches = false;
+									if(matches && outSize<=maxSize)
 									{
 										b0 = true;
 										outputSlots[iOut] = j;
+										if (outUpToNow[j-16]==null)
+											outUpToNow[j-16] = out.copy();
+										else
+											outUpToNow[j-16].stackSize+=out.stackSize;
 										break;
 									}
+								}
 								if(!b0)
 								{
 									spaceForOutput = false;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorLV.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorLV.java
@@ -110,13 +110,11 @@ public class TileEntityConnectorLV extends TileEntityImmersiveConnectable implem
 		TileEntity capacitor = worldObj.getTileEntity(xCoord+fd.offsetX, yCoord+fd.offsetY, zCoord+fd.offsetZ);
 		int ret = 0;
 		if(capacitor instanceof IEnergyReceiver && ((IEnergyReceiver)capacitor).canConnectEnergy(fd.getOpposite()))
-		{
 			ret = ((IEnergyReceiver)capacitor).receiveEnergy(fd.getOpposite(), toAccept, simulate);
-		}
 		else if(Lib.IC2 && IC2Helper.isAcceptingEnergySink(capacitor, this, fd.getOpposite()))
 		{
 			double left = IC2Helper.injectEnergy(capacitor, fd.getOpposite(), ModCompatability.convertRFtoEU(toAccept, getIC2Tier()), canTakeHV()?(256*256): canTakeMV()?(128*128) : (32*32), simulate);
-			ret = amount-ModCompatability.convertEUtoRF(left);
+			ret = toAccept-ModCompatability.convertEUtoRF(left);
 		}
 		else if(Lib.GREG && GregTechHelper.gregtech_isValidEnergyOutput(capacitor))
 		{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityMetalPress.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityMetalPress.java
@@ -1,8 +1,5 @@
 package blusunrize.immersiveengineering.common.blocks.metal;
 
-import java.util.List;
-
-import blusunrize.immersiveengineering.api.ApiUtils;
 import blusunrize.immersiveengineering.api.crafting.MetalPressRecipe;
 import blusunrize.immersiveengineering.common.Config;
 import blusunrize.immersiveengineering.common.IEContent;
@@ -225,6 +222,8 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 	@SideOnly(Side.CLIENT)
 	public AxisAlignedBB getRenderBoundingBox()
 	{
+		if (!formed)
+			return AxisAlignedBB.getBoundingBox(xCoord,yCoord,zCoord, xCoord,yCoord,zCoord);
 		if(renderAABB==null)
 			if(pos==4)
 				renderAABB = AxisAlignedBB.getBoundingBox(xCoord-1,yCoord-1,zCoord-1, xCoord+2,yCoord+2,zCoord+2);
@@ -261,7 +260,13 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 	public void invalidate()
 	{
 		super.invalidate();
-
+		
+		if (!worldObj.isRemote&&pos==4&&mold!=null)
+		{
+			EntityItem moldDrop = new EntityItem(worldObj, xCoord+.5, yCoord+.5, zCoord+.5, mold);
+			worldObj.spawnEntityInWorld(moldDrop);
+		}
+		
 		if(formed && !worldObj.isRemote)
 		{
 			int f = facing;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityMetalPress.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityMetalPress.java
@@ -22,6 +22,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.oredict.OreDictionary;
 
 public class TileEntityMetalPress extends TileEntityMultiblockPart implements ISidedInventory, IEnergyReceiver
 {
@@ -33,6 +34,8 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 	public ItemStack mold = null;
 	public boolean active;
 	public static final int MAX_PROCESS = 120;
+	public int stopped = -1;
+	private int stoppedReqSize = -1;
 
 	@Override
 	public TileEntityMetalPress master()
@@ -68,7 +71,7 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 				return;
 			for (int i = 0;i<process.length;i++)
 			{
-				if (process[i]>=0)
+				if (process[i]>=0&&stopped!=i)
 				{
 					process[i]++;
 					if (process[i]>MAX_PROCESS)
@@ -83,7 +86,7 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 
 		boolean update = false;
 		for(int i=0; i<inventory.length; i++)
-			if(inventory[i]!=null)
+			if(stopped!=i&&inventory[i]!=null)
 			{
 				if(process[i]>=MAX_PROCESS)
 				{
@@ -106,7 +109,7 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 					update = true;
 				}
 				if(curRecipes[i]==null)
-					curRecipes[i] = MetalPressRecipe.findRecipe(mold, inventory[i]);
+					curRecipes[i] = MetalPressRecipe.findRecipe(mold, inventory[i], true);
 
 				int perTick = curRecipes[i]!=null?curRecipes[i].energy/MAX_PROCESS:0;
 				if((perTick==0 || this.energyStorage.extractEnergy(perTick, true)==perTick)&&process[i]>=0)
@@ -129,7 +132,23 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 					update = true;
 				}
 			}
-
+			else if (stopped==i)
+			{
+				if (stoppedReqSize<0)
+				{
+					MetalPressRecipe recipe = MetalPressRecipe.findRecipe(mold, inventory[i], false);
+					if (recipe!=null)
+						stoppedReqSize = recipe.inputSize;
+					else
+					{
+						stopped = -1;
+						update = true;
+						continue;
+					}
+				}
+				if (stoppedReqSize<=inventory[i].stackSize)
+					stopped = -1;
+			}
 		if(update)
 		{
 			this.markDirty();
@@ -176,6 +195,8 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 		mold = ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("mold"));
 		if (descPacket)
 			active = nbt.getBoolean("active");
+		if (nbt.hasKey("stoppedSlot"))
+			stopped = nbt.getInteger("stoppedSlot");
 	}
 	@Override
 	public void writeCustomNBT(NBTTagCompound nbt, boolean descPacket)
@@ -189,6 +210,7 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 			nbt.setTag("mold", this.mold.writeToNBT(new NBTTagCompound()));
 		if (descPacket)
 			nbt.setBoolean("active", active);
+		nbt.setInteger("stoppedSlot", stopped);
 	}
 
 	@Override
@@ -348,10 +370,17 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 			master.setInventorySlotContents(slot,stack);
 			return;
 		}
+		int stackLimit = getInventoryStackLimit();
 		inventory[slot] = stack;
 		process[slot] = stack!=null?0:-1;
-		if (stack != null && stack.stackSize > getInventoryStackLimit())
-			stack.stackSize = getInventoryStackLimit();
+		if (stack != null && stack.stackSize > stackLimit)
+			stack.stackSize = stackLimit;
+		MetalPressRecipe recipe = MetalPressRecipe.findRecipe(mold, stack, false);
+		if (recipe!=null&&recipe.inputSize>inventory[slot].stackSize)
+		{
+			stopped = slot;
+			stoppedReqSize = recipe.inputSize;
+		}
 		this.markDirty();
 		worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 	}
@@ -369,15 +398,19 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 	public int getInventoryStackLimit()
 	{
 		TileEntityMetalPress master = master();
-		if(master==null)
-			master = this;
-		if(master.mold!=null)
+		if(master!=null)
+			return master.getInventoryStackLimit();
+		if (stopped>=0)
 		{
-			List<MetalPressRecipe> list = MetalPressRecipe.recipeList.get(ApiUtils.createComparableItemStack(master.mold));
-			if(list!=null && !list.isEmpty())
+			//some stack is waiting for more items to be able to process
+			ItemStack input = inventory[stopped];
+			MetalPressRecipe recipe = MetalPressRecipe.findRecipe(mold, input, false);
+			if (recipe!=null)
+				return recipe.inputSize;
+			else
 			{
-				int i = list.get(0).inputSize;
-				return i;
+				stopped = -1;
+				stoppedReqSize = -1;
 			}
 		}
 		return 1;
@@ -404,7 +437,10 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 		if(master!=null)
 			return master.isItemValidForSlot(slot,stack);
 		if(this.mold!=null)
-			return MetalPressRecipe.findRecipe(mold, stack)!=null;
+		{
+			MetalPressRecipe recipe = MetalPressRecipe.findRecipe(mold, stack, false);
+			return recipe!=null&&(inventory[slot]==null||OreDictionary.itemMatches(stack, inventory[slot], true));
+		}
 		return true;
 	}
 	@Override
@@ -414,6 +450,9 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 			return new int[0];
 		if(pos==3)
 		{
+			TileEntityMetalPress master = master();
+			if (master.stopped>=0)
+				return new int[]{master.stopped};
 			int next = getNextProcessID();
 			if(next==-1)
 				return new int[0];
@@ -427,7 +466,12 @@ public class TileEntityMetalPress extends TileEntityMultiblockPart implements IS
 		if(!formed)
 			return false;
 		if(pos==3 && side==ForgeDirection.OPPOSITES[facing])
-			return isItemValidForSlot(slot,stack);
+		{
+			if (!isItemValidForSlot(slot,stack))
+				return false;
+			TileEntityMetalPress master = master();
+			return master.inventory[slot]==null||master.inventory[slot].stackSize+stack.stackSize<=getInventoryStackLimit();
+		}
 		return false;
 	}
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/crafting/ArcRecyclingRecipe.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/crafting/ArcRecyclingRecipe.java
@@ -47,6 +47,12 @@ public class ArcRecyclingRecipe extends ArcFurnaceRecipe
 	}
 	public boolean matches(ItemStack input, ItemStack[] additives)
 	{
-		return input!=null&&this.input!=null && this.input instanceof ItemStack && input.getItem().equals(((ItemStack)this.input).getItem());
+		if (input!=null && this.input instanceof ItemStack)
+		{
+			boolean ignoreMeta = input.isItemStackDamageable();
+			ItemStack inStack = (ItemStack) this.input;
+			return input.getItem().equals(inStack.getItem()) && (ignoreMeta || inStack.getItemDamage()==input.getItemDamage());
+		}
+		return false;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/EntityRailgunShot.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/EntityRailgunShot.java
@@ -2,6 +2,7 @@ package blusunrize.immersiveengineering.common.entities;
 
 import blusunrize.immersiveengineering.api.tool.RailgunHandler;
 import blusunrize.immersiveengineering.api.tool.RailgunHandler.RailgunProjectileProperties;
+import blusunrize.immersiveengineering.common.Config;
 import blusunrize.immersiveengineering.common.util.IEDamageSources;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -97,7 +98,7 @@ public class EntityRailgunShot extends EntityIEProjectile
 				if(getAmmoProperties()!=null)
 				{
 					if(!getAmmoProperties().overrideHitEntity(mop.entityHit, getShooter()))
-						mop.entityHit.attackEntityFrom(IEDamageSources.causeRailgunDamage(this, getShooter()), (float)getAmmoProperties().damage);
+						mop.entityHit.attackEntityFrom(IEDamageSources.causeRailgunDamage(this, getShooter()), (float)(getAmmoProperties().damage*Config.getDouble("railgun_damage_multiplier")));
 				}
 			}
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/ContainerToolbox.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/ContainerToolbox.java
@@ -2,6 +2,7 @@ package blusunrize.immersiveengineering.common.gui;
 
 import blusunrize.immersiveengineering.api.energy.IImmersiveConnectable;
 import blusunrize.immersiveengineering.api.energy.IWireCoil;
+import blusunrize.immersiveengineering.api.tool.ITool;
 import blusunrize.immersiveengineering.common.IEContent;
 import blusunrize.immersiveengineering.common.gui.IESlot.ICallbackContainer;
 import blusunrize.immersiveengineering.common.items.ItemToolbox;
@@ -76,9 +77,9 @@ public class ContainerToolbox extends Container implements ICallbackContainer
 			return stack.getItem() instanceof ItemFood;
 		else if(slotNumer<10)
 		{
-			if(stack.getItem() instanceof ItemTool || stack.getItem().equals(IEContent.itemTool))
-				return true;
-			if(stack.getItem().equals(IEContent.itemDrill) || stack.getItem().equals(IEContent.itemRevolver) || stack.getItem().equals(IEContent.itemChemthrower) || stack.getItem().equals(IEContent.itemRailgun))
+			if (stack.getItem() instanceof ITool)
+				return ((ITool)stack.getItem()).isTool(stack);
+			if(stack.getItem() instanceof ItemTool)
 				return true;
 		}
 		else if(slotNumer<16)

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemChemthrower.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemChemthrower.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import blusunrize.immersiveengineering.api.shader.IShaderEquipableItem;
 import blusunrize.immersiveengineering.api.tool.ChemthrowerHandler;
+import blusunrize.immersiveengineering.api.tool.ITool;
 import blusunrize.immersiveengineering.common.Config;
 import blusunrize.immersiveengineering.common.entities.EntityChemthrowerShot;
 import blusunrize.immersiveengineering.common.gui.IESlot;
@@ -22,7 +23,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
-public class ItemChemthrower extends ItemUpgradeableTool implements IShaderEquipableItem, IFluidContainerItem
+public class ItemChemthrower extends ItemUpgradeableTool implements IShaderEquipableItem, IFluidContainerItem, ITool
 {
 	public ItemChemthrower()
 	{
@@ -241,6 +242,12 @@ public class ItemChemthrower extends ItemUpgradeableTool implements IShaderEquip
 	public int getInternalSlots(ItemStack stack)
 	{
 		return 4;
+	}
+
+	@Override
+	public boolean isTool(ItemStack item)
+	{
+		return true;
 	}
 
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemDrill.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemDrill.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Multimap;
 import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.shader.IShaderEquipableItem;
 import blusunrize.immersiveengineering.api.tool.IDrillHead;
+import blusunrize.immersiveengineering.api.tool.ITool;
 import blusunrize.immersiveengineering.common.IEContent;
 import blusunrize.immersiveengineering.common.gui.IESlot;
 import blusunrize.immersiveengineering.common.util.IEAchievements;
@@ -37,7 +38,7 @@ import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
-public class ItemDrill extends ItemUpgradeableTool implements IShaderEquipableItem, IFluidContainerItem
+public class ItemDrill extends ItemUpgradeableTool implements IShaderEquipableItem, IFluidContainerItem, ITool
 {
 	public static Material[] validMaterials = {Material.anvil,Material.clay,Material.glass,Material.grass,Material.ground,Material.ice,Material.iron,Material.packedIce,Material.piston,Material.rock,Material.sand, Material.snow};
 
@@ -451,4 +452,9 @@ public class ItemDrill extends ItemUpgradeableTool implements IShaderEquipableIt
 		return stack;
 	}
 	/*===================================== FLUIDS END =================================*/
+	@Override
+	public boolean isTool(ItemStack item)
+	{
+		return true;
+	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemIETool.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemIETool.java
@@ -22,6 +22,7 @@ import blusunrize.immersiveengineering.api.TargetingInfo;
 import blusunrize.immersiveengineering.api.energy.IImmersiveConnectable;
 import blusunrize.immersiveengineering.api.energy.ImmersiveNetHandler;
 import blusunrize.immersiveengineering.api.energy.ImmersiveNetHandler.AbstractConnection;
+import blusunrize.immersiveengineering.api.tool.ITool;
 import blusunrize.immersiveengineering.common.Config;
 import blusunrize.immersiveengineering.common.IESaveData;
 import blusunrize.immersiveengineering.common.util.IEAchievements;
@@ -36,7 +37,7 @@ import com.google.common.collect.ImmutableSet;
 import cpw.mods.fml.common.Optional;
 
 @Optional.Interface(iface = "cofh.api.item.IToolHammer", modid = "CoFHAPI|item")
-public class ItemIETool extends ItemIEBase implements cofh.api.item.IToolHammer
+public class ItemIETool extends ItemIEBase implements cofh.api.item.IToolHammer, ITool
 {
 	static int hammerMaxDamage;
 	public ItemIETool()
@@ -298,5 +299,10 @@ public class ItemIETool extends ItemIEBase implements cofh.api.item.IToolHammer
 	@Optional.Method(modid = "CoFHAPI|item")
 	public void toolUsed(ItemStack stack, EntityLivingBase living, int x, int y, int z)
 	{
+	}
+
+	@Override
+	public boolean isTool(ItemStack item) {
+		return item.getItemDamage()!=3;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemRailgun.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemRailgun.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import blusunrize.immersiveengineering.api.shader.IShaderEquipableItem;
+import blusunrize.immersiveengineering.api.tool.ITool;
 import blusunrize.immersiveengineering.api.tool.RailgunHandler;
 import blusunrize.immersiveengineering.api.tool.ZoomHandler.IZoomTool;
 import blusunrize.immersiveengineering.common.Config;
@@ -25,7 +26,7 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
-public class ItemRailgun extends ItemUpgradeableTool implements IShaderEquipableItem, IEnergyContainerItem, IZoomTool
+public class ItemRailgun extends ItemUpgradeableTool implements IShaderEquipableItem, IEnergyContainerItem, IZoomTool, ITool
 {
 	public ItemRailgun()
 	{
@@ -305,5 +306,10 @@ public class ItemRailgun extends ItemUpgradeableTool implements IShaderEquipable
 	public float[] getZoomSteps(ItemStack stack, EntityPlayer player)
 	{
 		return zoomSteps;
+	}
+
+	@Override
+	public boolean isTool(ItemStack item) {
+		return true;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemRevolver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemRevolver.java
@@ -28,6 +28,7 @@ import net.minecraft.world.World;
 import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.shader.IShaderEquipableItem;
 import blusunrize.immersiveengineering.api.tool.IBullet;
+import blusunrize.immersiveengineering.api.tool.ITool;
 import blusunrize.immersiveengineering.common.gui.IESlot;
 import blusunrize.immersiveengineering.common.util.IEAchievements;
 import blusunrize.immersiveengineering.common.util.ItemNBTHelper;
@@ -40,7 +41,7 @@ import com.google.common.collect.Multimap;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class ItemRevolver extends ItemUpgradeableTool implements IShaderEquipableItem
+public class ItemRevolver extends ItemUpgradeableTool implements IShaderEquipableItem, ITool
 {
 	public ItemRevolver()
 	{
@@ -441,5 +442,12 @@ public class ItemRevolver extends ItemUpgradeableTool implements IShaderEquipabl
 			this.baseUpgrades=baseUpgrades;
 			this.renderAdditions=renderAdditions;
 		}
+	}
+
+
+	@Override
+	public boolean isTool(ItemStack item)
+	{
+		return item.getItemDamage()!=1;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemSkyhook.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemSkyhook.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.google.common.collect.Multimap;
 
 import blusunrize.immersiveengineering.api.energy.ImmersiveNetHandler.Connection;
+import blusunrize.immersiveengineering.api.tool.ITool;
 import blusunrize.immersiveengineering.common.entities.EntitySkylineHook;
 import blusunrize.immersiveengineering.common.gui.IESlot;
 import blusunrize.immersiveengineering.common.util.ItemNBTHelper;
@@ -23,7 +24,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
-public class ItemSkyhook extends ItemUpgradeableTool
+public class ItemSkyhook extends ItemUpgradeableTool implements ITool
 {
 	public ItemSkyhook()
 	{
@@ -137,6 +138,12 @@ public class ItemSkyhook extends ItemUpgradeableTool
 	public int getInternalSlots(ItemStack stack)
 	{
 		return 2;
+	}
+
+	@Override
+	public boolean isTool(ItemStack item)
+	{
+		return true;
 	}
 
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemWireCoil.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemWireCoil.java
@@ -97,7 +97,7 @@ public class ItemWireCoil extends ItemIEBase implements IWireCoil
 						player.addChatMessage(new ChatComponentTranslation(Lib.CHAT_WARN+"sameConnection"));
 					else if( distance > type.getMaxLength())
 						player.addChatMessage(new ChatComponentTranslation(Lib.CHAT_WARN+"tooFar"));
-					else if(!(tileEntityLinkingPos instanceof IImmersiveConnectable))
+					else if(!(tileEntityLinkingPos instanceof IImmersiveConnectable)||!((IImmersiveConnectable)tileEntityLinkingPos).canConnectCable(getWireType(stack), target))
 						player.addChatMessage(new ChatComponentTranslation(Lib.CHAT_WARN+"invalidPoint"));
 					else
 					{

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/GeneralComputerHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/GeneralComputerHelper.java
@@ -41,6 +41,7 @@ public class GeneralComputerHelper {
 			ManualHelper.getManual().addEntry("computer.bottlingMachine", "computers", new ManualPages.Text(ManualHelper.getManual(), "computer.bottlingMachine0"),
 					new ManualPages.Text(ManualHelper.getManual(), "computer.bottlingMachine1"),
 					new ManualPages.Text(ManualHelper.getManual(), "computer.bottlingMachine2"));
+			ManualHelper.getManual().addEntry("computer.capacitor", "computers", new ManualPages.Text(ManualHelper.getManual(), "computer.capacitor0"));
 		}
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computercraft/IEPeripheral.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computercraft/IEPeripheral.java
@@ -22,7 +22,7 @@ public abstract class IEPeripheral implements IPeripheral
 	{
 		boolean usePipeline = FMLCommonHandler.instance().getEffectiveSide()!=Side.SERVER;
 		TileEntity te = usePipeline?EventHandler.requestTE(w, x, y, z):w.getTileEntity(x, y, z);
-		if (te!=null&&te.getClass().equals(type))
+		if (te!=null&&type.isAssignableFrom(te.getClass()))
 			return te;
 		return null;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computercraft/IEPeripheralProvider.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computercraft/IEPeripheralProvider.java
@@ -4,6 +4,10 @@ import blusunrize.immersiveengineering.common.blocks.TileEntityIEBase;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityArcFurnace;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityAssembler;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityBottlingMachine;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorCreative;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorHV;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorLV;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorMV;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCrusher;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityDieselGenerator;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityEnergyMeter;
@@ -108,6 +112,20 @@ public class IEPeripheralProvider implements IPeripheralProvider
 					return new PeripheralBottlingMachine(world, x-bott.offset[0], y, z-bott.offset[2]);
 				else
 					return null;
+			}
+			if (te instanceof TileEntityCapacitorLV)
+			{
+
+				String type = "";
+				if (te instanceof TileEntityCapacitorCreative)
+					type = "creative";
+				else if (te instanceof TileEntityCapacitorHV)
+					type = "hv";
+				else if (te instanceof TileEntityCapacitorMV)
+					type = "mv";
+				else if (te instanceof TileEntityCapacitorLV)
+					type = "lv";
+				return new PeripheralCapacitor(world, x, y, z, type);
 			}
 		}
 		return null;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computercraft/PeripheralCapacitor.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computercraft/PeripheralCapacitor.java
@@ -1,0 +1,54 @@
+package blusunrize.immersiveengineering.common.util.compat.computercraft;
+
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorLV;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.lua.LuaException;
+import dan200.computercraft.api.peripheral.IComputerAccess;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class PeripheralCapacitor extends IEPeripheral
+{
+	public static final String[] cmds = {"getEnergyStored", "getMaxEnergyStored"};
+	String type;
+
+	public PeripheralCapacitor(World w, int _x, int _y, int _z, String type)
+	{
+		super(w, _x, _y, _z);
+		this.type = type;
+	}
+
+	@Override
+	public String getType()
+	{
+		return "IE:"+type+"Capacitor";
+	}
+
+	@Override
+	public String[] getMethodNames()
+	{
+		return cmds;
+	}
+
+	@Override
+	public Object[] callMethod(IComputerAccess computer, ILuaContext context, int method, Object[] arguments)
+			throws LuaException, InterruptedException
+	{
+		TileEntityCapacitorLV te = (TileEntityCapacitorLV) getTileEntity(TileEntityCapacitorLV.class);
+		if (te==null)
+			throw new LuaException("The capacitor was removed");
+		if (method==0) //energy stored
+			return new Object[]{te.getEnergyStored(ForgeDirection.DOWN)};
+		else
+			return new Object[]{te.getMaxEnergyStored(ForgeDirection.EAST)};
+	}
+
+	@Override
+	public void attach(IComputerAccess computer)
+	{}
+
+	@Override
+	public void detach(IComputerAccess computer)
+	{}
+
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/ArcFurnaceDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/ArcFurnaceDriver.java
@@ -26,8 +26,8 @@ public class ArcFurnaceDriver extends DriverTileEntity
 			int pos = ((TileEntityArcFurnace)te).pos;
 			if (pos==25)
 			{
-				TileEntityArcFurnace master = ((TileEntityArcFurnace)te).master();
-				return new ArcFurnaceEnvironment(w, master.xCoord, master.yCoord, master.zCoord, TileEntityArcFurnace.class);
+				TileEntityArcFurnace arc = (TileEntityArcFurnace)te;
+				return new ArcFurnaceEnvironment(w, arc.xCoord-arc.offset[0], arc.yCoord-arc.offset[1], arc.zCoord-arc.offset[2], TileEntityArcFurnace.class);
 			}
 		}
 		return null;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/AssemblerDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/AssemblerDriver.java
@@ -28,8 +28,8 @@ public class AssemblerDriver extends DriverTileEntity
 			int offsetY = ((TileEntityAssembler)te).offset[1];
 			if (offsetY==-1)
 			{
-				TileEntityAssembler master = ((TileEntityAssembler)te).master();
-				return new AssemblerEnvironment(w, master.xCoord, master.yCoord, master.zCoord, TileEntityAssembler.class);
+				TileEntityAssembler assembler = (TileEntityAssembler)te;
+				return new AssemblerEnvironment(w, assembler.xCoord-assembler.offset[0], assembler.yCoord-assembler.offset[1], assembler.zCoord-assembler.offset[2], TileEntityAssembler.class);
 			}
 		}
 		return null;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/BottlingMachineDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/BottlingMachineDriver.java
@@ -29,8 +29,8 @@ public class BottlingMachineDriver extends DriverTileEntity
 			int pos = ((TileEntityBottlingMachine)te).pos;
 			if (offsetY==0&&pos!=0&&pos!=2)
 			{
-				TileEntityBottlingMachine master = ((TileEntityBottlingMachine)te).master();
-				return new BottlingMachineEnvironment(w, master.xCoord, master.yCoord, master.zCoord, TileEntityBottlingMachine.class);
+				TileEntityBottlingMachine bottle = (TileEntityBottlingMachine)te;
+				return new BottlingMachineEnvironment(w, bottle.xCoord-bottle.offset[0], bottle.yCoord-bottle.offset[1], bottle.zCoord-bottle.offset[2], TileEntityBottlingMachine.class);
 			}
 		}
 		return null;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/CapacitorDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/CapacitorDriver.java
@@ -1,0 +1,88 @@
+package blusunrize.immersiveengineering.common.util.compat.opencomputers;
+
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorCreative;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorHV;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorLV;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCapacitorMV;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.network.Node;
+import li.cil.oc.api.prefab.DriverTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class CapacitorDriver extends DriverTileEntity
+{
+
+	@Override
+	public ManagedEnvironment createEnvironment(World w, int x, int y, int z)
+	{
+		TileEntity te = w.getTileEntity(x, y, z);
+		if (te instanceof TileEntityCapacitorLV)
+		{
+			String pre = "";
+			if (te instanceof TileEntityCapacitorCreative)
+				pre = "creative";
+			else if (te instanceof TileEntityCapacitorHV)
+				pre = "hv";
+			else if (te instanceof TileEntityCapacitorMV)
+				pre = "mv";
+			else if (te instanceof TileEntityCapacitorLV)
+				pre = "lv";
+			return new CapacitorEnvironment(w, te.xCoord, te.yCoord, te.zCoord, pre);
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?> getTileEntityClass()
+	{
+		return TileEntityCapacitorLV.class;
+	}
+
+
+	public class CapacitorEnvironment extends ManagedEnvironmentIE<TileEntityCapacitorLV>
+	{
+		String prefix;
+		public CapacitorEnvironment(World w, int x, int y, int z, String name)
+		{
+			super(w, x, y, z, TileEntityCapacitorLV.class);
+			prefix = name;
+		}
+
+
+		@Override
+		public String preferredName() {
+			return "ie_"+prefix+"_capacitor";
+		}
+
+		@Override
+		public int priority() {
+			return 1000;
+		}
+
+		@Override
+		public void onConnect(Node node)
+		{}
+
+		@Override
+		public void onDisconnect(Node node)
+		{}
+
+		@Callback(doc = "function():int -- returns the amount of energy that can be stored")
+		public Object[] getMaxEnergyStored(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().getMaxEnergyStored(ForgeDirection.UP)};
+		}
+
+		@Callback(doc = "function():int -- returns the amount of energy that can be stored")
+		public Object[] getEnergyStored(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().getEnergyStored(ForgeDirection.DOWN)};
+		}
+
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/CrusherDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/CrusherDriver.java
@@ -23,8 +23,8 @@ public class CrusherDriver extends DriverTileEntity
 			int pos = ((TileEntityCrusher)te).pos;
 			if (pos==9)
 			{
-				TileEntityCrusher master = ((TileEntityCrusher)te).master();
-				return new CrusherEnvironment(w, master.xCoord, master.yCoord, master.zCoord, TileEntityCrusher.class);
+				TileEntityCrusher crush = (TileEntityCrusher)te;
+				return new CrusherEnvironment(w, crush.xCoord-crush.offset[0], crush.yCoord-crush.offset[1], crush.zCoord-crush.offset[2], TileEntityCrusher.class);
 			}
 		}
 		return null;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/ExcavatorDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/ExcavatorDriver.java
@@ -19,10 +19,10 @@ public class ExcavatorDriver extends DriverTileEntity
 		TileEntity te = w.getTileEntity(x, y, z);
 		if (te instanceof TileEntityExcavator)
 		{
-			TileEntityExcavator master = ((TileEntityExcavator)te).master();
+			TileEntityExcavator exc = (TileEntityExcavator)te;
 			int pos = ((TileEntityExcavator)te).pos;
 			if (pos==3)
-				return new ExcavatorEnvironment(w, master.xCoord, master.yCoord, master.zCoord);
+				return new ExcavatorEnvironment(w, exc.xCoord-exc.offset[0], exc.yCoord-exc.offset[1], exc.zCoord-exc.offset[2]);
 		}
 		return null;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/FermenterDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/FermenterDriver.java
@@ -21,8 +21,8 @@ public class FermenterDriver extends DriverTileEntity
 		TileEntity te = w.getTileEntity(x, y, z);
 		if (te instanceof TileEntityFermenter)
 		{
-			TileEntityFermenter master = ((TileEntityFermenter)te).master();
-			return new FermenterEnvironment(w, master.xCoord, master.yCoord, master.zCoord);
+			TileEntityFermenter ferment = (TileEntityFermenter)te;
+			return new FermenterEnvironment(w, ferment.xCoord-ferment.offset[0], ferment.yCoord-ferment.offset[1], ferment.zCoord-ferment.offset[2]);
 		}
 		return null;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/OCHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/OCHelper.java
@@ -26,6 +26,7 @@ public class OCHelper extends IECompatModule
 		API.driver.add(new FermenterDriver());
 		API.driver.add(new FloodlightDriver());
 		API.driver.add(new ExcavatorDriver());
+		API.driver.add(new CapacitorDriver());
 		
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/RefineryDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/RefineryDriver.java
@@ -29,8 +29,8 @@ public class RefineryDriver extends DriverTileEntity
 			int pos = ((TileEntityRefinery)te).pos;
 			if (pos==9)
 			{
-				TileEntityRefinery master = ((TileEntityRefinery)te).master();
-				return new RefineryEnvironment(w, master.xCoord, master.yCoord, master.zCoord, TileEntityRefinery.class);
+				TileEntityRefinery ref = (TileEntityRefinery)te;
+				return new RefineryEnvironment(w, ref.xCoord-ref.offset[0], ref.yCoord-ref.offset[1], ref.zCoord-ref.offset[2], TileEntityRefinery.class);
 			}
 		}
 		return null;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/SqueezerDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/SqueezerDriver.java
@@ -21,8 +21,8 @@ public class SqueezerDriver extends DriverTileEntity
 		TileEntity te = w.getTileEntity(x, y, z);
 		if (te instanceof TileEntitySqueezer)
 		{
-			TileEntitySqueezer master = ((TileEntitySqueezer)te).master();
-			return new FermenterEnvironment(w, master.xCoord, master.yCoord, master.zCoord);
+			TileEntitySqueezer squeezer = (TileEntitySqueezer)te;
+			return new FermenterEnvironment(w, squeezer.xCoord-squeezer.offset[0], squeezer.yCoord-squeezer.offset[1], squeezer.zCoord-squeezer.offset[2]);
 		}
 		return null;
 	}

--- a/src/main/java/blusunrize/lib/manual/gui/GuiManual.java
+++ b/src/main/java/blusunrize/lib/manual/gui/GuiManual.java
@@ -36,6 +36,7 @@ public class GuiManual extends GuiScreen
 	public static ArrayList<String> previousSelectedEntry = new ArrayList();
 	public static int page;
 	public static GuiManual activeManual;
+	private static String categoryBeforeSearch = null;
 
 	ManualInstance manual;
 	String texture;
@@ -409,11 +410,19 @@ public class GuiManual extends GuiScreen
 			String search = searchField.getText();
 			if(search==null || search.trim().isEmpty())
 			{
+				if (categoryBeforeSearch!=null)
+				{
+					selectedCategory = categoryBeforeSearch;
+					categoryBeforeSearch = null;
+				}
 				hasSuggestions = -1;
 				this.initGui();
 			}
 			else
 			{
+				if (categoryBeforeSearch==null)
+					categoryBeforeSearch = selectedCategory;
+				selectedCategory = "SomeStringThatIsntACategory";
 				search = search.toLowerCase();
 				ArrayList<String> lHeaders = new ArrayList<String>();
 				HashMap<String, String> lSpellcheck = new HashMap<String, String>();

--- a/src/main/resources/assets/immersiveengineering/lang/en_US.lang
+++ b/src/main/resources/assets/immersiveengineering/lang/en_US.lang
@@ -930,7 +930,7 @@ ie.manual.entry.excavator1=The structure is comprised of two pieces: The engine 
 
 ie.manual.category.computers.name=Computer support
 
-ie.manual.entry.computer.general.name=General information
+ie.manual.entry.computer.general.name=General information (computers)
 ie.manual.entry.computer.general.subtext=Still need some idea for this
 ie.manual.entry.computer.general0=Many of the machines described in this manual can be controlled using computers from OpenComputers or ComputerCraft. When using OpenComputers, an Adapter has to be used to connect the machine to the network. If the machine is a multiblock that has a redstone port, that is where you can attach your computer. Otherwise please check the machine-specific entry in this chapter. The following pages describe some commonly used return types.
 ie.manual.entry.computer.general1=§lItem stacks§r are a very common return type. They consist of a table containing these entries:<br>§lname§r: the internal name of the item, i.e. "minecraft:cobblestone" for cobblestone<br>§lsize§r: the size of the item stack<br>§lnameUnlocalized§r: the unlocalized name of the item, i.e. "tile.stonebrick" for cobblestone. Only available on ComputerCraft<br>§llabel§r: The name of the stack. Changes when the stack is renamed in an anvil.
@@ -938,31 +938,31 @@ ie.manual.entry.computer.general2=§ldamage§r: The damage (or, in most cases, m
 ie.manual.entry.computer.general3=§lFluid stacks§r: A fluid stack represents some amount of a specific fluid that isn't necessarily in a tank. These entries are available in the returned table:<br>§lname§r: the unlocalized name of the fluid<br>§lamount§r: the amount of fluid, in millibuckets<br>§lhasTag§r: whether the fluid has a nbt tag
 ie.manual.entry.computer.general4=§lFluid tanks§r are similar to fluid stacks, with the difference that this fluid is inside a tank. The returned table has the same entries as the table for a fluid stack. Additionally the capacity of the tank the fluid is in is stored in the entry §lcapacity§r
 
-ie.manual.entry.computer.arcfurnace.name=Arc Furnace
+ie.manual.entry.computer.arcfurnace.name=Arc Furnace (computers)
 ie.manual.entry.computer.arcfurnace.subtext=Not a reactor 
 ie.manual.entry.computer.arcFurnace0=§lsetEnabled(boolean active)§r: allows or disallows the arc furnace to operate, as if a redstone signal was applied to the control panel<br>§lisActive()§r: returns a boolean that is true if the arc furnace is currently processing something and false otherwise<br>§lgetInputStack(int slot)§r:returns the stack in the specified input slot (0-11). The table additionally has the keys §lprogress§r and §lmaxProgress§r to store the current progress and the progress at which it will be finished on the
 ie.manual.entry.computer.arcFurnace1=specified slot (both values in ticks)<br>§lgetOutputStack(int slot)§r:returns the stack in the specified output slot(0-5)<br>§lgetAdditiveStack(int slot)§r: returns the stack in the specified additive slot (0-3)<br>§lgetSlagStack()§r: returns the stack in the slag slot<br>§lhasElectrodes()§r:returns a boolean indicating whether all 3 electrodes in the arc furnace are valid<br>§lgetElectrode(int slot)§r: returns the item stack of the specified electrode (0-3)
 ie.manual.entry.computer.arcFurnace2=§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in this arc furnace<br>§lgetEnergyStored()§r: returns the amount of energy currently stored in this arc furnace
 
-ie.manual.entry.computer.sampleDrill.name=Core sample drill
+ie.manual.entry.computer.sampleDrill.name=Core sample drill (computers)
 ie.manual.entry.computer.sampleDrill.subtext=No idea for this either
 ie.manual.entry.computer.sampleDrill0=The sample drill can be connected to a computer on its bottom block.<br>§lgetSampleProgress()§r: returns the current sample progress, 1 means that the sampling is finished, 0 means that the sampling hasn't started yet<br>§lisSamplingFinished()§r: returns true if the drill has finished sampling, otherwise it returns false<br>§lgetVeinUnlocalizedName()§r: returns the unlocalized name of the found vein
 ie.manual.entry.computer.sampleDrill1=§lgetVeinLocalizedName()§r: returns the localized name of the found vein<br>§lgetVeinIntegrity()§r: returns the integrity of the vein, 1 represents a full vein, 0 an empty vein and -1 an infinite vein<br>§lgetEnergyStored()§r: returns the amount of energy stored in the drill<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy stored in this drill
 
-ie.manual.entry.computer.crusher.name=Crusher
+ie.manual.entry.computer.crusher.name=Crusher (computers)
 ie.manual.entry.computer.crusher.subtext=Keep your hands out!
 ie.manual.entry.computer.crusher0=§lgetQueueLength()§r: The amount of stacks that are waiting to be processed<br>§lsetEnabled(boolean active)§r: allows or disallows the crusher to operate, as if a redstone signal was applied to the control panel<br>§lisActive()§r: returns whether the crusher is currently crushing items<br>§lgetInputStack(int pos)§r: returns the stack in the specified position in the queue (the queue starts at 0)<br>§lgetCurrentMaxProgress()§r and §lgetCurrentProgress()§r
 ie.manual.entry.computer.crusher1=are meant to be used together, they return the amount of RF required to crush the current input and the energy already consumed processing the current input<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy stored in this crusher<br>§lgetEnergyStored()§r: returns the amount of energy that is stored in this crusher
 
-ie.manual.entry.computer.dieselgen.name=Diesel Generator
+ie.manual.entry.computer.dieselgen.name=Diesel Generator (computers)
 ie.manual.entry.computer.dieselgen.subtext=Better than volume: More volume.
 ie.manual.entry.computer.dieselgen0=§lsetEnabled(boolean active)§r: allows or disallows the diesel generator to run<br>§lisActive()§r: returns whether the generator is running<br>§lgetTankInfo()§r: returns the internal diesel tank
 
-ie.manual.entry.computer.energymeter.name=Current Transformer
+ie.manual.entry.computer.energymeter.name=Current Transformer (computers)
 ie.manual.entry.computer.energymeter.subtext=88 Flux per hour!
 ie.manual.entry.computer.energymeter0=The bottom block of a current transformer can be connected to a computer. It will provide a single method, §LgetAvgEnergy§r , that returns the average amount of energy per tick that was transferred through the transformer during the last 20 ticks.
 
-ie.manual.entry.computer.excavator.name=Excavator
+ie.manual.entry.computer.excavator.name=Excavator (computers)
 ie.manual.entry.computer.excavator.subtext=Better than Dwarves
 ie.manual.entry.computer.excavator0=§lisActive()§r: returns whether the excavator is running. This does not say anything about the existence of a mineral vein<br>§lsetEnabled(boolean active)§r: allows or disallows the excavator to run<br>§lgetEnergyStored()§r: returns the amount of energy currently stored in this excavator<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in this excavator
 
@@ -972,23 +972,27 @@ ie.manual.entry.computer.squeezerAndFermenter0=The computer support for fermente
 ie.manual.entry.computer.squeezerAndFermenter1=found" will be returned.<br>§lgetInputStack(int slot)§r: returns the stack in the specified input slot (0-8)<br>§lgetOutputStack()§r: returns the stack in the item output slot<br>§lgetFluid()§r: returns the output fluid tank<br>§lgetEmptyCannisters§r: returns the stack of empty cannisters in the top right slot<br>§lgetFilledCannisters()§r: returns the stack of filled cannisters in the bottom right<br>§lgetEnergyStored§r: returns the amount of energy stored in this machine
 ie.manual.entry.computer.squeezerAndFermenter2=§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in this machine
 
-ie.manual.entry.computer.floodlight.name=Floodlight
+ie.manual.entry.computer.floodlight.name=Floodlight (computers)
 ie.manual.entry.computer.floodlight.subtext=NO IDEA
 ie.manual.entry.computer.floodlight0=The following assumes that the floodlight is placed on the ground. The floodlight can be connected to a computer on it's bottom face. After rotating a floodlight using a computer you have to wait for one second before you can rotate it again.<br>§lturnAroundXZ(boolean dir)§r: changes the pitch of the floodlight<br>§lturnAroundY(boolean dir)§r: turns the floodlight as if it was rightclicked on its top or bottom<br>§lcanTurn()§r: returns whether the floodlight can rotate again yet
 ie.manual.entry.computer.floodlight1=§lwaitForTimeout()§r: waits until the floodlight can turn again. Only available when using ComputerCraft<br>§lsetEnabled(boolean on)§r: turns the floodlight on or off<br>§lisActive()§r: returns whether this floodlight is currently active<br>§lgetEnergyStored()§r: returns the amount of energy stored in the floodlight<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in the floodlight
 
-ie.manual.entry.computer.refinery.name=Refinery
+ie.manual.entry.computer.refinery.name=Refinery (computers)
 ie.manual.entry.computer.refinery.subtext=STOP ASKING
 ie.manual.entry.computer.refinery0=§lgetInputFluidTanks()§r: returns a table storing the input tanks in the keys "input0" and "input1"<br>§lgetOutputTank()§r: returns the output tank<br>§lgetRecipe()§r: returns a table containing the input fluids in the keys "input0" and "input1" and the output fluid in the key "output"<br>§lsetEnabled(boolean on)§r: allows or disallows the refinery to run<br>§lisValidRecipe()§r: returns whether a recipe with the current input fluids exists
 ie.manual.entry.computer.refinery1=§lgetEmptyCannisters()§r: returns a table containing the stacks of empty cannisters, the keys "input0" and "input1" for the input tanks, the key "output" for the output tank<br>§lgetMaxEnergyStored()§r: returns the maximum of energy that can be stored in this refinery<br>§lgetEnergyStored()§r: returns the amount of energy stored in the refinery
 
-ie.manual.entry.computer.assembler.name=Assembler
+ie.manual.entry.computer.assembler.name=Assembler (computers)
 ie.manual.entry.computer.assembler.subtext=Some assembly required
 ie.manual.entry.computer.assembler0=The bottom row of an assembler can be connected to a computer.<br>§lhasIngredients(int recipe)§r: returns whether the ingredients for the specified recipe (0-2) are available<br>§lsetEnabled(int slot, boolean on)§r: enables or disables the specified recipe (0-2). If a recipe is disabled, it will not be crafted even if the materials are available.<br>§lgetRecipe(int recipe)l§r: returns a table containing the specified recipe (0-2). The keys "in1", "in2", ..., "in9" store the recipe inputs, the key "out"
 ie.manual.entry.computer.assembler1=stores the output<br>§lgetTank(int tank)§r: returns the specified tank (0-2)<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in the assembler<br>§lgetEnergyStored()§r: returns the amount of energy stored in the assembler<br>§lgetStackInSlot(int slot)§r: returns the stack in the specified input slot.<br>§lgetBufferStack(recipe:int)§r: returns the output buffer slot for the specified recipe (0-2)
 
-ie.manual.entry.computer.bottlingMachine.name=Bottling Machine
+ie.manual.entry.computer.bottlingMachine.name=Bottling Machine (computers)
 ie.manual.entry.computer.bottlingMachine.subtext=Fill 'er up!
 ie.manual.entry.computer.bottlingMachine0=The block in the bottom middle of the front of a bottling machine and the back bottom row can be connected to a computer. A cannister is considered filled if it has passed the black box on the conveyor.<br>§lgetFluid()§r: returns the internal fluid tank of the bottling machine<br>§lgetEmptyCannister(int n)§r: returns the n'th empty cannister, starting where the cannisters enter the machine. The table contains the current filling progress in ticks in the key "process". A bottle is filled
 ie.manual.entry.computer.bottlingMachine1=at progress 72 and output at progress 120.<br>§lgetEmptyCannisterCount()§r: returns the amount of empty cannisters in the bottling machine<br>§lgetFilledCannister(int n)§r: returns the n'th filled cannister, starting at the black box. The returned table contains the filling progress stored in the key "process".<br>§lgetFilledCannisterCount()§r: returns the amount of filled cannisters in the bottling machine<br>§lgetEnergyStored()§r: returns
 ie.manual.entry.computer.bottlingMachine2=the amount of energy stored in the bottling machine<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy stored in this bottling machine<br>§lsetEnabled(boolean on)§r: turns the bottling machine on or off
+
+ie.manual.entry.computer.capacitor.name=Capacitors (computers)
+ie.manual.entry.computer.capacitor.subtext=Many Farads at a lot of Volts
+ie.manual.entry.computer.capacitor0=Any capacitor can be connected to a computer on any side.<br>§lgetEnergyStored()§r: returns the amount of energy that is stored<br>§lgetMaxEnergyStored()§r: returns the amount of energy that can be stored


### PR DESCRIPTION
@BluSunrize didn't want computers to be able to set in-/outputs, so I didn't implement that.
The manual now just shows "Engineer's manual" as a category while searching.
Manual entries for computer support now have " (Computers)" behind their name to make them different from the normal entries.

I love that my variations of "I don't know any good subtitle for this" went into the release :smile:, the capacitor entry actually has a proper subtitle