### PR TITLE
Added configurable power draw/max storage for the lantern and floodlight

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/Config.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/Config.java
@@ -121,7 +121,11 @@ public class Config
 		
 		//Lights
 		setBoolean("lantern_spawnPrevent", config.get("machines", "Powered Lantern: Spawn Prevention", true, "Set this to false to disable the mob-spawn prevention of the Powered Lantern").getBoolean());
+		setInt("lantern_energyDraw", config.get("machines", "Powered Lantern: Energy Draw", 1, "How much Flux the powered lantern draws per tick").getInt());
+		setInt("lantern_maximumStorage", config.get("machines", "Powered Lantern: Maximum Storage", 10, "How much Flux the powered lantern can hold (should be greater than the power draw)").getInt());
 		setBoolean("floodlight_spawnPrevent", config.get("machines", "Floodlight: Spawn Prevention", true, "Set this to false to disable the mob-spawn prevention of the Floodlight").getBoolean());
+		setInt("floodlight_energyDraw", config.get("machines", "Floodlight: Energy Draw", 5, "How much Flux the floodlight draws per tick").getInt());
+		setInt("floodlight_maximumStorage", config.get("machines", "Floodlight: Maximum Storage", 80, "How much Flux the floodlight can hold (must be at least 10x the power draw)").getInt());
 
 
 		//Multiblock Recipes

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityElectricLantern.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityElectricLantern.java
@@ -21,8 +21,10 @@ import net.minecraft.world.EnumSkyBlock;
 public class TileEntityElectricLantern extends TileEntityImmersiveConnectable implements ISpawnInterdiction, ITickable, IBlockBounds, IActiveState, ILightValue
 {
 	public int energyStorage = 0;
+	private int energyDraw = Config.getInt("lantern_energyDraw");
+	private int maximumStorage = Config.getInt("lantern_maximumStorage");
 	public boolean active = false;
-	private boolean interdictionList=false; 
+	private boolean interdictionList=false;
 
 	@Override
 	public void update()
@@ -38,9 +40,9 @@ public class TileEntityElectricLantern extends TileEntityImmersiveConnectable im
 			interdictionList=true;
 		}
 		boolean b = active;
-		if(energyStorage>0)
+		if(energyStorage >= energyDraw)
 		{
-			energyStorage--;
+			energyStorage -= energyDraw;
 			if(!active)
 				active=true;
 		}
@@ -105,15 +107,15 @@ public class TileEntityElectricLantern extends TileEntityImmersiveConnectable im
 	@Override
 	public int outputEnergy(int amount, boolean simulate, int energyType)
 	{
-		if(amount>0 && energyStorage<10)
+		if(amount > 0 && energyStorage < maximumStorage)
 		{
 			if(!simulate)
 			{
-				int rec = Math.min(10-energyStorage, 2);
+				int rec = Math.min(maximumStorage - energyStorage, energyDraw);
 				energyStorage+=rec;
 				return rec;
 			}
-			return Math.min(10-energyStorage, 2);
+			return Math.min(maximumStorage - energyStorage, energyDraw);
 		}
 		return 0;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
@@ -7,6 +7,7 @@ import blusunrize.immersiveengineering.api.energy.wires.ImmersiveNetHandler.Conn
 import blusunrize.immersiveengineering.api.energy.wires.TileEntityImmersiveConnectable;
 import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.client.models.IOBJModelCallback;
+import blusunrize.immersiveengineering.common.Config;
 import blusunrize.immersiveengineering.common.EventHandler;
 import blusunrize.immersiveengineering.common.IEContent;
 import blusunrize.immersiveengineering.common.blocks.BlockFakeLight.TileEntityFakeLight;
@@ -44,6 +45,8 @@ import java.util.List;
 public class TileEntityFloodlight extends TileEntityImmersiveConnectable implements ITickable, IAdvancedDirectionalTile, IHammerInteraction, ISpawnInterdiction, IBlockBounds, IActiveState, ILightValue, IOBJModelCallback<IBlockState>
 {
 	public int energyStorage = 0;
+	private int energyDraw = Config.getInt("floodlight_energyDraw");
+	private int maximumStorage = Config.getInt("floodlight_maximumStorage");
 	public boolean active = false;
 	public EnumFacing facing = EnumFacing.NORTH;
 	public EnumFacing side = EnumFacing.UP;
@@ -80,9 +83,9 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable impleme
 		}
 
 		enabled = (controllingComputers > 0 && computerOn) || worldObj.isBlockIndirectlyGettingPowered(getPos()) > 0;
-		if(energyStorage >= (!active ? 50 : 5) && enabled && switchCooldown <= 0)
+		if(energyStorage >= (!active ? energyDraw*10 : energyDraw) && enabled && switchCooldown <= 0)
 		{
-			energyStorage-=5;
+			energyStorage -= energyDraw;
 			if(!active)
 				active=true;
 		}
@@ -331,15 +334,15 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable impleme
 	@Override
 	public int outputEnergy(int amount, boolean simulate, int energyType)
 	{
-		if(amount>0 && energyStorage<80)
+		if(amount > 0 && energyStorage < maximumStorage)
 		{
 			if(!simulate)
 			{
-				int rec = Math.min(80-energyStorage, amount);
+				int rec = Math.min(maximumStorage - energyStorage, amount);
 				energyStorage+=rec;
 				return rec;
 			}
-			return Math.min(80-energyStorage, amount);
+			return Math.min(maximumStorage - energyStorage, amount);
 		}
 		return 0;
 	}


### PR DESCRIPTION
I thought the powered lantern and especially the floodlight are overpowered because of their extremely low energy draw, so I made them configurable. Also, a lot of other energy draws are configurable, so it seems logical this should be as well.