### PR TITLE
Stuff related to breaker switches

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/energy/wires/ImmersiveNetHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/energy/wires/ImmersiveNetHandler.java
@@ -501,7 +501,7 @@ public class ImmersiveNetHandler
 		@Override
 		public int compareTo(Connection o)
 		{
-			if(equals(o))
+			if(this==o)
 				return 0;
 			int distComp = Integer.compare(length, o.length);
 			int cableComp = -1*Integer.compare(cableType.getTransferRate(), o.cableType.getTransferRate());
@@ -522,6 +522,13 @@ public class ImmersiveNetHandler
 								if (end.getZ()!=o.end.getZ())
 									return end.getZ()>o.end.getZ()?1:-1;
 									return 0;
+		}
+		@Override
+		public boolean equals(Object obj)
+		{
+			if (!(obj instanceof Connection))
+				return false;
+			return compareTo((Connection)obj)==0;
 		}
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientEventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientEventHandler.java
@@ -171,7 +171,7 @@ public class ClientEventHandler implements IResourceManagerReloadListener
 	@SubscribeEvent
 	public void onPlaySound(PlaySoundEvent event)
 	{
-		if(!ItemEarmuffs.affectedSoundCategories.contains(event.getSound().getCategory()))
+		if(!ItemEarmuffs.affectedSoundCategories.contains(event.getSound().getCategory().getName()))
 			return;
 		if(ClientUtils.mc().thePlayer!=null && ClientUtils.mc().thePlayer.getItemStackFromSlot(EntityEquipmentSlot.HEAD)!=null)
 		{

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
@@ -58,6 +58,7 @@ import blusunrize.lib.manual.ManualInstance.ManualEntry;
 import blusunrize.lib.manual.ManualPages;
 import blusunrize.lib.manual.ManualPages.PositionedItemStack;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.block.Block;
@@ -115,6 +116,10 @@ import net.minecraftforge.fml.common.registry.GameData;
 import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nonnull;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
 import java.io.IOException;
 import java.net.URL;
 import java.text.DecimalFormat;
@@ -1409,13 +1414,15 @@ public class ClientProxy extends CommonProxy
 	public void removeStateFromSmartModelCache(IExtendedBlockState state)
 	{
 		for (BlockRenderLayer r:BlockRenderLayer.values())
-			IESmartObjModel.modelCache.remove(new ExtBlockstateAdapter(state, r));
+			IESmartObjModel.modelCache.remove(new ExtBlockstateAdapter(state, r, ImmutableSet.of()));
+		IESmartObjModel.modelCache.remove(new ExtBlockstateAdapter(state, null, ImmutableSet.of()));
 	}
 	@Override
 	public void removeStateFromConnectionModelCache(IExtendedBlockState state)
 	{
 		for (BlockRenderLayer r:BlockRenderLayer.values())
-			ConnModelReal.cache.remove(new ExtBlockstateAdapter(state, r));
+			ConnModelReal.cache.remove(new ExtBlockstateAdapter(state, r, ImmutableSet.of()));
+		ConnModelReal.cache.remove(new ExtBlockstateAdapter(state, null, ImmutableSet.of()));
 	}
 	@Override
 	public void clearConnectionModelCache()

--- a/src/main/java/blusunrize/immersiveengineering/client/models/IESmartObjModel.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/IESmartObjModel.java
@@ -156,7 +156,7 @@ public class IESmartObjModel extends OBJBakedModel
 		if(blockState instanceof IExtendedBlockState)
 		{
 			IExtendedBlockState exState = (IExtendedBlockState) blockState;
-			ExtBlockstateAdapter adapter = new ExtBlockstateAdapter(exState, MinecraftForgeClient.getRenderLayer());
+			ExtBlockstateAdapter adapter = new ExtBlockstateAdapter(exState, MinecraftForgeClient.getRenderLayer(), ExtBlockstateAdapter.CONNS_OBJ_CALLBACK);
 			if(!modelCache.containsKey(adapter))
 			{
 				IESmartObjModel model = null;

--- a/src/main/java/blusunrize/immersiveengineering/common/CommonProxy.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/CommonProxy.java
@@ -2,6 +2,7 @@ package blusunrize.immersiveengineering.common;
 
 import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.Lib;
+import blusunrize.immersiveengineering.client.models.smart.ConnModelReal.ExtBlockstateAdapter;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IGuiTile;
 import blusunrize.immersiveengineering.common.blocks.metal.*;
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityBlastFurnace;
@@ -18,6 +19,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -26,6 +28,9 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.IGuiHandler;
 
 import javax.annotation.Nonnull;
+
+import org.apache.commons.lang3.tuple.Pair;
+
 import java.util.UUID;
 
 public class CommonProxy implements IGuiHandler

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityBreakerSwitch.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityBreakerSwitch.java
@@ -17,7 +17,6 @@ import blusunrize.immersiveengineering.api.energy.wires.WireType;
 import blusunrize.immersiveengineering.client.models.IOBJModelCallback;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.*;
 import blusunrize.immersiveengineering.common.util.ChatUtils;
-import blusunrize.immersiveengineering.common.util.IELogger;
 import blusunrize.immersiveengineering.common.util.chickenbones.Matrix4;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms.TransformType;
@@ -317,7 +316,6 @@ public class TileEntityBreakerSwitch extends TileEntityImmersiveConnectable impl
 			if ((side==EnumFacing.UP&&f.getAxis()==Axis.Z)||side==EnumFacing.DOWN)
 				f = f.getOpposite();
 		}
-		IELogger.info(f+"__"+side);
 		rotation = f.getHorizontalIndex();
 	}
 	protected void onConnectionChange()

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityBreakerSwitch.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityBreakerSwitch.java
@@ -180,6 +180,8 @@ public class TileEntityBreakerSwitch extends TileEntityImmersiveConnectable impl
 		{
 			inverted = !inverted;
 			ChatUtils.sendServerNoSpamMessages(player, new TextComponentTranslation(Lib.CHAT_INFO+"rsSignal."+(inverted?"invertedOn":"invertedOff")));
+			if (this instanceof TileEntityBreakerSwitch && wires>1)
+				ImmersiveNetHandler.INSTANCE.resetCachedIndirectConnections();
 			notifyNeighbours();
 		}
 		else
@@ -195,7 +197,8 @@ public class TileEntityBreakerSwitch extends TileEntityImmersiveConnectable impl
 		if (!Utils.isHammer(heldItem))
 		{
 			active = !active;
-			ImmersiveNetHandler.INSTANCE.resetCachedIndirectConnections();
+			if (wires>1)
+				ImmersiveNetHandler.INSTANCE.resetCachedIndirectConnections();
 			worldObj.addBlockEvent(getPos(), getBlockType(), active?1:0, 0);
 			notifyNeighbours();
 		}
@@ -226,7 +229,7 @@ public class TileEntityBreakerSwitch extends TileEntityImmersiveConnectable impl
 	@Override
 	public boolean getIsActive()
 	{
-		return inverted^active;
+		return active;
 	}
 	@Override
 	public EnumFacing getFacing()

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRedstoneBreaker.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRedstoneBreaker.java
@@ -5,7 +5,10 @@ import blusunrize.immersiveengineering.api.energy.wires.ImmersiveNetHandler;
 import blusunrize.immersiveengineering.api.energy.wires.ImmersiveNetHandler.Connection;
 import blusunrize.immersiveengineering.common.util.chickenbones.Matrix4;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.math.Vec3d;
@@ -75,5 +78,10 @@ public class TileEntityRedstoneBreaker extends TileEntityBreakerSwitch implement
 	public int getStrongRSOutput(IBlockState state, EnumFacing side)
 	{
 		return 0;
+	}
+	@Override
+	public boolean interact(EnumFacing side, EntityPlayer player, EnumHand hand, ItemStack heldItem, float hitX, float hitY, float hitZ)
+	{
+		return false;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRedstoneBreaker.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRedstoneBreaker.java
@@ -9,7 +9,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
-import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.math.Vec3d;
 
@@ -64,7 +63,7 @@ public class TileEntityRedstoneBreaker extends TileEntityBreakerSwitch implement
 		mat.translate(.5, .5, 0).rotate(Math.PI/2*rotation, 0, 0, 1).translate(-.5, -.5, 0);
 		if (endOfLeftConnection==null)
 			calculateLeftConn(mat);
-		boolean isLeft = con.end==endOfLeftConnection||con.start==endOfLeftConnection;
+		boolean isLeft = con.end.equals(endOfLeftConnection)||con.start.equals(endOfLeftConnection);
 		Vec3d ret = mat.apply(isLeft?new Vec3d(.125, .5, 1.03125):new Vec3d(.875, .5, 1.03125));
 		return ret;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRedstoneBreaker.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRedstoneBreaker.java
@@ -32,7 +32,7 @@ public class TileEntityRedstoneBreaker extends TileEntityBreakerSwitch implement
 	@Override
 	public boolean allowEnergyToPass(Connection con)
 	{
-		return active;
+		return active^inverted;
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/util/chickenbones/Matrix4.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/chickenbones/Matrix4.java
@@ -2,7 +2,6 @@ package blusunrize.immersiveengineering.common.util.chickenbones;
 
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.Vec3d;
-import net.minecraftforge.common.model.TRSRTransformation;
 
 import javax.vecmath.Matrix4f;
 import javax.vecmath.Vector3f;
@@ -84,7 +83,29 @@ public class Matrix4
 
 	public Matrix4(EnumFacing facing)
 	{
-		this(TRSRTransformation.getMatrix(facing));
+		this();
+		setIdentity();
+		translate(.5, .5, .5);
+		switch(facing)
+		{
+		case UP:
+			rotate(Math.PI/2, 1, 0, 0);
+			break;
+		case DOWN:
+			rotate(-Math.PI/2, 1, 0, 0);
+			break;
+		case SOUTH:
+			rotate(Math.PI, 0, 1, 0);
+			break;
+		case EAST:
+			rotate(-Math.PI/2, 0, 1, 0);
+			break;
+		case WEST:
+			rotate(Math.PI/2, 0, 1, 0);
+			break;
+		case NORTH:
+		}
+		translate(-.5, -.5, -.5);
 	}
 	public Matrix4 setIdentity()
 	{
@@ -416,14 +437,13 @@ public class Matrix4
 		m20 = mat.m20;	m21 = mat.m21;	m22 = mat.m22;	m23 = mat.m23;
 		m30 = mat.m30;	m31 = mat.m31;	m32 = mat.m32;	m33 = mat.m33;
 	}
-	
+
 	public final void invert()
 	{
 		Matrix4f temp = toMatrix4f();
 		temp.invert();
 		this.fromMatrix4f(temp);
 	}
-
 
 	@Override
 	public String toString()


### PR DESCRIPTION
(and redstone breakers as well):
1. Fixed them crashing on servers
2. Made them rotatable (right-click with the hammer, shift-right-click inverts)
Stuff not related to breaker switches:
1. Fixed pipes (or any other .obj.ie model) causing bad FPS lag (#1621)
2. Some changes to the model caches, mostly to `ExtBlockstateAdapter`