### PR TITLE
#1290 for 1.10

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/energy/wires/TileEntityImmersiveConnectable.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/energy/wires/TileEntityImmersiveConnectable.java
@@ -286,12 +286,10 @@ public abstract class TileEntityImmersiveConnectable extends TileEntityIEBase im
 		};
 		for (Connection c : conns)
 		{
-			// generate subvertices
-			if (c.end.compareTo(pos) >= 0)
-				continue;
 			IImmersiveConnectable end = ApiUtils.toIIC(c.end, worldObj, false);
 			if (end==null)
 				continue;
+			// generate subvertices
 			c.getSubVertices(worldObj);
 			ret.add(c);
 		}

--- a/src/main/java/blusunrize/immersiveengineering/client/models/SmartLightingQuad.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/SmartLightingQuad.java
@@ -1,0 +1,108 @@
+package blusunrize.immersiveengineering.client.models;
+
+import java.lang.reflect.Field;
+
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraft.client.renderer.vertex.VertexFormatElement.EnumType;
+import net.minecraft.client.renderer.vertex.VertexFormatElement.EnumUsage;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ChunkCache;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.client.model.pipeline.BlockInfo;
+import net.minecraftforge.client.model.pipeline.IVertexConsumer;
+import net.minecraftforge.client.model.pipeline.LightUtil;
+import net.minecraftforge.client.model.pipeline.QuadGatheringTransformer;
+import net.minecraftforge.client.model.pipeline.VertexLighterFlat;
+
+public class SmartLightingQuad extends BakedQuad
+{
+	private static Field parent;
+	private static Field blockInfo;
+	static
+	{
+		try
+		{
+			blockInfo = VertexLighterFlat.class.getDeclaredField("blockInfo");
+			blockInfo.setAccessible(true);
+			parent = QuadGatheringTransformer.class.getDeclaredField("parent");
+			parent.setAccessible(true);
+		}
+		catch (Exception x)
+		{
+			x.printStackTrace();
+		}
+	}
+	BlockPos blockPos;
+	int[][] relativePos;
+	boolean ignoreLight;
+	public SmartLightingQuad(int[] vertexDataIn, int tintIndexIn, EnumFacing faceIn, TextureAtlasSprite spriteIn, VertexFormat format, BlockPos p, boolean noLight)
+	{
+		super(vertexDataIn, tintIndexIn, faceIn, spriteIn, false, format);
+		ignoreLight = noLight;
+		blockPos = p;
+		relativePos = new int[4][];
+		for (int i = 0;i<4;i++)
+			relativePos[i] = new int[]{(int)Math.floor(Float.intBitsToFloat(vertexDataIn[7*i])),
+					(int)Math.floor(Float.intBitsToFloat(vertexDataIn[7*i+1])),
+					(int)Math.floor(Float.intBitsToFloat(vertexDataIn[7*i+2]))
+		};
+	}
+	@Override
+	public void pipe(IVertexConsumer consumer)
+	{
+		IBlockAccess world = null;
+		BlockInfo info = null;
+		if (consumer instanceof VertexLighterFlat)
+		{
+			try
+			{
+				info = (BlockInfo) blockInfo.get(consumer);
+				world = info.getWorld();
+				if (world instanceof ChunkCache)
+					world = ((ChunkCache)world).worldObj;
+				consumer = (IVertexConsumer) parent.get(consumer);
+			}
+			catch (Throwable e)
+			{
+				e.printStackTrace();
+			}
+		}
+		consumer.setQuadOrientation(this.getFace());
+		if(this.hasTintIndex())
+			consumer.setQuadTint(this.getTintIndex());
+		float[] data = new float[4];
+		VertexFormat format = consumer.getVertexFormat();
+		int count = format.getElementCount();
+		int[] eMap = LightUtil.mapFormats(format, DefaultVertexFormats.ITEM);
+		int itemCount = DefaultVertexFormats.ITEM.getElementCount();
+		eMap[eMap.length-1] = 2;
+		for(int v = 0; v < 4; v++)
+			for(int e = 0; e < count; e++)
+				if(eMap[e] != itemCount)
+				{
+					if (world!=null&&!(world instanceof ChunkCache)&&format.getElement(e).getUsage()==EnumUsage.UV&&format.getElement(e).getType()==EnumType.SHORT)//lightmap is UV with 2 shorts
+					{
+						BlockPos here = blockPos.add(relativePos[v][0], relativePos[v][1], relativePos[v][2]);
+						int brightness = world.getCombinedLight(here, 0);
+						if (ignoreLight) {
+							data[0] = ((float)(15*0x20))/0xFFFF;
+							data[1] = ((float)(15*0x20))/0xFFFF;
+						}
+						else
+						{
+							data[0] = ((float)((brightness >> 0x04) & 0xF) * 0x20) / 0xFFFF;
+							data[1] = ((float)((brightness >> 0x14) & 0xF) * 0x20) / 0xFFFF;
+						}
+					}
+					else
+						LightUtil.unpack(this.getVertexData(), data, DefaultVertexFormats.ITEM, v, eMap[e]);
+					consumer.put(e, data);
+				}
+				else
+					consumer.put(e, 0);
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/client/models/smart/ConnLoader.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/smart/ConnLoader.java
@@ -166,7 +166,7 @@ public class ConnLoader implements ICustomModelLoader
 					OBJModel obj = (OBJModel) model;
 					model = obj.process(ImmutableMap.of("flip-v", "true"));
 				}
-				return new ConnModelReal(model.bake(state, Attributes.DEFAULT_BAKED_FORMAT, bakedTextureGetter));
+				return new ConnModelReal(model.bake(state, format, bakedTextureGetter));
 			}
 			catch (Exception e)
 			{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/BlockClothDevice.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/BlockClothDevice.java
@@ -10,6 +10,7 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -28,6 +29,7 @@ public class BlockClothDevice extends BlockIETileProvider<BlockTypes_ClothDevice
 		super("clothDevice", Material.CLOTH, PropertyEnum.create("type", BlockTypes_ClothDevice.class), ItemBlockClothDevice.class, IEProperties.FACING_ALL);
 		setHardness(0.8F);
 		setMetaLightOpacity(1, 0);
+		setMetaBlockLayer(1, BlockRenderLayer.SOLID, BlockRenderLayer.TRANSLUCENT);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
@@ -13,6 +13,7 @@ import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
@@ -31,6 +32,7 @@ public class BlockConnector extends BlockIETileProvider<BlockTypes_Connector>
 		setHardness(3.0F);
 		setResistance(15.0F);
 		lightOpacity = 0;
+		setBlockLayer(BlockRenderLayer.SOLID, BlockRenderLayer.TRANSLUCENT);
 	}
 
 	@Override

--- a/src/main/resources/META-INF/ImmersiveEngineering_at.cfg
+++ b/src/main/resources/META-INF/ImmersiveEngineering_at.cfg
@@ -17,3 +17,4 @@ public net.minecraft.client.particle.ParticleRedstone field_70570_a # reddustPar
 public net.minecraft.client.particle.Particle field_187129_i # motionX
 public net.minecraft.client.particle.Particle field_187130_j # motionY
 public net.minecraft.client.particle.Particle field_187131_k # motionZ
+public net.minecraft.world.ChunkCache field_72815_e #worldObj


### PR DESCRIPTION
- wires split rendering between both connectors. The split happens at a chunk border. (The transparent bit at the end doesn't look as good as it does in 1.8, I blame the changes to the vanilla rendering code from 1.8 to 1.10 for that)
- fixed wire lighting, closes #1280 (this needs to be done manually since I forgot to add it to the commit note)
- fixed inverted textures on half of a wire's faces (the black and gray bits did not line up properly)