### PR TITLE
Try all other horizontal directions if multiblock structure creation fails using the direction the player is facing

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemIETool.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemIETool.java
@@ -193,6 +193,13 @@ public class ItemIETool extends ItemIEBase implements ITool, IGuiItem
 						continue;
 					if(mb.createStructure(world, pos, side, player))
 						return EnumActionResult.SUCCESS;
+					for(EnumFacing otherSide : EnumFacing.HORIZONTALS)
+					{
+						if(side == otherSide)
+							continue;
+						if(mb.createStructure(world, pos, otherSide, player))
+							return EnumActionResult.SUCCESS;
+					}
 				}
 			TileEntity tile = world.getTileEntity(pos);
 			if(!(tile instanceof IDirectionalTile) && !(tile instanceof IHammerInteraction) && !(tile instanceof IConfigurableSides))


### PR DESCRIPTION
The player's direction is still attempted first, just in case it matters somewhere.

Fixes #2051

A video where I test this patch is available here: https://youtu.be/Zlx-Ee4O53E