### PR TITLE
Fix for #1421 and safer fix for #1449

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
@@ -53,6 +53,7 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -157,7 +158,7 @@ public class EventHandler
 						{
 							if(f_lootEntries==null)
 							{
-								f_lootEntries = LootPool.class.getDeclaredField("lootEntries");
+								f_lootEntries = LootPool.class.getDeclaredField(ObfuscationReflectionHelper.remapFieldNames(LootPool.class.getName(), "lootEntries")[0]);
 								f_lootEntries.setAccessible(true);
 							}
 							if(f_lootEntries!=null)

--- a/src/main/resources/assets/immersiveengineering/lang/en_US.lang
+++ b/src/main/resources/assets/immersiveengineering/lang/en_US.lang
@@ -1143,8 +1143,8 @@ ie.manual.entry.computer.sampleDrill1=§lgetVeinLocalizedName()§r: returns the 
 
 ie.manual.entry.computer.crusher.name=Crusher ☎
 ie.manual.entry.computer.crusher.subtext=Keep your hands out!
-ie.manual.entry.computer.crusher0=§lgetQueueLength()§r: The amount of stacks that are waiting to be processed<br>§lsetEnabled(boolean active)§r: allows or disallows the crusher to operate, as if a redstone signal was applied to the control panel<br>§lisActive()§r: returns whether the crusher is currently crushing items<br>§lgetInputStack(int pos)§r: returns the stack in the specified position in the queue (the queue starts at 1). The returned table contains information on the progress and
-ie.manual.entry.computer.crusher1=maximum progress of the requested item in the key "progress" and "maxProgress".<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy stored in this crusher<br>§lgetEnergyStored()§r: returns the amount of energy that is stored in this crusher
+ie.manual.entry.computer.crusher0=§lsetEnabled(boolean active)§r: allows or disallows the crusher to operate, as if a redstone signal was applied to the control panel<br>§lisActive()§r: returns whether the crusher is currently crushing items<br>§lgetInputQueue()§r: returns the input queue of the crusher as a table. The table contains the places in the input queue as keys (starting at 1). Each place in the queue is saved as a table with the following keys:<br>"progress": the current progress
+ie.manual.entry.computer.crusher1="maxProgress": the progress the crusher has to reach to finish the recipe<br>"input": the input item stack<br>"output": the main output stack.<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy stored in this crusher<br>§lgetEnergyStored()§r: returns the amount of energy that is stored in this crusher
 
 ie.manual.entry.computer.dieselgen.name=Diesel Generator ☎
 ie.manual.entry.computer.dieselgen.subtext=Better than volume: More volume.


### PR DESCRIPTION
#1421: Removed the old `getInputStack` method and replaced it with a `getInputQueue` method. Return values include the primary output of the recipe now.
#1449: see https://github.com/BluSunrize/ImmersiveEngineering/issues/1449#issuecomment-247043945 