### PR TITLE
Wiring fixes

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockIETileProvider.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockIETileProvider.java
@@ -77,11 +77,9 @@ public abstract class BlockIETileProvider<E extends Enum<E> & BlockIEBase.IBlock
 		{
 			((IHasDummyBlocks)tile).breakDummies(pos, state);
 		}
-		if(tile instanceof IImmersiveConnectable && world.getGameRules().getBoolean("doTileDrops"))
-		{
-			if(world!=null&&(!world.isRemote||!Minecraft.getMinecraft().isSingleplayer()))
-				ImmersiveNetHandler.INSTANCE.clearAllConnectionsFor(Utils.toCC(tile),world, !world.isRemote);
-		}
+		if(tile instanceof IImmersiveConnectable)
+			if(!world.isRemote||!Minecraft.getMinecraft().isSingleplayer())
+				ImmersiveNetHandler.INSTANCE.clearAllConnectionsFor(Utils.toCC(tile),world, !world.isRemote&&world.getGameRules().getBoolean("doTileDrops"));
 		super.breakBlock(world, pos, state);
 		world.removeTileEntity(pos);
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
@@ -129,7 +129,8 @@ public class BlockConnector extends BlockIETileProvider<BlockTypes_Connector>
 				connector.getWorld().setBlockToAir(pos);
 				return;
 			}
-			connector.getNetwork().updateValues();
+			if (connector.isRSInput())
+				connector.rsDirty = true;
 		}
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorRedstone.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorRedstone.java
@@ -31,6 +31,7 @@ public class TileEntityConnectorRedstone extends TileEntityImmersiveConnectable 
 	public EnumFacing facing = EnumFacing.DOWN;
 	public int ioMode = 0; // 0 - input, 1 -output
 	public int redstoneChannel = 0;
+	public boolean rsDirty = false;
 
 	private RedstoneWireNetwork wireNetwork = new RedstoneWireNetwork().add(this);
 	private boolean loaded = false;
@@ -43,6 +44,8 @@ public class TileEntityConnectorRedstone extends TileEntityImmersiveConnectable 
 			loaded = true;
 			wireNetwork.removeFromNetwork(null);
 		}
+		if (hasWorldObj() && !worldObj.isRemote && rsDirty)
+			wireNetwork.updateValues();
 	}
 
 	@Override
@@ -82,7 +85,7 @@ public class TileEntityConnectorRedstone extends TileEntityImmersiveConnectable 
 	@Override
 	public void onChange()
 	{
-		if (!isInvalid())
+		if (!isInvalid() && isRSOutput())
 		{
 			markContainingBlockForUpdate(null);
 			markBlockForUpdate(pos.offset(facing), null);
@@ -102,6 +105,7 @@ public class TileEntityConnectorRedstone extends TileEntityImmersiveConnectable 
 			int val = worldObj.isBlockIndirectlyGettingPowered(pos);
 			signals[redstoneChannel] = (byte) Math.max(val, signals[redstoneChannel]);
 		}
+		rsDirty = false;
 	}
 
 	public boolean isRSOutput()

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorRedstone.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityConnectorRedstone.java
@@ -136,9 +136,9 @@ public class TileEntityConnectorRedstone extends TileEntityImmersiveConnectable 
 	public void connectCable(WireType cableType, TargetingInfo target, IImmersiveConnectable other)
 	{
 		super.connectCable(cableType, target, other);
-		if(other instanceof TileEntityConnectorRedstone)
-			if(((TileEntityConnectorRedstone) other).wireNetwork != wireNetwork)
-				wireNetwork.mergeNetwork(((TileEntityConnectorRedstone) other).wireNetwork);
+		if(other instanceof IRedstoneConnector)
+			if(((IRedstoneConnector) other).getNetwork() != wireNetwork)
+				wireNetwork.mergeNetwork(((IRedstoneConnector) other).getNetwork());
 	}
 
 	@Override


### PR DESCRIPTION
 - Small addition to #1986, I missed one place where `TEConenctorRS` needed to be replaced with `IRSConnector`
 - Wires weren't being removed from the NetHandler properly if `doTileDrops` was enabled. I found this because I completely forgot to add that call when removing IW's dependency on `BlockIEBase/TileProvider`, came looking for code I missed and realized that method wasn't called at all if `doTileDrops` was false
 - The "local" RS wire net (the part sharing a signal) will be updated once per tick at most. Updating the RS input of output connectors won't trigger updates any more and input connectors won't cause block updates on channel value change any more.