### PR TITLE
Only permit recipe ItemStack queries to look for a single item

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/tool/AssemblerHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/tool/AssemblerHandler.java
@@ -71,7 +71,7 @@ public class AssemblerHandler
 			if(stack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, null))
 				return new RecipeQuery(FluidUtil.getFluidContained(stack), stack.stackSize);
 			else
-				return new RecipeQuery(stack, stack.stackSize);
+				return new RecipeQuery(stack, 1);
 		} else if(o instanceof IngredientStack)
 			return new RecipeQuery(o, ((IngredientStack)o).inputSize);
 		return new RecipeQuery(o, 1);


### PR DESCRIPTION
Only permit recipe ItemStack queries to look for a single item in a stack to prevent misinterpretation of original Minecraft block recipes that call for 9 items in each recipe slot. Investigation is noted here https://github.com/BluSunrize/ImmersiveEngineering/issues/1853, but while I originally closed the issue I later wondered if there was ever any actually valid instance where a recipe calls for a stack of more than a single item in a given slot, and failed to think of any. If this is mistaken, feel free to disregard and close. However, this fixes the issue of being unable to assemble coal blocks from 9 coal that is present in the multiplayer version of the mod.