### PR TITLE
Add a flag to ComparableItemStack (ignoreOreDict)

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/ComparableItemStack.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/ComparableItemStack.java
@@ -1,5 +1,6 @@
 package blusunrize.immersiveengineering.api;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -7,6 +8,7 @@ public class ComparableItemStack
 {
 	public ItemStack stack;
 	public boolean useNBT;
+    public boolean ignoreOreDict;
 	public int oreID=-1;
 
 	public ComparableItemStack(ItemStack stack)
@@ -14,9 +16,9 @@ public class ComparableItemStack
 		if(stack==null)
 			throw new RuntimeException("You cannot instantiate a ComparableItemStack with null for an Item!");
 		this.stack = stack;
-		int[] oids = OreDictionary.getOreIDs(stack);
-		if(oids!=null && oids.length>0)
-			this.oreID = oids[0];
+        int[] oids = OreDictionary.getOreIDs(stack);
+        if(oids!=null && oids.length>0)
+            this.oreID = oids[0];
 	}
 	public ComparableItemStack(String oreName)
 	{
@@ -43,7 +45,7 @@ public class ComparableItemStack
 	@Override
 	public int hashCode()
 	{
-		if(this.oreID!=-1)
+		if(!ignoreOreDict && this.oreID!=-1)
 			return this.oreID;
 		//return this.stack.getItemDamage()&0xFFFF | Item.getIdFromItem(this.stack.getItem())<<16;
 		return (stack.getItemDamage()&0xffff)*31 + stack.getItem().hashCode()*31;
@@ -59,7 +61,7 @@ public class ComparableItemStack
 			return this.oreID == ((ComparableItemStack)object).oreID;
 
 		ItemStack otherStack = ((ComparableItemStack)object).stack;
-		if(!OreDictionary.itemMatches(stack,otherStack, false))
+		if(!OreDictionary.itemMatches(stack,otherStack, !ignoreOreDict))
 			return false;
 		if(this.useNBT)
 		{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityCrusher.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityCrusher.java
@@ -262,6 +262,7 @@ public class TileEntityCrusher extends TileEntityMultiblockPart implements IEner
 		comp.stack.stackTagCompound = null;
 		comp.stack.stackSize = 1;
 		comp.useNBT = false;
+        comp.ignoreOreDict = true;
 		if(recipeCache.containsKey(comp))
 		{
 			CrusherRecipe r = recipeCache.get(comp);


### PR DESCRIPTION
Flag allows oreDict entries to be ignored when comparing stacks. As discussed in our conversation on MCF and IRC.