### PR TITLE
Add OpenComputers support to Mixer and Bottling Machine

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/GeneralComputerHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/GeneralComputerHelper.java
@@ -24,6 +24,7 @@ public class GeneralComputerHelper
 			ManualHelper.getManual().addEntry("computer.arcfurnace", "computers", new ManualPages.Text(ManualHelper.getManual(), "computer.arcFurnace0"),
 					new ManualPages.Text(ManualHelper.getManual(), "computer.arcFurnace1"),
 					new ManualPages.Text(ManualHelper.getManual(), "computer.arcFurnace2"));
+			ManualHelper.getManual().addEntry("computer.bottlingmachine", "computers", new ManualPages.Text(ManualHelper.getManual(), "computer.bottlingmachine0"), new ManualPages.Text(ManualHelper.getManual(), "computer.bottlingmachine1"));
 			ManualHelper.getManual().addEntry("computer.sampleDrill", "computers", new ManualPages.Text(ManualHelper.getManual(), "computer.sampleDrill0"),
 					new ManualPages.Text(ManualHelper.getManual(), "computer.sampleDrill1"));
 			ManualHelper.getManual().addEntry("computer.crusher", "computers", new ManualPages.Text(ManualHelper.getManual(), "computer.crusher0"),
@@ -40,6 +41,7 @@ public class GeneralComputerHelper
 					new ManualPages.Text(ManualHelper.getManual(), "computer.refinery1"));
 			ManualHelper.getManual().addEntry("computer.assembler", "computers", new ManualPages.Text(ManualHelper.getManual(), "computer.assembler0"),
 					new ManualPages.Text(ManualHelper.getManual(), "computer.assembler1"));
+			ManualHelper.getManual().addEntry("computer.mixer","computers", new ManualPages.Text(ManualHelper.getManual(), "computer.mixer0"), new ManualPages.Text(ManualHelper.getManual(), "computer.mixer1"));
 //			ManualHelper.getManual().addEntry("computer.bottlingMachine", "computers", new ManualPages.Text(ManualHelper.getManual(), "computer.bottlingMachine0"),
 //					new ManualPages.Text(ManualHelper.getManual(), "computer.bottlingMachine1"),
 //					new ManualPages.Text(ManualHelper.getManual(), "computer.bottlingMachine2"));

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/BottlingMachineDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/BottlingMachineDriver.java
@@ -1,0 +1,122 @@
+package blusunrize.immersiveengineering.common.util.compat.opencomputers;
+
+import blusunrize.immersiveengineering.api.crafting.BottlingMachineRecipe;
+import blusunrize.immersiveengineering.common.blocks.TileEntityIEBase;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityBottlingMachine;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.network.Node;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTankInfo;
+
+import java.util.HashMap;
+
+public class BottlingMachineDriver extends DriverSidedTileEntity
+{
+
+	@Override
+	public ManagedEnvironment createEnvironment(World w, BlockPos bp, EnumFacing facing)
+	{
+		TileEntity te = w.getTileEntity(bp);
+		if(te instanceof TileEntityBottlingMachine)
+		{
+			TileEntityBottlingMachine ref = (TileEntityBottlingMachine) te;
+			TileEntityBottlingMachine master = ref.master();
+			if(master != null && ref.isRedstonePos())
+				return new BottlingMachineEnvironment(w, master.getPos(), TileEntityBottlingMachine.class);
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?> getTileEntityClass()
+	{
+		return TileEntityBottlingMachine.class;
+	}
+
+	public class BottlingMachineEnvironment extends ManagedEnvironmentIE<TileEntityBottlingMachine>
+	{
+
+		public BottlingMachineEnvironment(World w, BlockPos bp, Class<? extends TileEntityIEBase> teClass)
+		{
+			super(w, bp, teClass);
+		}
+
+		@Override
+		public void onConnect(Node node)
+		{
+			TileEntityBottlingMachine master = getTileEntity();
+			if(master != null)
+			{
+				master.controllingComputers++;
+				master.computerOn = true;
+			}
+		}
+
+		@Override
+		public void onDisconnect(Node node)
+		{
+			TileEntityBottlingMachine te = getTileEntity();
+			if(te != null)
+				te.controllingComputers--;
+		}
+
+		@Callback(doc = "function():boolean -- checks whether the Bottling Machine is currently active")
+		public Object[] isActive(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().shouldRenderAsActive()};
+		}
+		
+		@Callback(doc = "function(enable:boolean) -- enable or disable the Bottling Machine")
+		public Object[] setEnabled(Context context, Arguments args)
+		{
+			getTileEntity().computerOn = args.checkBoolean(0);
+			return null;
+		}
+		
+		@Callback(doc = "function():boolean -- checks whether the bottling machine is on or off)")
+		public Object[] isEnabled(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().computerOn};
+		}
+		
+		@Callback(doc = "function():number -- get energy storage capacity")
+		public Object[] getEnergyStored(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().energyStorage.getEnergyStored()};
+		}
+
+		@Callback(doc = "function():number -- get currently stored energy")
+		public Object[] getMaxEnergyStored(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().energyStorage.getMaxEnergyStored()};
+		}
+
+		@Callback(doc = "function():table -- get tankinfo for fluid tank")
+		public Object[] getTankContents(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().tanks[0].getInfo()};
+		}
+
+
+		@Override
+		public String preferredName()
+		{
+			return "ie_bottling_machine";
+		}
+
+		@Override
+		public int priority()
+		{
+			return 1000;
+		}
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/BottlingMachineDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/BottlingMachineDriver.java
@@ -81,13 +81,7 @@ public class BottlingMachineDriver extends DriverSidedTileEntity
 			getTileEntity().computerOn = args.checkBoolean(0);
 			return null;
 		}
-		
-		@Callback(doc = "function():boolean -- checks whether the bottling machine is on or off)")
-		public Object[] isEnabled(Context context, Arguments args)
-		{
-			return new Object[]{getTileEntity().computerOn};
-		}
-		
+
 		@Callback(doc = "function():number -- get energy storage capacity")
 		public Object[] getEnergyStored(Context context, Arguments args)
 		{
@@ -101,7 +95,7 @@ public class BottlingMachineDriver extends DriverSidedTileEntity
 		}
 
 		@Callback(doc = "function():table -- get tankinfo for fluid tank")
-		public Object[] getTankContents(Context context, Arguments args)
+		public Object[] getTank(Context context, Arguments args)
 		{
 			return new Object[]{getTileEntity().tanks[0].getInfo()};
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/MixerDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/MixerDriver.java
@@ -101,12 +101,6 @@ public class MixerDriver extends DriverSidedTileEntity
 			getTileEntity().computerOn = args.checkBoolean(0);
 			return null;
 		}
-		
-		@Callback(doc = "function():boolean -- checks whether the mixer is on or off)")
-		public Object[] isEnabled(Context context, Arguments args)
-		{
-			return new Object[]{getTileEntity().computerOn};
-		}
 
 		@Callback(doc = "function():boolean -- checks whether the mixer is currently active")
 		public Object[] isActive(Context context, Arguments args)
@@ -139,9 +133,9 @@ public class MixerDriver extends DriverSidedTileEntity
 			return new Object[]{stack};
 		}
 		
-		// Only wants to return info on the bottom fluid, so renamed the method from getTankInfo to getBottomFluid. Might be able to force displaying all fluids, not sure yet.
+		// Only wants to return info on the bottom fluid. Might be able to force displaying all fluids, not sure yet.
 		@Callback(doc = "function():table -- get bottom fluid in tank")
-		public Object[] getBottomFluid(Context context, Arguments args)
+		public Object[] getTank(Context context, Arguments args)
 		{
 			return new Object[]{getTileEntity().tank.getInfo()};
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/MixerDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/MixerDriver.java
@@ -1,0 +1,156 @@
+package blusunrize.immersiveengineering.common.util.compat.opencomputers;
+
+import blusunrize.immersiveengineering.api.crafting.MixerRecipe;
+import blusunrize.immersiveengineering.common.blocks.TileEntityIEBase;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityMixer;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityMultiblockMetal.MultiblockProcess;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityMultiblockMetal.MultiblockProcessInMachine;
+import blusunrize.immersiveengineering.common.util.ItemNBTHelper;
+import blusunrize.immersiveengineering.common.util.Utils;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.network.Node;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.Map;
+
+public class MixerDriver extends DriverSidedTileEntity
+{
+
+	@Override
+	public ManagedEnvironment createEnvironment(World w, BlockPos bp, EnumFacing facing)
+	{
+		TileEntity te = w.getTileEntity(bp);
+		if(te instanceof TileEntityMixer)
+		{
+			TileEntityMixer arc = (TileEntityMixer) te;
+			TileEntityMixer master = arc.master();
+			if(master != null && arc.isRedstonePos())
+				return new MixerEnvironment(w, master.getPos(), TileEntityMixer.class);
+		}
+		return null;
+	}
+
+	@Override
+	public Class<?> getTileEntityClass()
+	{
+		return TileEntityMixer.class;
+	}
+
+	public class MixerEnvironment extends ManagedEnvironmentIE<TileEntityMixer>
+	{
+
+		@Override
+		public String preferredName()
+		{
+			return "ie_mixer";
+		}
+
+		@Override
+		public int priority()
+		{
+			return 1000;
+		}
+
+		public MixerEnvironment(World w, BlockPos p, Class<? extends TileEntityIEBase> teClass)
+		{
+			super(w, p, teClass);
+		}
+
+		@Override
+		public void onConnect(Node node)
+		{
+			TileEntityMixer master = getTileEntity();
+			if(master != null)
+			{
+				master.controllingComputers++;
+				master.computerOn = true;
+			}
+		}
+
+		@Override
+		public void onDisconnect(Node node)
+		{
+			TileEntityMixer te = getTileEntity();
+			if(te != null)
+				te.controllingComputers--;
+		}
+
+		@Callback(doc = "function():int -- gets the maximum amount of energy stored")
+		public Object[] getMaxEnergyStored(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().energyStorage.getMaxEnergyStored()};
+		}
+
+		@Callback(doc = "function():int -- gets the amount of energy stored")
+		public Object[] getEnergyStored(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().energyStorage.getEnergyStored()};
+		}
+
+		@Callback(doc = "function(on:boolean) -- turns the mixer on or off")
+		public Object[] setEnabled(Context context, Arguments args)
+		{
+			getTileEntity().computerOn = args.checkBoolean(0);
+			return null;
+		}
+		
+		@Callback(doc = "function():boolean -- checks whether the mixer is on or off)")
+		public Object[] isEnabled(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().computerOn};
+		}
+
+		@Callback(doc = "function():boolean -- checks whether the mixer is currently active")
+		public Object[] isActive(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().shouldRenderAsActive()};
+		}
+
+		@Callback(doc = "function(stack:int):table -- returns the specified input stack as described in the manual")
+		public Object[] getInputStack(Context context, Arguments args)
+		{
+			int slot = args.checkInteger(0);
+			if(slot < 1 || slot > 12)
+				throw new IllegalArgumentException("Input slots are 1-12");
+			TileEntityMixer master = getTileEntity();
+			Map<String, Object> stack = Utils.saveStack(master.inventory[slot - 1]);
+			mainLoop:
+			for(MultiblockProcess<MixerRecipe> p : master.processQueue)
+				for(int i : ((MultiblockProcessInMachine<MixerRecipe>) p).getInputSlots())
+					if(i == slot - 1)
+					{
+						stack.put("progress", p.processTick);
+						stack.put("maxProgress", p.maxTicks);
+						break mainLoop;
+					}
+			if(!stack.containsKey("progress"))
+			{
+				stack.put("progress", 0);
+				stack.put("maxProgress", 0);
+			}
+			return new Object[]{stack};
+		}
+		
+		// Only wants to return info on the bottom fluid, so renamed the method from getTankInfo to getBottomFluid. Might be able to force displaying all fluids, not sure yet.
+		@Callback(doc = "function():table -- get bottom fluid in tank")
+		public Object[] getBottomFluid(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().tank.getInfo()};
+		}
+		
+		// Only returns true if machine is set to active. Don't think that's fixable from here.
+		@Callback(doc = "function():boolean -- check whether a valid recipe exists for the current inputs")
+		public Object[] isValidRecipe(Context context, Arguments args)
+		{
+			return new Object[]{getTileEntity().processQueue.get(0).recipe != null};
+		}
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/OCHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/OCHelper.java
@@ -19,7 +19,7 @@ public class OCHelper extends IECompatModule
 		API.driver.add(new CrusherDriver());
 		API.driver.add(new ArcFurnaceDriver());
 		API.driver.add(new AssemblerDriver());
-//		API.driver.add(new BottlingMachineDriver());
+		API.driver.add(new BottlingMachineDriver());
 		API.driver.add(new RefineryDriver());
 		API.driver.add(new SqueezerDriver());
 		API.driver.add(new SampleDrillDriver());
@@ -29,6 +29,7 @@ public class OCHelper extends IECompatModule
 		API.driver.add(new CapacitorDriver());
 		API.driver.add(new EnergyMeterDriver());
 		API.driver.add(new TeslaCoilDriver());
+		API.driver.add(new MixerDriver());
 	}
 
 	@Override

--- a/src/main/resources/assets/immersiveengineering/lang/en_US.lang
+++ b/src/main/resources/assets/immersiveengineering/lang/en_US.lang
@@ -1405,6 +1405,13 @@ ie.manual.entry.computer.arcFurnace0=§lsetEnabled(boolean active)§r: allows or
 ie.manual.entry.computer.arcFurnace1=specified slot (both values in ticks)<br>§lgetOutputStack(int slot)§r:returns the stack in the specified output slot(1-6)<br>§lgetAdditiveStack(int slot)§r: returns the stack in the specified additive slot (1-4)<br>§lgetSlagStack()§r: returns the stack in the slag slot<br>§lhasElectrodes()§r:returns a boolean indicating whether all 3 electrodes in the arc furnace are valid<br>§lgetElectrode(int slot)§r: returns the item stack of the specified electrode (1-4)
 ie.manual.entry.computer.arcFurnace2=§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in this arc furnace<br>§lgetEnergyStored()§r: returns the amount of energy currently stored in this arc furnace
 
+ie.manual.entry.computer.bottlingmachine.name=Bottling Machine ☎
+ie.manual.entry.computer.bottlingmachine.subtext=Fill 'er up! 
+ie.manual.entry.computer.bottlingmachine0=§lsetEnabled(boolean active)§r: allows or disallows the bottling machine to operate, as if a redstone signal was applied to the control panel<br>§lisActive()§r: returns a boolean that is true if the bottling machine is currently processing something and false otherwise<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in this machine<br>§lgetEnergyStored()§r: returns the amount of energy currently stored in this machine
+ie.manual.entry.computer.bottlingmachine1=§lgetTank()§r: returns the contents of the fluid tank
+
+
+
 ie.manual.entry.computer.sampleDrill.name=Core Sample Drill ☎
 ie.manual.entry.computer.sampleDrill.subtext=Guaranteed representative samples 
 ie.manual.entry.computer.sampleDrill0=The sample drill can be connected to a computer on its bottom block.<br>§lgetSampleProgress()§r: returns the current sample progress, 1 means that the sampling is finished, 0 means that the sampling hasn't started yet<br>§lisSamplingFinished()§r: returns true if the drill has finished sampling, otherwise it returns false<br>§lgetVeinUnlocalizedName()§r: returns the unlocalized name of the found vein
@@ -1448,12 +1455,6 @@ ie.manual.entry.computer.assembler.subtext=objdump -d
 ie.manual.entry.computer.assembler0=The bottom row of an assembler can be connected to a computer.<br>§lhasIngredients(int recipe)§r: returns whether the ingredients for the specified recipe (1-3) are available<br>§lsetEnabled(int slot, boolean on)§r: enables or disables the specified recipe (1-3). If a recipe is disabled, it will not be crafted even if the materials are available.<br>§lgetRecipe(int recipe)l§r: returns a table containing the specified recipe (0-2). The keys "in1", "in2", ..., "in9" store the recipe inputs, the key "out"
 ie.manual.entry.computer.assembler1=stores the output<br>§lgetTank(int tank)§r: returns the specified tank (1-3)<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in the assembler<br>§lgetEnergyStored()§r: returns the amount of energy stored in the assembler<br>§lgetStackInSlot(int slot)§r: returns the stack in the specified input slot (1-18).<br>§lgetBufferStack(recipe:int)§r: returns the output buffer slot for the specified recipe (1-3)
 
-ie.manual.entry.computer.bottlingMachine.name=Bottling Machine ☎
-ie.manual.entry.computer.bottlingMachine.subtext=Fill 'er up!
-ie.manual.entry.computer.bottlingMachine0=The block in the bottom middle of the front of a bottling machine and the back bottom row can be connected to a computer. A cannister is considered filled if it has passed the black box on the conveyor.<br>§lgetFluid()§r: returns the internal fluid tank of the bottling machine<br>§lgetEmptyCannister(int n)§r: returns the n'th empty cannister, starting where the cannisters enter the machine. The table contains the current filling progress in ticks in the key "process". A bottle is filled
-ie.manual.entry.computer.bottlingMachine1=at progress 72 and output at progress 120.<br>§lgetEmptyCannisterCount()§r: returns the amount of empty cannisters in the bottling machine<br>§lgetFilledCannister(int n)§r: returns the n'th filled cannister, starting at the black box. The returned table contains the filling progress stored in the key "process".<br>§lgetFilledCannisterCount()§r: returns the amount of filled cannisters in the bottling machine<br>§lgetEnergyStored()§r: returns
-ie.manual.entry.computer.bottlingMachine2=the amount of energy stored in the bottling machine<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy stored in this bottling machine<br>§lsetEnabled(boolean on)§r: turns the bottling machine on or off
-
 ie.manual.entry.computer.capacitor.name=Capacitors ☎
 ie.manual.entry.computer.capacitor.subtext=Many Farads at a lot of Volts
 ie.manual.entry.computer.capacitor0=Any capacitor can be connected to a computer on any side.<br>§lgetEnergyStored()§r: returns the amount of energy that is stored<br>§lgetMaxEnergyStored()§r: returns the amount of energy that can be stored
@@ -1462,9 +1463,14 @@ ie.manual.entry.computer.teslaCoil.name=Tesla coil ☎
 ie.manual.entry.computer.teslaCoil.subtext=No, it isn't an SSTC
 ie.manual.entry.computer.teslaCoil0=§lisActive()§r: returns whether the coil is currently active<br>§lsetRSMode(boolean)§r: changes whether the coil is switch on by a high or a low redstone signal<br>§lsetPowerMode(boolean)§r: changes whether the coil is running in high (true)- or low (false)-power mode (<link;teslaCoil;§o§nexplanation§r;2>). This command can only be used if the coil is not active.
 
+ie.manual.entry.computer.mixer.name=Mixer ☎
+ie.manual.entry.computer.mixer.subtext=Vats of Cookie Dough!
+ie.manual.entry.computer.mixer0=§lisActive()§r: returns whether the mixer is currently active.<br>§lisValidRecipe()§r: returns whether a valid recipe exists for any of the input item and fluid combinations.<br>§lgetEnergyStored()§r: returns the amount of energy stored in this machine.<br>§lgetMaxEnergyStored()§r: returns the maximum amount of energy that can be stored in this machine<br>§lgetInputStack(int slot)§r: returns the stack in the specified input slot (1-12). The table additionally has the keys
+ie.manual.entry.computer.mixer1=§lprogress§r and §lmaxProgress§r to store the current progress and the progress at which it will be finished on the specified slot (both values in ticks).<br>§lgetTank()§r: returns the bottom fluid in the tank.
+
 #SHADER INFO
 desc.immersiveengineering.info.shader.details.rosequartz=First shader ever made!<br>No direct reference, though the name itself was inspired by a character in the „Inkheart“ series of novels
-desc.immersiveengineering.info.shader.details.argo=No direct reference, but style+colour were inspired by the videgame 'Destiny'.
+desc.immersiveengineering.info.shader.details.argo=No direct reference, but style+colour were inspired by the videogame 'Destiny'.
 desc.immersiveengineering.info.shader.details.sunstrike=No direct reference but name+colour were inspired by Sunbreaker Titans from the videogame 'Destiny'.
 desc.immersiveengineering.info.shader.details.locus=Named and coloured after the mercenary 'Locus' in RvB Seasons 11-13.
 desc.immersiveengineering.info.shader.details.felix=Named and coloured after the mercenary 'Felix' in RvB Seasons 11-13.


### PR DESCRIPTION
Added drivers and manual entries for bottling machine and mixer computer support. Tested to work on OC 1.6.2.7. 
The getTank() function for the mixer only seems to want to return the bottom fluid in the tank. I'll look more into it, but it really doesn't affect functionality that much since the mixer outputs the fluid on bottom first anyhow.