### PR TITLE
Drill damage and manual double[]

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/manual/IEManualInstance.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/manual/IEManualInstance.java
@@ -106,13 +106,13 @@ public class IEManualInstance extends ManualInstance
 				if(segment.length>3)
 					try{
 						int idx = Integer.parseInt(segment[3]);
-						result = ""+Utils.formatDouble(iD[idx], "#.***");
+						result = ""+Utils.formatDouble(iD[idx], "##0.0##");
 					}catch(Exception ex){
 						break;
 					}
 				else
 					for(int i=0; i<iD.length; i++)
-						result += (i>0?", ":"")+Utils.formatDouble(iD[i], "#.***");
+						result += (i>0?", ":"")+Utils.formatDouble(iD[i], "##0.0##");
 			}
 
 			s = s.replaceFirst(rep, result);

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemDrill.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemDrill.java
@@ -446,13 +446,14 @@ public class ItemDrill extends ItemUpgradeableTool implements IAdvancedFluidItem
 				{
 					block.onBlockHarvested(world, pos, state, player);
 					TileEntity te = world.getTileEntity(pos);
+					//implicitly damages head
+					stack.onBlockDestroyed(world, state, pos, player);
 					if(block.removedByPlayer(state, world, pos, player, true))
 					{
 						block.onBlockDestroyedByPlayer( world, pos, state);
 						block.harvestBlock(world, player, pos, state, te, stack);
 						block.dropXpOnBlockBreak(world, pos, xpDropEvent);
 					}
-					stack.onBlockDestroyed(world, state, pos, player);
 				}
 				world.playEvent(2001, pos, Block.getStateId(state));
 				((EntityPlayerMP)player).connection.sendPacket(new SPacketBlockChange(world, pos));


### PR DESCRIPTION
Drill damage: #1934
Manual double arrays had broken formatting (displayed as 1.### instead of 1.234): I am using that feature in IndustrialWires to display EU consumption of different Jacob's ladders. Formatting now forces 1 digit before and one digit after the decimal point, up to 3 either way.