### PR TITLE
Fixed EntityDataManager registration, closes #1868

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/entities/EntityFluorescentTube.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/EntityFluorescentTube.java
@@ -23,11 +23,11 @@ import net.minecraft.world.World;
 
 public class EntityFluorescentTube extends Entity implements ITeslaEntity
 {
-	private static final DataParameter<Boolean> dataMarker_active = EntityDataManager.createKey(EntityChemthrowerShot.class, DataSerializers.BOOLEAN);
-	private static final DataParameter<Float> dataMarker_r = EntityDataManager.createKey(EntityChemthrowerShot.class, DataSerializers.FLOAT);
-	private static final DataParameter<Float> dataMarker_g = EntityDataManager.createKey(EntityChemthrowerShot.class, DataSerializers.FLOAT);
-	private static final DataParameter<Float> dataMarker_b = EntityDataManager.createKey(EntityChemthrowerShot.class, DataSerializers.FLOAT);
-	private static final DataParameter<Float> dataMarker_angleHorizontal = EntityDataManager.createKey(EntityChemthrowerShot.class, DataSerializers.FLOAT);
+	private static final DataParameter<Boolean> dataMarker_active = EntityDataManager.createKey(EntityFluorescentTube.class, DataSerializers.BOOLEAN);
+	private static final DataParameter<Float> dataMarker_r = EntityDataManager.createKey(EntityFluorescentTube.class, DataSerializers.FLOAT);
+	private static final DataParameter<Float> dataMarker_g = EntityDataManager.createKey(EntityFluorescentTube.class, DataSerializers.FLOAT);
+	private static final DataParameter<Float> dataMarker_b = EntityDataManager.createKey(EntityFluorescentTube.class, DataSerializers.FLOAT);
+	private static final DataParameter<Float> dataMarker_angleHorizontal = EntityDataManager.createKey(EntityFluorescentTube.class, DataSerializers.FLOAT);
 	
 	private int timer = 0;
 	public boolean active = false;

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/EntityIEExplosive.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/EntityIEExplosive.java
@@ -26,8 +26,8 @@ public class EntityIEExplosive extends EntityTNTPrimed
 	public IBlockState block;
 	String name;
 
-	private static final DataParameter<Optional<IBlockState>> dataMarker_block = EntityDataManager.createKey(EntityIEProjectile.class, DataSerializers.OPTIONAL_BLOCK_STATE);
-	private static final DataParameter<Integer> dataMarker_fuse = EntityDataManager.createKey(EntityIEProjectile.class, DataSerializers.VARINT);
+	private static final DataParameter<Optional<IBlockState>> dataMarker_block = EntityDataManager.createKey(EntityIEExplosive.class, DataSerializers.OPTIONAL_BLOCK_STATE);
+	private static final DataParameter<Integer> dataMarker_fuse = EntityDataManager.createKey(EntityIEExplosive.class, DataSerializers.VARINT);
 
 	public EntityIEExplosive(World world)
 	{

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/EntityRailgunShot.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/EntityRailgunShot.java
@@ -17,7 +17,7 @@ import net.minecraft.world.World;
 public class EntityRailgunShot extends EntityIEProjectile
 {
 	private ItemStack ammo;
-	private static final DataParameter<Optional<ItemStack>> dataMarker_ammo = EntityDataManager.createKey(EntityIEProjectile.class, DataSerializers.OPTIONAL_ITEM_STACK);
+	private static final DataParameter<Optional<ItemStack>> dataMarker_ammo = EntityDataManager.createKey(EntityRailgunShot.class, DataSerializers.OPTIONAL_ITEM_STACK);
 	private RailgunProjectileProperties ammoProperties;
 
 	public EntityRailgunShot(World world)

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/EntityRevolvershot.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/EntityRevolvershot.java
@@ -48,7 +48,7 @@ public class EntityRevolvershot extends Entity
 	public boolean bulletElectro = false;
 	public ItemStack bulletPotion = null;
 
-	private static final DataParameter<String> dataMarker_shooter = EntityDataManager.createKey(EntityIEProjectile.class, DataSerializers.STRING);
+	private static final DataParameter<String> dataMarker_shooter = EntityDataManager.createKey(EntityRevolvershot.class, DataSerializers.STRING);
 
 	public EntityRevolvershot(World world)
 	{

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/EntityRevolvershotFlare.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/EntityRevolvershotFlare.java
@@ -17,7 +17,7 @@ public class EntityRevolvershotFlare extends EntityRevolvershot
 {
 	boolean shootUp = false;
 	public int colour = -1;
-	private static final DataParameter<Integer> dataMarker_colour = EntityDataManager.createKey(EntityIEProjectile.class, DataSerializers.VARINT);
+	private static final DataParameter<Integer> dataMarker_colour = EntityDataManager.createKey(EntityRevolvershotFlare.class, DataSerializers.VARINT);
 
 	public EntityRevolvershotFlare(World world)
 	{


### PR DESCRIPTION
Possibly also #1768.

Best I can tell, these classes should be calling `EntityDataManater.createKey()` with their own class objects. This seems to prevent the crash.