### PR TITLE
Misc fixes

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderClothDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderClothDevices.java
@@ -15,7 +15,7 @@ public class BlockRenderClothDevices implements ISimpleBlockRenderingHandler
 {
 	public static int renderID = RenderingRegistry.getNextAvailableRenderId();
 	public static int renderPass;
-
+	private static final TileEntityBalloon balloon = new TileEntityBalloon();
 	@Override
 	public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer)
 	{
@@ -24,7 +24,7 @@ public class BlockRenderClothDevices implements ISimpleBlockRenderingHandler
 			if(metadata==0)
 			{
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityBalloon());
+				ClientUtils.handleStaticTileRenderer(balloon);
 				Tessellator.instance.draw();
 			}
 		}catch(Exception e)

--- a/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderMetalDecoration.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderMetalDecoration.java
@@ -23,7 +23,9 @@ import cpw.mods.fml.client.registry.RenderingRegistry;
 public class BlockRenderMetalDecoration implements ISimpleBlockRenderingHandler
 {
 	public static int renderID = RenderingRegistry.getNextAvailableRenderId();
-
+	private static final TileEntityLantern lantern = new TileEntityLantern();
+	private static final TileEntityConnectorStructural conn = new TileEntityConnectorStructural();
+	private static final TileEntityWallmountMetal wall = new TileEntityWallmountMetal();
 	@Override
 	public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer)
 	{
@@ -50,7 +52,7 @@ public class BlockRenderMetalDecoration implements ISimpleBlockRenderingHandler
 			else if(metadata==BlockMetalDecoration.META_lantern)
 			{
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityLantern());
+				ClientUtils.handleStaticTileRenderer(lantern);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDecoration.META_structuralArm||metadata==BlockMetalDecoration.META_aluminiumStructuralArm)
@@ -112,13 +114,13 @@ public class BlockRenderMetalDecoration implements ISimpleBlockRenderingHandler
 			else if(metadata==BlockMetalDecoration.META_connectorStructural)
 			{
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityConnectorStructural());
+				ClientUtils.handleStaticTileRenderer(conn);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDecoration.META_wallMount)
 			{
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityWallmountMetal());
+				ClientUtils.handleStaticTileRenderer(wall);
 				Tessellator.instance.draw();
 			}
 			else

--- a/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderMetalDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderMetalDevices.java
@@ -27,7 +27,13 @@ import cpw.mods.fml.client.registry.RenderingRegistry;
 public class BlockRenderMetalDevices implements ISimpleBlockRenderingHandler
 {
 	public static int renderID = RenderingRegistry.getNextAvailableRenderId();
-
+	private static final TileEntityConnectorLV connLv = new TileEntityConnectorLV();
+	private static final TileEntityConnectorMV connMv = new TileEntityConnectorMV();
+	private static final TileEntityConnectorHV connHv = new TileEntityConnectorHV();
+	private static final TileEntityRelayHV relayHv = new TileEntityRelayHV();
+	private static final TileEntityTransformer transform = new TileEntityTransformer();
+	private static final TileEntityTransformerHV transformHv = new TileEntityTransformerHV();
+	private static final TileEntitySampleDrill drill = new TileEntitySampleDrill();
 	@Override
 	public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer)
 	{
@@ -38,7 +44,7 @@ public class BlockRenderMetalDevices implements ISimpleBlockRenderingHandler
 			{
 				GL11.glScalef(1.25f, 1.25f, 1.25f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityConnectorLV());
+				ClientUtils.handleStaticTileRenderer(connLv);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices.META_capacitorLV)
@@ -51,7 +57,7 @@ public class BlockRenderMetalDevices implements ISimpleBlockRenderingHandler
 			{
 				GL11.glScalef(1.25f, 1.25f, 1.25f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityConnectorMV());
+				ClientUtils.handleStaticTileRenderer(connMv);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices.META_capacitorMV)
@@ -64,21 +70,21 @@ public class BlockRenderMetalDevices implements ISimpleBlockRenderingHandler
 			{
 				GL11.glScalef(.5f,.5f,.5f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityTransformer());
+				ClientUtils.handleStaticTileRenderer(transform);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices.META_relayHV)
 			{
 				GL11.glScalef(1f, 1f, 1f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityRelayHV());
+				ClientUtils.handleStaticTileRenderer(relayHv);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices.META_connectorHV)
 			{
 				GL11.glScalef(1.25f, 1.25f, 1.25f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityConnectorHV());
+				ClientUtils.handleStaticTileRenderer(connHv);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices.META_capacitorHV)
@@ -91,7 +97,7 @@ public class BlockRenderMetalDevices implements ISimpleBlockRenderingHandler
 			{
 				GL11.glScalef(.5f,.5f,.5f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityTransformerHV());
+				ClientUtils.handleStaticTileRenderer(transformHv);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices.META_dynamo)
@@ -128,7 +134,7 @@ public class BlockRenderMetalDevices implements ISimpleBlockRenderingHandler
 			{
 				GL11.glScalef(.5f,.5f,.5f);
 				GL11.glTranslatef(0,-1f,0);
-				TileEntityRendererDispatcher.instance.renderTileEntityAt(new TileEntitySampleDrill(), 0.0D, 0.0D, 0.0D, 0.0F);
+				TileEntityRendererDispatcher.instance.renderTileEntityAt(drill, 0.0D, 0.0D, 0.0D, 0.0F);
 			}
 		}catch(Exception e)
 		{

--- a/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderMetalDevices2.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderMetalDevices2.java
@@ -29,7 +29,15 @@ public class BlockRenderMetalDevices2 implements ISimpleBlockRenderingHandler
 {
 	public static int renderID = RenderingRegistry.getNextAvailableRenderId();
 	public static int renderPass = 0;
-
+	private static final TileEntityBlastFurnacePreheater heat = new TileEntityBlastFurnacePreheater();
+	private static final TileEntityBreakerSwitch breaker = new TileEntityBreakerSwitch();
+	private static final TileEntityChargingStation charge = new TileEntityChargingStation();
+	private static final TileEntityElectricLantern lantern = new TileEntityElectricLantern();
+	private static final TileEntityFloodlight flood = new TileEntityFloodlight();
+	private static final TileEntityFluidPipe pipe = new TileEntityFluidPipe();
+	private static final TileEntityFluidPump pump = new TileEntityFluidPump();
+	private static final TileEntityRedstoneBreaker redBreaker = new TileEntityRedstoneBreaker();
+	private static final TileEntityEnergyMeter meter = new TileEntityEnergyMeter();
 	@Override
 	public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer)
 	{
@@ -41,7 +49,7 @@ public class BlockRenderMetalDevices2 implements ISimpleBlockRenderingHandler
 				GL11.glScalef(1.25f, 1.25f, 1.25f);
 				GL11.glRotatef(-90, 1,0,0);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityBreakerSwitch());
+				ClientUtils.handleStaticTileRenderer(breaker);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices2.META_energyMeter)
@@ -49,28 +57,27 @@ public class BlockRenderMetalDevices2 implements ISimpleBlockRenderingHandler
 				GL11.glScalef(.75f,.75f,.75f);
 				GL11.glTranslatef(0,.625f,0);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityEnergyMeter());
+				ClientUtils.handleStaticTileRenderer(meter);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices2.META_electricLantern)
 			{
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityElectricLantern());
+				ClientUtils.handleStaticTileRenderer(lantern);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices2.META_floodlight)
 			{
 				Tessellator.instance.startDrawingQuads();
-				TileEntityFloodlight tile = new TileEntityFloodlight();
-				TileEntitySpecialRenderer tesr = TileEntityRendererDispatcher.instance.getSpecialRenderer(tile);
+				TileEntitySpecialRenderer tesr = TileEntityRendererDispatcher.instance.getSpecialRenderer(flood);
 				if(tesr instanceof TileRenderFloodlight)
-					((TileRenderFloodlight)tesr).model.render(tile, Tessellator.instance, new Matrix4().translate(0,.125,0),new Matrix4().rotate(Math.PI,0,1,0), 0,false);
+					((TileRenderFloodlight)tesr).model.render(flood, Tessellator.instance, new Matrix4().translate(0,.125,0),new Matrix4().rotate(Math.PI,0,1,0), 0,false);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices2.META_fluidPipe)
 			{
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityFluidPipe());
+				ClientUtils.handleStaticTileRenderer(pipe);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices2.META_fluidPump)
@@ -106,7 +113,7 @@ public class BlockRenderMetalDevices2 implements ISimpleBlockRenderingHandler
 				Tessellator.instance.draw();
 
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityFluidPump());
+				ClientUtils.handleStaticTileRenderer(pump);
 				Tessellator.instance.draw();
 				GL11.glPopMatrix();
 			}
@@ -125,19 +132,18 @@ public class BlockRenderMetalDevices2 implements ISimpleBlockRenderingHandler
 			{
 				GL11.glTranslatef(-.5f,-.5f,-.5f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityRedstoneBreaker());
+				ClientUtils.handleStaticTileRenderer(redBreaker);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices2.META_chargingStation)
 			{
 				Tessellator.instance.startDrawingQuads();
-				TileEntityChargingStation tile = new TileEntityChargingStation();
 				GL11.glRotatef(-180, 0,1,0);
 				GL11.glTranslatef(-.5f,-.5f,-.5f);
 				renderPass = 0;
-				ClientUtils.handleStaticTileRenderer(tile);
+				ClientUtils.handleStaticTileRenderer(charge);
 				renderPass = 1;
-				ClientUtils.handleStaticTileRenderer(tile);
+				ClientUtils.handleStaticTileRenderer(charge);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==BlockMetalDevices2.META_blastFurnacePreheater)
@@ -145,7 +151,7 @@ public class BlockRenderMetalDevices2 implements ISimpleBlockRenderingHandler
 				GL11.glScalef(0.4375f, 0.4375f, 0.4375f);
 				GL11.glTranslatef(-.5f,-1.25f,-.5f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityBlastFurnacePreheater());
+				ClientUtils.handleStaticTileRenderer(heat);
 				Tessellator.instance.draw();
 			}
 

--- a/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderWoodenDecoration.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderWoodenDecoration.java
@@ -16,7 +16,7 @@ import cpw.mods.fml.client.registry.RenderingRegistry;
 public class BlockRenderWoodenDecoration implements ISimpleBlockRenderingHandler
 {
 	public static int renderID = RenderingRegistry.getNextAvailableRenderId();
-
+	private static final TileEntityWallmount wallmount = new TileEntityWallmount();
 	@Override
 	public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer)
 	{
@@ -56,7 +56,7 @@ public class BlockRenderWoodenDecoration implements ISimpleBlockRenderingHandler
 			else if(metadata==6)
 			{
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityWallmount());
+				ClientUtils.handleStaticTileRenderer(wallmount);
 				Tessellator.instance.draw();
 			}
 		}catch(Exception e)

--- a/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderWoodenDevices.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/BlockRenderWoodenDevices.java
@@ -19,7 +19,15 @@ import net.minecraft.world.IBlockAccess;
 public class BlockRenderWoodenDevices implements ISimpleBlockRenderingHandler
 {
 	public static int renderID = RenderingRegistry.getNextAvailableRenderId();
-
+	private static final TileEntityWoodenPost woodenPost = new TileEntityWoodenPost();
+	private static final TileEntityWatermill waterMill = new TileEntityWatermill();
+	private static final TileEntityWindmill windMill = new TileEntityWindmill();
+	private static final TileEntityWindmillAdvanced windMillAdv = new TileEntityWindmillAdvanced();
+	private static final TileEntityModWorkbench workbench = new TileEntityModWorkbench();
+	static
+	{
+		workbench.facing=3;
+	}
 	@Override
 	public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer)
 	{
@@ -30,23 +38,23 @@ public class BlockRenderWoodenDevices implements ISimpleBlockRenderingHandler
 				GL11.glScalef(.5f, .33f, .5f);
 				GL11.glTranslatef(-.5f, -2F, -.5f);
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(new TileEntityWoodenPost());
+				ClientUtils.handleStaticTileRenderer(woodenPost);
 				Tessellator.instance.draw();
 			}
 			else if(metadata==1)
 			{
 				GL11.glScalef(.25f, .25f, .25f);
-				TileEntityRendererDispatcher.instance.renderTileEntityAt(new TileEntityWatermill(), 0.0D, 0.0D, 0.0D, 0.0F);
+				TileEntityRendererDispatcher.instance.renderTileEntityAt(waterMill, 0.0D, 0.0D, 0.0D, 0.0F);
 			}
 			else if(metadata==2)
 			{
 				GL11.glScalef(.125f, .125f, .125f);
-				TileEntityRendererDispatcher.instance.renderTileEntityAt(new TileEntityWindmill(), 0.0D, 0.0D, 0.0D, 0.0F);
+				TileEntityRendererDispatcher.instance.renderTileEntityAt(windMill, 0.0D, 0.0D, 0.0D, 0.0F);
 			}
 			else if(metadata==3)
 			{
 				GL11.glScalef(.125f, .125f, .125f);
-				TileEntityRendererDispatcher.instance.renderTileEntityAt(new TileEntityWindmillAdvanced(), 0.0D, 0.0D, 0.0D, 0.0F);
+				TileEntityRendererDispatcher.instance.renderTileEntityAt(windMillAdv, 0.0D, 0.0D, 0.0D, 0.0F);
 			}
 			else if(metadata==4)
 			{
@@ -57,10 +65,8 @@ public class BlockRenderWoodenDevices implements ISimpleBlockRenderingHandler
 			{
 				GL11.glScalef(.75f, .75f, .75f);
 				GL11.glTranslatef(-.75f, -.5F, -.25f);
-				TileEntityModWorkbench tile = new TileEntityModWorkbench();
-				tile.facing=3;
 				Tessellator.instance.startDrawingQuads();
-				ClientUtils.handleStaticTileRenderer(tile);
+				ClientUtils.handleStaticTileRenderer(workbench);
 				Tessellator.instance.draw();
 //				TileEntityRendererDispatcher.instance.renderTileEntityAt(tile, 0,0,0,0);
 			}

--- a/src/main/java/blusunrize/immersiveengineering/common/IERecipes.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IERecipes.java
@@ -98,8 +98,8 @@ public class IERecipes
 			BlueprintCraftingRecipe.addRecipe("specialBullet", new ItemStack(IEContent.itemBullet,1,6), new ItemStack(IEContent.itemBullet,1,1),Items.gunpowder,"dustAluminium","dustAluminium");
 		BlueprintCraftingRecipe.addRecipe("specialBullet", new ItemStack(IEContent.itemBullet,1,10), new ItemStack(IEContent.itemBullet,1,0),Items.gunpowder,"dustQuartz",Items.glass_bottle);
 
-		BlueprintCraftingRecipe.addVillagerTrade("bullet", new ItemStack(Items.emerald,1,2));
-		BlueprintCraftingRecipe.addVillagerTrade("specialBullet", new ItemStack(Items.emerald,1,7));
+		BlueprintCraftingRecipe.addVillagerTrade("bullet", new ItemStack(Items.emerald,2));
+		BlueprintCraftingRecipe.addVillagerTrade("specialBullet", new ItemStack(Items.emerald,7));
 		GameRegistry.addRecipe(new RecipePotionBullets());
 		RecipeSorter.register(ImmersiveEngineering.MODID+":potionBullet", RecipePotionBullets.class, RecipeSorter.Category.SHAPELESS, "after:forge:shapelessore");
 
@@ -107,7 +107,7 @@ public class IERecipes
 		addOredictRecipe(new ItemStack(IEContent.itemBlueprint,1,blueprint), "JKL","DDD","PPP", 'J',Items.gunpowder,'K',"ingotCopper",'L',Items.gunpowder, 'D',"dyeBlue",'P',Items.paper);
 
 		BlueprintCraftingRecipe.addRecipe("electrode", new ItemStack(IEContent.itemGraphiteElectrode), "ingotHOPGraphite","ingotHOPGraphite","ingotHOPGraphite","ingotHOPGraphite");
-		BlueprintCraftingRecipe.addVillagerTrade("electrode", new ItemStack(Items.emerald,1,18));
+		BlueprintCraftingRecipe.addVillagerTrade("electrode", new ItemStack(Items.emerald,18));
 		blueprint = BlueprintCraftingRecipe.blueprintCategories.indexOf("electrode");
 		ChestGenHooks.getInfo(ChestGenHooks.STRONGHOLD_LIBRARY).addItem(new WeightedRandomChestContent(new ItemStack(IEContent.itemBlueprint,1,blueprint), 1,1, 10));
 		ChestGenHooks.getInfo(ChestGenHooks.VILLAGE_BLACKSMITH).addItem(new WeightedRandomChestContent(new ItemStack(IEContent.itemBlueprint,1,blueprint), 1,1, 2));

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockArcFurnace.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockArcFurnace.java
@@ -24,9 +24,13 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class MultiblockArcFurnace implements IMultiblock
 {
 	public static MultiblockArcFurnace instance = new MultiblockArcFurnace();
+	private static final TileEntityArcFurnace furn = new TileEntityArcFurnace();
 
 	static ItemStack[][][] structure = new ItemStack[5][5][5];
 	static{
+		furn.formed=true;
+		furn.pos=62;
+		furn.facing=4;
 		for(int h=0;h<5;h++)
 			for(int l=0;l<5;l++)
 				for(int w=0;w<5;w++)
@@ -113,14 +117,10 @@ public class MultiblockArcFurnace implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityArcFurnace te = new TileEntityArcFurnace();
-		te.formed=true;
-		te.pos=62;
-		te.facing=4;
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5,-.5,-.5);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(furn, false);
 		ClientUtils.tes().setTranslation(0,0,0);
 		ClientUtils.tes().draw();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockAssembler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockAssembler.java
@@ -25,6 +25,7 @@ public class MultiblockAssembler implements IMultiblock
 {
 	public static MultiblockAssembler instance = new MultiblockAssembler();
 	static ItemStack[][][] structure = new ItemStack[3][3][3];
+	private static final TileEntityAssembler assemble = new TileEntityAssembler();
 	static{
 		for(int h=0;h<3;h++)
 			for(int l=0;l<3;l++)
@@ -78,11 +79,10 @@ public class MultiblockAssembler implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityAssembler te = new TileEntityAssembler();
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5f,-1.5f,-.5f);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(assemble, false);
 		ClientUtils.tes().draw();
 		ClientUtils.tes().setTranslation(0,0,0);
 	}
@@ -97,7 +97,7 @@ public class MultiblockAssembler implements IMultiblock
 	{
 		return "IE:Assembler";
 	}
-	
+
 	@Override
 	public boolean isBlockTrigger(Block b, int meta)
 	{
@@ -174,18 +174,18 @@ public class MultiblockAssembler implements IMultiblock
 					int yy = startY+ h;
 					int zz = startZ+ (side==2?l: side==3?-l: side==5?-w : w);
 
-						world.setBlock(xx, yy, zz, IEContent.blockMetalMultiblocks, BlockMetalMultiblocks.META_assembler, 0x3);
-						TileEntity curr = world.getTileEntity(xx, yy, zz);
-						if(curr instanceof TileEntityAssembler)
-						{
-							TileEntityAssembler tile = (TileEntityAssembler)curr;
-							tile.facing=side;
-							tile.formed=true;
-							tile.pos = (h+1)*9 + l*3 + (w+1);
-							tile.offset = new int[]{(side==4?l-1: side==5?1-l: side==2?-w: w),h,(side==2?l-1: side==3?1-l: side==5?-w: w)};
-						}
+					world.setBlock(xx, yy, zz, IEContent.blockMetalMultiblocks, BlockMetalMultiblocks.META_assembler, 0x3);
+					TileEntity curr = world.getTileEntity(xx, yy, zz);
+					if(curr instanceof TileEntityAssembler)
+					{
+						TileEntityAssembler tile = (TileEntityAssembler)curr;
+						tile.facing=side;
+						tile.formed=true;
+						tile.pos = (h+1)*9 + l*3 + (w+1);
+						tile.offset = new int[]{(side==4?l-1: side==5?1-l: side==2?-w: w),h,(side==2?l-1: side==3?1-l: side==5?-w: w)};
 					}
-//			player.triggerAchievement(IEAchievements.mbCrusher);
+				}
+		//			player.triggerAchievement(IEAchievements.mbCrusher);
 		return true;
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockBlastFurnaceAdvanced.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockBlastFurnaceAdvanced.java
@@ -22,9 +22,10 @@ public class MultiblockBlastFurnaceAdvanced implements IMultiblock
 {
 
 	public static MultiblockBlastFurnaceAdvanced instance = new MultiblockBlastFurnaceAdvanced();
-
+	private static final TileEntityBlastFurnaceAdvanced furnace = new TileEntityBlastFurnaceAdvanced();
 	static ItemStack[][][] structure = new ItemStack[4][3][3];
 	static{
+		furnace.facing = 3;
 		for(int h=0;h<4;h++)
 			for(int l=0;l<3;l++)
 				for(int w=0;w<3;w++)
@@ -58,9 +59,7 @@ public class MultiblockBlastFurnaceAdvanced implements IMultiblock
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5, -1, .5);
-		TileEntityBlastFurnaceAdvanced tile = new TileEntityBlastFurnaceAdvanced();
-		tile.facing = 3;
-		ClientUtils.handleStaticTileRenderer(tile, false);
+		ClientUtils.handleStaticTileRenderer(furnace, false);
 		ClientUtils.tes().setTranslation(0,0,0);
 		ClientUtils.tes().draw();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockBottlingMachine.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockBottlingMachine.java
@@ -27,7 +27,10 @@ public class MultiblockBottlingMachine implements IMultiblock
 {
 	public static MultiblockBottlingMachine instance = new MultiblockBottlingMachine();
 	static ItemStack[][][] structure = new ItemStack[2][2][3];
+	private static final TileEntityBottlingMachine bottle = new TileEntityBottlingMachine();
 	static{
+		bottle.pos = 4;
+		bottle.formed=true;
 		for(int h=0;h<2;h++)
 			for(int l=0;l<2;l++)
 				for(int w=0;w<3;w++)
@@ -77,17 +80,14 @@ public class MultiblockBottlingMachine implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityBottlingMachine te = new TileEntityBottlingMachine();
-		te.pos = 4;
-		te.formed=true;
 		ClientUtils.bindAtlas(0);
 		GL11.glRotatef(180, 0, 1, 0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5f,-1.5f,-.5f);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(bottle, false);
 		ClientUtils.tes().draw();
 		ClientUtils.tes().setTranslation(0,0,0);
-		TileEntityRendererDispatcher.instance.renderTileEntityAt(te, -.5D, -1.5D, -.5D, 0.0F);
+		TileEntityRendererDispatcher.instance.renderTileEntityAt(bottle, -.5D, -1.5D, -.5D, 0.0F);
 	}
 	@Override
 	public float getManualScale()

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockBucketWheel.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockBucketWheel.java
@@ -19,7 +19,11 @@ public class MultiblockBucketWheel implements IMultiblock
 {
 	public static MultiblockBucketWheel instance = new MultiblockBucketWheel();
 	static ItemStack[][][] structure = new ItemStack[7][7][1];
+	private static final TileEntityBucketWheel wheel = new TileEntityBucketWheel();
 	static{
+		wheel.formed=true;
+		wheel.pos=24;
+		wheel.facing=4;
 		for(int h=0;h<7;h++)
 			for(int l=0;l<7;l++)
 			{
@@ -59,11 +63,7 @@ public class MultiblockBucketWheel implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityBucketWheel te = new TileEntityBucketWheel();
-		te.formed=true;
-		te.pos=24;
-		te.facing=4;
-		TileEntityRendererDispatcher.instance.renderTileEntityAt(te, -.5D, 0.0D, -.5D, 0.0F);
+		TileEntityRendererDispatcher.instance.renderTileEntityAt(wheel, -.5D, 0.0D, -.5D, 0.0F);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockCrusher.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockCrusher.java
@@ -22,7 +22,11 @@ public class MultiblockCrusher implements IMultiblock
 {
 	public static MultiblockCrusher instance = new MultiblockCrusher();
 	static ItemStack[][][] structure = new ItemStack[3][5][3];
+	private static final TileEntityCrusher crush = new TileEntityCrusher();
 	static{
+		crush.formed=true;
+		crush.pos=17;
+		crush.facing=4;
 		for(int h=0;h<3;h++)
 			for(int l=0;l<5;l++)
 				for(int w=0;w<3;w++)
@@ -67,17 +71,13 @@ public class MultiblockCrusher implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityCrusher te = new TileEntityCrusher();
-		te.formed=true;
-		te.pos=17;
-		te.facing=4;
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-1f, -1, 0);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(crush, false);
 		ClientUtils.tes().draw();
 		ClientUtils.tes().setTranslation(0,0,0);
-		TileEntityRendererDispatcher.instance.renderTileEntityAt(te, -1D, -1D, .0D, 0.0F);
+		TileEntityRendererDispatcher.instance.renderTileEntityAt(crush, -1D, -1D, .0D, 0.0F);
 	}
 	@Override
 	public float getManualScale()

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockDieselGenerator.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockDieselGenerator.java
@@ -20,9 +20,11 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class MultiblockDieselGenerator implements IMultiblock
 {
 	public static MultiblockDieselGenerator instance = new MultiblockDieselGenerator();
-
+	private static final TileEntityDieselGenerator gen = new TileEntityDieselGenerator();
 	static ItemStack[][][] structure = new ItemStack[3][5][3];
 	static{
+		gen.formed=true;
+		gen.pos=31;
 		for(int h=0;h<3;h++)
 			for(int l=0;l<5;l++)
 				for(int w=0;w<3;w++)
@@ -53,16 +55,13 @@ public class MultiblockDieselGenerator implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityDieselGenerator te = new TileEntityDieselGenerator();
-		te.formed=true;
-		te.pos=31;
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5,-.5,-1.5);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(gen, false);
 		ClientUtils.tes().setTranslation(0,0,0);
 		ClientUtils.tes().draw();
-		TileEntityRendererDispatcher.instance.renderTileEntityAt(te, -.5D, -.5D, -1.5D, 0.0F);
+		TileEntityRendererDispatcher.instance.renderTileEntityAt(gen, -.5D, -.5D, -1.5D, 0.0F);
 	}
 	@Override
 	public float getManualScale()

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockExcavator.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockExcavator.java
@@ -23,7 +23,11 @@ public class MultiblockExcavator implements IMultiblock
 	public static MultiblockExcavator instance = new MultiblockExcavator();
 	
 	static ItemStack[][][] structure = new ItemStack[3][6][3];
+	private static final TileEntityExcavator exc = new TileEntityExcavator();
 	static{
+		exc.formed=true;
+		exc.pos=4;
+		exc.facing=3;
 		for(int l=0;l<6;l++)
 			for(int w=0;w<3;w++)
 				for(int h=0;h<3;h++)
@@ -80,14 +84,10 @@ public class MultiblockExcavator implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityExcavator te = new TileEntityExcavator();
-		te.formed=true;
-		te.pos=4;
-		te.facing=3;
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5,-.5,2.5);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(exc, false);
 		ClientUtils.tes().setTranslation(0,0,0);
 		ClientUtils.tes().draw();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockExcavatorDemo.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockExcavatorDemo.java
@@ -17,9 +17,16 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class MultiblockExcavatorDemo implements IMultiblock
 {
 	public static MultiblockExcavatorDemo instance = new MultiblockExcavatorDemo();
-
+	private static final TileEntityBucketWheel wheel = new TileEntityBucketWheel();
+	private static final TileEntityExcavator exc = new TileEntityExcavator();
 	static ItemStack[][][] structure = new ItemStack[7][8][3];
 	static{
+		exc.formed=true;
+		exc.pos=4;
+		exc.facing=3;
+		wheel.formed=true;
+		wheel.pos=24;
+		wheel.facing=4;
 		for(int l=0;l<6;l++)
 			for(int w=0;w<3;w++)
 				for(int h=0;h<3;h++)
@@ -89,22 +96,14 @@ public class MultiblockExcavatorDemo implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityExcavator te = new TileEntityExcavator();
-		te.formed=true;
-		te.pos=4;
-		te.facing=3;
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5,-.5,3.5);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(exc, false);
 		ClientUtils.tes().setTranslation(0,0,0);
 		ClientUtils.tes().draw();
 
-		TileEntityBucketWheel te2 = new TileEntityBucketWheel();
-		te2.formed=true;
-		te2.pos=24;
-		te2.facing=4;
-		TileEntityRendererDispatcher.instance.renderTileEntityAt(te2, -.5D, -.5D, -.5D, 0.0F);
+		TileEntityRendererDispatcher.instance.renderTileEntityAt(wheel, -.5D, -.5D, -.5D, 0.0F);
 	}
 	@Override
 	public float getManualScale()

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockMetalPress.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockMetalPress.java
@@ -25,6 +25,7 @@ public class MultiblockMetalPress implements IMultiblock
 {
 	public static MultiblockMetalPress instance = new MultiblockMetalPress();
 	static ItemStack[][][] structure = new ItemStack[3][3][1];
+	private static final TileEntityMetalPress press = new TileEntityMetalPress();
 	static{
 		for(int h=0;h<3;h++)
 			for(int l=0;l<3;l++)
@@ -65,11 +66,10 @@ public class MultiblockMetalPress implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityMetalPress te = new TileEntityMetalPress();
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5f,-.5f,-.5f);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(press, false);
 		ClientUtils.tes().draw();
 		ClientUtils.tes().setTranslation(0,0,0);
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockRefinery.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockRefinery.java
@@ -18,7 +18,11 @@ public class MultiblockRefinery implements IMultiblock
 {
 	public static MultiblockRefinery instance = new MultiblockRefinery();
 	static ItemStack[][][] structure = new ItemStack[3][5][3];
+	private static final TileEntityRefinery ref = new TileEntityRefinery();
 	static{
+		ref.formed=true;
+		ref.pos=17;
+		ref.facing=4;
 		for(int w=0;w<5;w++)
 			for(int l=0;l<3;l++)
 				for(int h=0;h<3;h++)
@@ -63,14 +67,10 @@ public class MultiblockRefinery implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntityRefinery te = new TileEntityRefinery();
-		te.formed=true;
-		te.pos=17;
-		te.facing=4;
 		ClientUtils.bindAtlas(0);
 		ClientUtils.tes().startDrawingQuads();
 		ClientUtils.tes().setTranslation(-.5,-1.5,-.5);
-		ClientUtils.handleStaticTileRenderer(te, false);
+		ClientUtils.handleStaticTileRenderer(ref, false);
 		ClientUtils.tes().setTranslation(0,0,0);
 		ClientUtils.tes().draw();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockSheetmetalTank.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockSheetmetalTank.java
@@ -18,9 +18,11 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class MultiblockSheetmetalTank implements IMultiblock
 {
 	public static MultiblockSheetmetalTank instance = new MultiblockSheetmetalTank();
-
+	private static final TileEntitySheetmetalTank tank = new TileEntitySheetmetalTank();
 	static ItemStack[][][] structure = new ItemStack[5][3][3];
 	static{
+		tank.formed=true;
+		tank.pos=4;
 		for(int h=0;h<5;h++)
 			for(int l=0;l<3;l++)
 				for(int w=0;w<3;w++)
@@ -62,10 +64,7 @@ public class MultiblockSheetmetalTank implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntitySheetmetalTank te = new TileEntitySheetmetalTank();
-		te.formed=true;
-		te.pos=4;
-		TileEntityRendererDispatcher.instance.renderTileEntityAt(te, -.5D, -2.5D, -.5D, 0.0F);
+		TileEntityRendererDispatcher.instance.renderTileEntityAt(tank, -.5D, -2.5D, -.5D, 0.0F);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockSilo.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/MultiblockSilo.java
@@ -19,9 +19,12 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class MultiblockSilo implements IMultiblock
 {
 	public static MultiblockSilo instance = new MultiblockSilo();
+	private static final TileEntitySilo silo = new TileEntitySilo();
 
 	static ItemStack[][][] structure = new ItemStack[7][3][3];
 	static{
+		silo.formed=true;
+		silo.pos=4;
 		for(int h=0;h<7;h++)
 			for(int l=0;l<3;l++)
 				for(int w=0;w<3;w++)
@@ -63,10 +66,7 @@ public class MultiblockSilo implements IMultiblock
 	@SideOnly(Side.CLIENT)
 	public void renderFormedStructure()
 	{
-		TileEntitySilo te = new TileEntitySilo();
-		te.formed=true;
-		te.pos=4;
-		TileEntityRendererDispatcher.instance.renderTileEntityAt(te, -.5D, -3.5D, -.5D, 0.0F);
+		TileEntityRendererDispatcher.instance.renderTileEntityAt(silo, -.5D, -3.5D, -.5D, 0.0F);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemIETool.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemIETool.java
@@ -157,14 +157,17 @@ public class ItemIETool extends ItemIEBase implements cofh.api.item.IToolHammer,
 						if(pos[0]==world.provider.dimensionId)
 						{
 							IImmersiveConnectable nodeHere = (IImmersiveConnectable)tileEntity;
-							IImmersiveConnectable nodeLink = (IImmersiveConnectable)world.getTileEntity(pos[1], pos[2], pos[3]);
-							if(nodeLink!=null)
+							TileEntity te2 = world.getTileEntity(pos[1], pos[2], pos[3]);
+							if (!(te2 instanceof IImmersiveConnectable))
 							{
-								Set<AbstractConnection> connections = ImmersiveNetHandler.INSTANCE.getIndirectEnergyConnections(Utils.toCC(nodeLink), world);
-								for(AbstractConnection con : connections)
-									if(Utils.toCC(nodeHere).equals(con.end))
-										player.addChatComponentMessage(new ChatComponentTranslation(Lib.CHAT_INFO+"averageLoss",Utils.formatDouble(con.getAverageLossRate()*100, "###.000")));
+								player.addChatMessage(new ChatComponentTranslation(Lib.CHAT_WARN+"invalidPoint"));
+								return true;
 							}
+							IImmersiveConnectable nodeLink = (IImmersiveConnectable)te2;
+							Set<AbstractConnection> connections = ImmersiveNetHandler.INSTANCE.getIndirectEnergyConnections(Utils.toCC(nodeLink), world);
+							for(AbstractConnection con : connections)
+								if(Utils.toCC(nodeHere).equals(con.end))
+									player.addChatComponentMessage(new ChatComponentTranslation(Lib.CHAT_INFO+"averageLoss",Utils.formatDouble(con.getAverageLossRate()*100, "###.000")));
 						}
 						ItemNBTHelper.remove(stack, "linkingPos");
 					}


### PR DESCRIPTION
Improved rendering memory usage by not creating a new TE every time an item that belongs to a block with a TE is rendered
fixed a crash when measuring loss between non-existing points
Why the hell would the villager buy emeralds with metadata 2, 7 or 18? This was very confusing when I was testing my villager fix :smile:
@cobra hasn't answered about the slot id's in OC compat yet (I asked about a week ago), if you want to release a new version, just tell me and I will make those changes myself.