### PR TITLE
Fix for #1281

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/energy/wires/TileEntityImmersiveConnectable.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/energy/wires/TileEntityImmersiveConnectable.java
@@ -269,12 +269,10 @@ public abstract class TileEntityImmersiveConnectable extends TileEntityIEBase im
 		};
 		for (Connection c : conns)
 		{
-			// generate subvertices
-			if (c.end.compareTo(pos) >= 0)
-				continue;
 			IImmersiveConnectable end = ApiUtils.toIIC(c.end, worldObj, false);
 			if (end==null)
 				continue;
+			// generate subvertices
 			c.getSubVertices(worldObj);
 			ret.add(c);
 		}

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientUtils.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientUtils.java
@@ -1264,9 +1264,11 @@ public class ClientUtils
 		return quat;
 	}
 
-	public static List<BakedQuad> convertConnectionFromBlockstate(IExtendedBlockState s, TextureAtlasSprite t)
+	public static List<BakedQuad>[] convertConnectionFromBlockstate(IExtendedBlockState s, TextureAtlasSprite t)
 	{
-		List<BakedQuad> ret = new ArrayList<>();
+		List<BakedQuad>[] ret = new List[2];
+		ret[0] = new ArrayList<>();
+		ret[1] = new ArrayList<>();
 		Set<Connection> conns = s.getValue(IEProperties.CONNECTIONS);
 		if (conns == null)
 			return ret;
@@ -1283,12 +1285,18 @@ public class ClientUtils
 			int color = conn.cableType.getColour(conn);
 			Vector3f start = new Vector3f(conn.start.getX(), conn.start.getY(), conn.start.getZ());
 			float radius = (float) (conn.cableType.getRenderDiameter() / 2);
-			for (int i = 1; i < f.length; i++)
+			int max = f.length/2+2;
+			if (f.length%2==1&&conn.start.compareTo(conn.end)>0) {
+				max++;
+			}
+			for (int i = 1; i < max; i++)
 			{
+				boolean fading = i==max-1;
+				List<BakedQuad> currList = ret[fading?1:0];
 				int j = i - 1;
-				Vector3f here = new Vector3f((float) f[i].xCoord, (float) f[i].yCoord, (float) f[i].zCoord);
+				Vector3f here = new Vector3f((float) f[i].xCoord+(fading?.0001F:0), (float) f[i].yCoord+(fading?.0001F:0), (float) f[i].zCoord+(fading?.0001F:0));
 				Vector3f.sub(here, start, here);
-				Vector3f there = new Vector3f((float) f[j].xCoord, (float) f[j].yCoord, (float) f[j].zCoord);
+				Vector3f there = new Vector3f((float) f[j].xCoord+(fading?.0001F:0), (float) f[j].yCoord+(fading?.0001F:0), (float) f[j].zCoord+(fading?.0001F:0));
 				Vector3f.sub(there, start, there);
 				boolean vertical = here.x == there.x && here.z == there.z;
 				int[] data;
@@ -1303,19 +1311,19 @@ public class ClientUtils
 				data = new int[28];
 				dataInv = new int[28];
 				Vector3f.add(here, cross, tmp);
-				storeVertexData(data, 0, tmp, t, 0, 0, color);
-				storeVertexData(dataInv, 3, tmp, t, 0, 0, color);
+				storeVertexData(data, 0, tmp, t, 0, 0, color, 0);
+				storeVertexData(dataInv, 3, tmp, t, 0, 0, color, 0);
 				Vector3f.sub(here, cross, tmp);
-				storeVertexData(data, 1, tmp, t, 0, 16, color);
-				storeVertexData(dataInv, 2, tmp, t, 0, 16, color);
+				storeVertexData(data, 1, tmp, t, 0, 16, color, 0);
+				storeVertexData(dataInv, 2, tmp, t, 0, 16, color, 0);
 				Vector3f.sub(there, cross, tmp);
-				storeVertexData(data, 2, tmp, t, 16, 16, color);
-				storeVertexData(dataInv, 1, tmp, t, 16, 16, color);
+				storeVertexData(data, 2, tmp, t, 16, 16, color, 255);
+				storeVertexData(dataInv, 1, tmp, t, 16, 16, color, 255);
 				Vector3f.add(there, cross, tmp);
-				storeVertexData(data, 3, tmp, t, 16, 0, color);
-				storeVertexData(dataInv, 0, tmp, t, 16, 0, color);
-				ret.add(new BakedQuad(data, -1, EnumFacing.DOWN));
-				ret.add(new BakedQuad(dataInv, -1, EnumFacing.UP));
+				storeVertexData(data, 3, tmp, t, 16, 0, color, 255);
+				storeVertexData(dataInv, 0, tmp, t, 16, 0, color, 255);
+				currList.add(new BakedQuad(data, -1, EnumFacing.DOWN));
+				currList.add(new BakedQuad(dataInv, -1, EnumFacing.UP));
 
 				data = new int[28];
 				dataInv = new int[28];
@@ -1323,22 +1331,23 @@ public class ClientUtils
 				{
 					Vector3f.cross(cross, dir, cross);
 					cross.scale(radius / cross.length());
-				} else
+				}
+				else
 					cross.set(0, 0, radius);
 				Vector3f.add(here, cross, tmp);
-				storeVertexData(data, 0, tmp, t, 0, 0, color);
-				storeVertexData(dataInv, 3, tmp, t, 0, 0, color);
+				storeVertexData(data, 0, tmp, t, 0, 0, color, 0);
+				storeVertexData(dataInv, 3, tmp, t, 0, 0, color, 0);
 				Vector3f.sub(here, cross, tmp);
-				storeVertexData(data, 1, tmp, t, 0, 16, color);
-				storeVertexData(dataInv, 2, tmp, t, 0, 16, color);
+				storeVertexData(data, 1, tmp, t, 0, 16, color, 0);
+				storeVertexData(dataInv, 2, tmp, t, 0, 16, color, 0);
 				Vector3f.sub(there, cross, tmp);
-				storeVertexData(data, 2, tmp, t, 16, 16, color);
-				storeVertexData(dataInv, 1, tmp, t, 16, 16, color);
+				storeVertexData(data, 2, tmp, t, 16, 16, color, 255);
+				storeVertexData(dataInv, 1, tmp, t, 16, 16, color, 255);
 				Vector3f.add(there, cross, tmp);
-				storeVertexData(data, 3, tmp, t, 16, 0, color);
-				storeVertexData(dataInv, 0, tmp, t, 16, 0, color);
-				ret.add(new BakedQuad(data, -1, EnumFacing.WEST));
-				ret.add(new BakedQuad(dataInv, -1, EnumFacing.EAST));
+				storeVertexData(data, 3, tmp, t, 16, 0, color, 255);
+				storeVertexData(dataInv, 0, tmp, t, 16, 0, color, 255);
+				currList.add(new BakedQuad(data, -1, EnumFacing.WEST));
+				currList.add(new BakedQuad(dataInv, -1, EnumFacing.EAST));
 
 			}
 		}
@@ -1346,22 +1355,23 @@ public class ClientUtils
 	}
 
 	private static void storeVertexData(int[] faceData, int storeIndex, Vector3f position, TextureAtlasSprite t, int u,
-			int v, int color)
+			int v, int color, int alpha)
 	{
 		int i = storeIndex * 7;
 		faceData[i] = Float.floatToRawIntBits(position.x);
 		faceData[i + 1] = Float.floatToRawIntBits(position.y);
 		faceData[i + 2] = Float.floatToRawIntBits(position.z);
-		faceData[i + 3] = invertRgb(color);
+		faceData[i + 3] = invertRgb(color, alpha);
 		faceData[i + 4] = Float.floatToRawIntBits(t.getInterpolatedU(u));
 		faceData[i + 5] = Float.floatToRawIntBits(t.getInterpolatedV(v));
 	}
 
-	private static int invertRgb(int in)
+	private static int invertRgb(int in, int alpha)
 	{
 		int ret = in & (255 << 8);
 		ret += (in >> 16) & 255;
 		ret += (in & 255) << 16;
+		ret += alpha<<24;
 		return ret;
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/client/models/SmartLightingQuad.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/SmartLightingQuad.java
@@ -1,0 +1,110 @@
+package blusunrize.immersiveengineering.client.models;
+
+import java.lang.reflect.Field;
+
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.client.renderer.vertex.VertexFormatElement.EnumType;
+import net.minecraft.client.renderer.vertex.VertexFormatElement.EnumUsage;
+import net.minecraft.util.BlockPos;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.world.ChunkCache;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.model.IColoredBakedQuad;
+import net.minecraftforge.client.model.pipeline.BlockInfo;
+import net.minecraftforge.client.model.pipeline.IVertexConsumer;
+import net.minecraftforge.client.model.pipeline.LightUtil;
+import net.minecraftforge.client.model.pipeline.QuadGatheringTransformer;
+import net.minecraftforge.client.model.pipeline.VertexLighterFlat;
+
+public class SmartLightingQuad extends BakedQuad
+{
+	private static Field parent;
+	private static Field blockInfo;
+	static
+	{
+		try
+		{
+			blockInfo = VertexLighterFlat.class.getDeclaredField("blockInfo");
+			blockInfo.setAccessible(true);
+			parent = QuadGatheringTransformer.class.getDeclaredField("parent");
+			parent.setAccessible(true);
+		}
+		catch (Exception x)
+		{
+			x.printStackTrace();
+		}
+	}
+	BlockPos blockPos;
+	int[][] relativePos;
+	boolean ignoreLight;
+	public SmartLightingQuad(int[] vertexDataIn, int tintIndexIn, EnumFacing faceIn, BlockPos p, boolean noLight)
+	{
+		super(vertexDataIn, tintIndexIn, faceIn);
+		ignoreLight = noLight;
+		blockPos = p;
+		relativePos = new int[4][];
+		for (int i = 0;i<4;i++)
+			relativePos[i] = new int[]{(int)Math.floor(Float.intBitsToFloat(vertexDataIn[7*i])),
+					(int)Math.floor(Float.intBitsToFloat(vertexDataIn[7*i+1])),
+					(int)Math.floor(Float.intBitsToFloat(vertexDataIn[7*i+2]))
+		};
+	}
+	@Override
+	public void pipe(IVertexConsumer consumer)
+	{
+		IBlockAccess world = null;
+		BlockInfo info = null;
+		if (consumer instanceof VertexLighterFlat)
+		{
+			try
+			{
+				info = (BlockInfo) blockInfo.get(consumer);
+				world = info.getWorld();
+				if (world instanceof ChunkCache)
+					world = ((ChunkCache)world).worldObj;
+				consumer = (IVertexConsumer) parent.get(consumer);
+			}
+			catch (Throwable e)
+			{
+				e.printStackTrace();
+			}
+		}
+		consumer.setQuadOrientation(this.getFace());
+		if(this.hasTintIndex())
+			consumer.setQuadTint(this.getTintIndex());
+		if(this instanceof IColoredBakedQuad)
+			consumer.setQuadColored();
+		float[] data = new float[4];
+		VertexFormat format = consumer.getVertexFormat();
+		int count = format.getElementCount();
+		int[] eMap = LightUtil.mapFormats(format, DefaultVertexFormats.ITEM);
+		int itemCount = DefaultVertexFormats.ITEM.getElementCount();
+		eMap[eMap.length-1] = 2;
+		for(int v = 0; v < 4; v++)
+			for(int e = 0; e < count; e++)
+				if(eMap[e] != itemCount)
+				{
+					if (world!=null&&!(world instanceof ChunkCache)&&format.getElement(e).getUsage()==EnumUsage.UV&&format.getElement(e).getType()==EnumType.SHORT)//lightmap is UV with 2 shorts
+					{
+						BlockPos here = blockPos.add(relativePos[v][0], relativePos[v][1], relativePos[v][2]);
+						int brightness = world.getBlockState(here).getBlock().getMixedBrightnessForBlock(world, here);
+						if (ignoreLight) {
+							data[0] = ((float)(15*0x20))/0xFFFF;
+							data[1] = ((float)(15*0x20))/0xFFFF;
+						}
+						else
+						{
+							data[0] = ((float)((brightness >> 0x04) & 0xF) * 0x20) / 0xFFFF;
+							data[1] = ((float)((brightness >> 0x14) & 0xF) * 0x20) / 0xFFFF;
+						}
+					}
+					else
+						LightUtil.unpack(this.getVertexData(), data, DefaultVertexFormats.ITEM, v, eMap[e]);
+					consumer.put(e, data);
+				}
+				else
+					consumer.put(e, 0);
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/client/models/smart/ConnModelReal.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/smart/ConnModelReal.java
@@ -18,6 +18,8 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.resources.model.IBakedModel;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumWorldBlockLayer;
+import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.client.model.Attributes;
 import net.minecraftforge.client.model.IFlexibleBakedModel;
 import net.minecraftforge.client.model.ISmartBlockModel;
@@ -104,21 +106,21 @@ public class ConnModelReal implements IFlexibleBakedModel, ISmartBlockModel
 	public class AssembledBakedModel implements IBakedModel
 	{
 		IBakedModel basic;
-		List<BakedQuad> list;
+		List<BakedQuad>[] lists;
 
 		public AssembledBakedModel(IBakedModel b)
 		{
 			basic = b;
-			list = b.getGeneralQuads();
+			lists = new List[]{b.getGeneralQuads(), ImmutableList.of()};
 		}
 
 		public AssembledBakedModel(IExtendedBlockState iExtendedBlockState, TextureAtlasSprite tex, IBakedModel b)
 		{
-			list = ClientUtils.convertConnectionFromBlockstate(iExtendedBlockState, tex);
+			lists = ClientUtils.convertConnectionFromBlockstate(iExtendedBlockState, tex);
 			basic = b;
 			if(basic instanceof ISmartBlockModel)
 				basic = ((ISmartBlockModel)basic).handleBlockState(iExtendedBlockState);
-			list.addAll(basic.getGeneralQuads());
+			lists[0].addAll(basic.getGeneralQuads());
 		}
 
 		@Override
@@ -130,7 +132,10 @@ public class ConnModelReal implements IFlexibleBakedModel, ISmartBlockModel
 		@Override
 		public List<BakedQuad> getGeneralQuads()
 		{
-			List<BakedQuad> quadList = Collections.synchronizedList(Lists.newArrayList(list));
+			EnumWorldBlockLayer layer = MinecraftForgeClient.getRenderLayer();
+			if (layer != EnumWorldBlockLayer.SOLID&&layer!=EnumWorldBlockLayer.TRANSLUCENT)
+				return ImmutableList.of();
+			List<BakedQuad> quadList = Collections.synchronizedList(Lists.newArrayList(lists[layer==EnumWorldBlockLayer.SOLID?0:1]));
 			return quadList;
 		}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/BlockClothDevice.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/BlockClothDevice.java
@@ -13,6 +13,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
+import net.minecraft.util.EnumWorldBlockLayer;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.property.ExtendedBlockState;
@@ -28,6 +29,7 @@ public class BlockClothDevice extends BlockIETileProvider<BlockTypes_ClothDevice
 		super("clothDevice", Material.cloth, PropertyEnum.create("type", BlockTypes_ClothDevice.class), ItemBlockClothDevice.class, IEProperties.FACING_ALL);
 		setHardness(0.8F);
 		lightOpacity = 0;
+		setBlockLayer(EnumWorldBlockLayer.SOLID, EnumWorldBlockLayer.TRANSLUCENT);
 	}
 	
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/TileEntityBalloon.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/TileEntityBalloon.java
@@ -2,13 +2,14 @@ package blusunrize.immersiveengineering.common.blocks.cloth;
 
 import blusunrize.immersiveengineering.api.energy.wires.IImmersiveConnectable;
 import blusunrize.immersiveengineering.api.energy.wires.ImmersiveNetHandler.Connection;
+import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.ILightValue;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityConnectorStructural;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Vec3;
 
-public class TileEntityBalloon extends TileEntityConnectorStructural
+public class TileEntityBalloon extends TileEntityConnectorStructural implements ILightValue
 {
 	public int style = 0;
 	public byte colour0 = 15;
@@ -89,5 +90,11 @@ public class TileEntityBalloon extends TileEntityConnectorStructural
 			return new Vec3(.5,.09375,zDif>0?.78125:.21875);
 		else
 			return new Vec3(xDif>0?.78125:.21875,.09375,.5);
+	}
+
+	@Override
+	public int getLightValue()
+	{
+		return 13;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumWorldBlockLayer;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.property.ExtendedBlockState;
@@ -31,6 +32,7 @@ public class BlockConnector extends BlockIETileProvider<BlockTypes_Connector>
 		setHardness(3.0F);
 		setResistance(15.0F);
 		lightOpacity = 0;
+		setBlockLayer(EnumWorldBlockLayer.SOLID, EnumWorldBlockLayer.TRANSLUCENT);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevice1.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockMetalDevice1.java
@@ -35,6 +35,8 @@ public class BlockMetalDevice1 extends BlockIETileProvider<BlockTypes_MetalDevic
 		this.setMetaBlockLayer(BlockTypes_MetalDevice1.CHARGING_STATION.getMeta(), EnumWorldBlockLayer.SOLID,EnumWorldBlockLayer.TRANSLUCENT);
 		this.setMetaBlockLayer(BlockTypes_MetalDevice1.SAMPLE_DRILL.getMeta(), EnumWorldBlockLayer.CUTOUT);
 		this.setMetaBlockLayer(BlockTypes_MetalDevice1.FLOODLIGHT.getMeta(), EnumWorldBlockLayer.SOLID,EnumWorldBlockLayer.TRANSLUCENT);
+		this.setMetaBlockLayer(BlockTypes_MetalDevice1.ELECTRIC_LANTERN.getMeta(), EnumWorldBlockLayer.SOLID,EnumWorldBlockLayer.TRANSLUCENT);
+		lightOpacity = 0;
 	}
 
 	@Override

--- a/src/main/resources/META-INF/ImmersiveEngineering_at.cfg
+++ b/src/main/resources/META-INF/ImmersiveEngineering_at.cfg
@@ -15,3 +15,4 @@ public net.minecraft.client.multiplayer.PlayerControllerMP field_78770_f # curBl
 public net.minecraft.client.renderer.RenderGlobal field_147593_P # mapSoundPositions
 protected net.minecraft.world.Explosion * # all Explosion fields
 public net.minecraft.client.particle.EntityReddustFX field_70570_a # reddustParticleScale
+public net.minecraft.world.ChunkCache field_72815_e #worldObj


### PR DESCRIPTION
Well, not really a fix. But something to reduce the impact. Each connector now renders half of each connection and adds one fading segment to the end of its half of the wire, as seen in the screenshot below. ![Screenshot](https://cloud.githubusercontent.com/assets/10406104/17862140/3a463272-6894-11e6-9d4a-da97aa6ffea2.png)