### PR TITLE
Fixed world loading caused by connection persistence and validation

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/energy/wires/ImmersiveNetHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/energy/wires/ImmersiveNetHandler.java
@@ -109,12 +109,16 @@ public class ImmersiveNetHandler
 	{
 		return directConnections.keySet();
 	}
-	public Collection<Connection> getAllConnections(World world)
+	public Collection<Connection> getAllConnections(int dimensionId)
 	{
 		Set<Connection> ret = newSetFromMap(new ConcurrentHashMap<Connection, Boolean>());
-		for (Set<Connection> conlist : getMultimap(world.provider.getDimension()).values())
+		for (Set<Connection> conlist : getMultimap(dimensionId).values())
 			ret.addAll(conlist);
 		return ret;
+	}
+	public Collection<Connection> getAllConnections(World world)
+	{
+		return getAllConnections(world.provider.getDimension());
 	}
 	public synchronized Set<Connection> getConnections(World world, BlockPos node)
 	{

--- a/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
@@ -204,29 +204,34 @@ public class EventHandler
 			int invalidConnectionsDropped = 0;
 			for (int dim:ImmersiveNetHandler.INSTANCE.getRelevantDimensions())
 			{
+				if (!validateConnections)
+				{
+					continue;
+				}
 				World world = FMLCommonHandler.instance().getMinecraftServerInstance().worldServerForDimension(dim);
 				if (world==null) {
 					ImmersiveNetHandler.INSTANCE.directConnections.remove(dim);
 					continue;
 				}
-				if (validateConnections)
+				for (Connection con:ImmersiveNetHandler.INSTANCE.getAllConnections(world))
 				{
-					for (Connection con:ImmersiveNetHandler.INSTANCE.getAllConnections(world))
+					if (!(world.getTileEntity(con.start) instanceof IImmersiveConnectable
+							&& world.getTileEntity(con.end) instanceof IImmersiveConnectable))
 					{
-						if (!(world.getTileEntity(con.start) instanceof IImmersiveConnectable
-								&& world.getTileEntity(con.end) instanceof IImmersiveConnectable))
-						{
-							ImmersiveNetHandler.INSTANCE.removeConnection(world, con);
-							invalidConnectionsDropped++;
-						}
+						ImmersiveNetHandler.INSTANCE.removeConnection(world, con);
+						invalidConnectionsDropped++;
 					}
-					IELogger.info("removed "+invalidConnectionsDropped+" invalid connections from world");
 				}
+				IELogger.info("removed "+invalidConnectionsDropped+" invalid connections from world");
 			}
 			int invalidProxies = 0;
 			Set<DimensionBlockPos> toRemove = new HashSet<>();
 			for (Entry<DimensionBlockPos, IICProxy> e:ImmersiveNetHandler.INSTANCE.proxies.entrySet())
 			{
+				if (!validateConnections)
+				{
+					continue;
+				}
 				DimensionBlockPos p = e.getKey();
 				World w = FMLCommonHandler.instance().getMinecraftServerInstance().worldServerForDimension(p.dimension);
 				if (w!=null&&w.isBlockLoaded(p))

--- a/src/main/java/blusunrize/immersiveengineering/common/IESaveData.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IESaveData.java
@@ -95,16 +95,12 @@ public class IESaveData extends WorldSavedData
 		nbt.setIntArray("savedDimensions", savedDimensions);
 		for(int dim: savedDimensions)
 		{
-			World world = FMLCommonHandler.instance().getMinecraftServerInstance().worldServerForDimension(dim);
-			if(world!=null)
+			NBTTagList connectionList = new NBTTagList();
+			for(Connection con : ImmersiveNetHandler.INSTANCE.getAllConnections(dim))
 			{
-				NBTTagList connectionList = new NBTTagList();
-				for(Connection con : ImmersiveNetHandler.INSTANCE.getAllConnections(world))
-				{
-					connectionList.appendTag(con.writeToNBT());
-				}
-				nbt.setTag("connectionList"+dim, connectionList);
+				connectionList.appendTag(con.writeToNBT());
 			}
+			nbt.setTag("connectionList"+dim, connectionList);
 		}
 		
 		NBTTagList proxies = new NBTTagList();


### PR DESCRIPTION
MinecraftServer.worldServerForDimension also load worlds which can lead to unintended behaviour.

I added an API function to get all wire connections in a world by dimension id to remove a call to worldServerForDimension, and fixed the check if connection validation is enabled, to prevent other calls.

(PR for #1710)