### PR TITLE
Remapper&Null ItemStack fixes

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/ImmersiveEngineering.java
+++ b/src/main/java/blusunrize/immersiveengineering/ImmersiveEngineering.java
@@ -22,7 +22,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonStreamParser;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -136,6 +135,7 @@ public class ImmersiveEngineering
 					TileEntityFluidPipe.climbablePipeCovers.add(opFunc.get());
 			}
 		}
+		NameRemapper.init();
 	}
 	@Mod.EventHandler
 	public void postInit(FMLPostInitializationEvent event)
@@ -190,6 +190,11 @@ public class ImmersiveEngineering
 				IESaveData.setInstance(world.provider.getDimension(), worldData);
 			}
 		}
+	}
+
+	@Mod.EventHandler
+	public void remap(FMLMissingMappingsEvent ev) {
+		NameRemapper.remap(ev);
 	}
 
 	public static <T extends IForgeRegistryEntry<?>> T register(T object, String name)

--- a/src/main/java/blusunrize/immersiveengineering/api/ApiUtils.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/ApiUtils.java
@@ -494,7 +494,7 @@ public class ApiUtils
 				amount -= taken;
 				itemstack.shrink(taken);
 				if(itemstack.getCount() <= 0)
-					player.setHeldItem(hand, null);
+					player.setHeldItem(hand, ItemStack.EMPTY);
 				if(amount<=0)
 					return;
 			}
@@ -508,7 +508,7 @@ public class ApiUtils
 				amount -= taken;
 				itemstack.shrink(taken);
 				if(itemstack.getCount() <= 0)
-					player.inventory.setInventorySlotContents(i, null);
+					player.inventory.setInventorySlotContents(i, ItemStack.EMPTY);
 				if(amount<=0)
 					return;
 			}

--- a/src/main/java/blusunrize/immersiveengineering/api/crafting/MultiblockRecipe.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/crafting/MultiblockRecipe.java
@@ -94,7 +94,7 @@ public abstract class MultiblockRecipe implements IMultiblockRecipe, IJEIRecipe
 			for(int i=0; i<outputList.size(); i++)
 			{
 				ItemStack s = outputList.get(i);
-				ArrayList<ItemStack> list = Lists.newArrayList(s!=null&&!s.isEmpty()?s.copy():ItemStack.EMPTY);
+				ArrayList<ItemStack> list = Lists.newArrayList(!s.isEmpty()?s.copy():ItemStack.EMPTY);
 				this.jeiItemOutputList[i] = list;
 				this.jeiTotalItemOutputList.addAll(list);
 			}

--- a/src/main/java/blusunrize/immersiveengineering/api/tool/BelljarHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/tool/BelljarHandler.java
@@ -127,7 +127,7 @@ public class BelljarHandler
 	}
 	public interface ItemFertilizerHandler
 	{
-		boolean isValid(@Nullable ItemStack fertilizer);
+		boolean isValid(ItemStack fertilizer);
 		float getGrowthMultiplier(ItemStack fertilizer, ItemStack seed, ItemStack soil, TileEntity tile);
 	}
 
@@ -282,7 +282,7 @@ public class BelljarHandler
 				if(growth>=.5)
 				{
 					ItemStack[] fruit = seedOutputMap.get(new ComparableItemStack(seed,false));
-					if(fruit!=null&&fruit.length>0&&fruit[0]!=null&&fruit[0].getItem()!=null)
+					if(fruit!=null&&fruit.length>0&&!fruit[0].isEmpty())
 					{
 						Block fruitBlock = Block.getBlockFromItem(fruit[0].getItem());
 						if(fruitBlock!=null)
@@ -380,7 +380,7 @@ public class BelljarHandler
 		{
 			final ItemStack bonemeal = new ItemStack(Items.DYE,1,15);
 			@Override
-			public boolean isValid(@Nullable ItemStack fertilizer)
+			public boolean isValid(ItemStack fertilizer)
 			{
 				return !fertilizer.isEmpty()&&OreDictionary.itemMatches(bonemeal,fertilizer,true);
 			}

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientEventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientEventHandler.java
@@ -292,7 +292,7 @@ public class ClientEventHandler implements IResourceManagerReloadListener
 	@SubscribeEvent
 	public void onRenderItemFrame(RenderItemInFrameEvent event)
 	{
-		if(event.getItem()!=null && event.getItem().getItem() instanceof ItemEngineersBlueprint)
+		if(!event.getItem().isEmpty() && event.getItem().getItem() instanceof ItemEngineersBlueprint)
 		{
 			double playerDistanceSq = ClientUtils.mc().player.getDistanceSq(event.getEntityItemFrame().getPosition());
 
@@ -1037,7 +1037,7 @@ public class ClientEventHandler implements IResourceManagerReloadListener
 				chunkBorders = true;
 				break;
 			}
-		if(!chunkBorders && ClientUtils.mc().objectMouseOver!=null && ClientUtils.mc().objectMouseOver.typeOfHit==Type.BLOCK && ClientUtils.mc().objectMouseOver.getBlockPos()!=null && ClientUtils.mc().world.getTileEntity(ClientUtils.mc().objectMouseOver.getBlockPos()) instanceof TileEntitySampleDrill)
+		if(!chunkBorders && ClientUtils.mc().objectMouseOver!=null && ClientUtils.mc().objectMouseOver.typeOfHit==Type.BLOCK && ClientUtils.mc().world.getTileEntity(ClientUtils.mc().objectMouseOver.getBlockPos()) instanceof TileEntitySampleDrill)
 			chunkBorders = true;
 
 		if(chunkBorders)

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
@@ -1527,7 +1527,7 @@ public class ClientProxy extends CommonProxy
 	{
 		Item item = Item.getItemFromBlock(block);
 		FluidStateMapper mapper = new FluidStateMapper(fluid);
-		if(item != null)
+		if(item != Items.AIR)
 		{
 			ModelLoader.registerItemVariants(item);
 			ModelLoader.setCustomMeshDefinition(item, mapper);

--- a/src/main/java/blusunrize/immersiveengineering/client/fx/EntityFXItemParts.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/fx/EntityFXItemParts.java
@@ -15,13 +15,13 @@ public class EntityFXItemParts extends EntityFXIEBase
 		this.item = item;
 		this.part = part;
 		this.particleMaxAge = 16;
-		if(!item.isEmpty() && item.getItem()!=null)
-		{
+//		if(!item.isEmpty() && item.getItem()!=null)
+//		{
 //			if(item.getItem() instanceof ItemBlock)
 //				this.particleIcon = Block.getBlockFromItem(item.getItem()).getIcon(0, item.getItemDamage());
 //			else
 //				this.particleIcon = item.getItem().getIcon(item, 0);
-		}
+//		}
 		this.posX = x;
 		this.posY = y;
 		this.posZ = z;

--- a/src/main/java/blusunrize/immersiveengineering/common/NameRemapper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/NameRemapper.java
@@ -1,0 +1,88 @@
+package blusunrize.immersiveengineering.common;
+
+import blusunrize.immersiveengineering.ImmersiveEngineering;
+import blusunrize.immersiveengineering.common.util.IELogger;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.event.FMLMissingMappingsEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NameRemapper {
+	private final static String mappings = "woodendecoration:wooden_decoration\n" +
+			"storageslab:storage_slab\n" +
+			"stonedecorationstairs_concrete_leaded:stone_decoration_stairs_concrete_leaded\n" +
+			"fakelight:fake_light\n" +
+			"woodendevice0:wooden_device0\n" +
+			"woodendevice1:wooden_device1\n" +
+			"stonedecoration:stone_decoration\n" +
+			"metalmultiblock:metal_multiblock\n" +
+			"clothdevice:cloth_device\n" +
+			"stonedecorationstairs_concrete:stone_decoration_stairs_concrete\n" +
+			"treatedwoodstairs2:treated_wood_stairs2\n" +
+			"treatedwoodstairs1:treated_wood_stairs1\n" +
+			"treatedwoodstairs0:treated_wood_stairs0\n" +
+			"stonedevice:stone_device\n" +
+			"sheetmetalslab:sheetmetal_slab\n" +
+			"treatedwoodslab:treated_wood_slab\n" +
+			"metaldevice0:metal_device0\n" +
+			"metaldevice1:metal_device1\n" +
+			"stonedecorationstairs_concrete_tile:stone_decoration_stairs_concrete_tile\n" +
+			"metaldecoration1:metal_decoration1\n" +
+			"metaldecoration2:metal_decoration2\n" +
+			"metaldecoration0:metal_decoration0\n" +
+			"treatedwood:treated_wood\n" +
+			"stonedecorationslab:stone_decoration_slab\n" +
+			"stonedecorationstairs_hempcrete:stone_decoration_stairs_hempcrete\n" +
+			"faradaysuit_feet:faraday_suit_feet\n" +
+			"faradaysuit_head:faraday_suit_head\n" +
+			"fakeicon:fake_icon\n" +
+			"fluorescenttube:fluorescent_tube\n" +
+			"shaderbag:shader_bag\n" +
+			"faradaysuit_legs:faraday_suit_legs\n" +
+			"graphiteelectrode:graphite_electrode\n" +
+			"faradaysuit_chest:faraday_suit_chest";
+	private final static Map<String, String> nameMap = new HashMap<>();
+
+	public static void init() {
+		String[] lines = mappings.split("\n");
+		for (String l : lines) {
+			String[] mapping = l.split(":");
+			if (mapping.length == 2) {
+				nameMap.put(mapping[0], mapping[1]);
+			}
+		}
+	}
+
+	public static void remap(FMLMissingMappingsEvent ev) {
+		for (FMLMissingMappingsEvent.MissingMapping miss : ev.get()) {
+			String newName = nameMap.get(miss.resourceLocation.getResourcePath());
+			if (newName != null) {
+				ResourceLocation newLoc = new ResourceLocation(ImmersiveEngineering.MODID, newName);
+				if (miss.type == GameRegistry.Type.ITEM) {
+					Item item = Item.REGISTRY.getObject(newLoc);
+					if (item != null) {
+						IELogger.info("Successfully remapped item " + miss.resourceLocation);
+						miss.remap(item);
+					} else {
+						miss.warn();
+					}
+				} else {
+					Block item = Block.REGISTRY.getObject(newLoc);
+					if (item != Blocks.AIR) {
+						IELogger.info("Successfully remapped block " + miss.resourceLocation);
+						miss.remap(item);
+					} else {
+						miss.warn();
+					}
+				}
+			} else {
+				IELogger.error("Couldn't remap " + miss.resourceLocation);
+			}
+		}
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockIEMultiblock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockIEMultiblock.java
@@ -57,7 +57,7 @@ public abstract class BlockIEMultiblock<E extends Enum<E> & BlockIEBase.IBlockEn
 	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
 	{
 		ItemStack stack = getOriginalBlock(world, pos);
-		if(stack!=null)
+		if(!stack.isEmpty())
 			return stack;
 		return super.getPickBlock(state, target, world, pos, player);
 	}
@@ -66,6 +66,6 @@ public abstract class BlockIEMultiblock<E extends Enum<E> & BlockIEBase.IBlockEn
 		TileEntity te = world.getTileEntity(pos);
 		if(te instanceof TileEntityMultiblockPart)
 			return ((TileEntityMultiblockPart)te).getOriginalBlock();
-		return null;
+		return ItemStack.EMPTY;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityAssembler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityAssembler.java
@@ -590,12 +590,12 @@ public class TileEntityAssembler extends TileEntityMultiblockMetal<TileEntityAss
 			ItemStack stack = getStackInSlot(slot);
 			if(slot<9 && !stack.isEmpty())
 				if(stack.getCount() <= amount)
-					setInventorySlotContents(slot, null);
+					setInventorySlotContents(slot, ItemStack.EMPTY);
 				else
 				{
 					stack = stack.splitStack(amount);
 					if(stack.getCount() == 0)
-						setInventorySlotContents(slot, null);
+						setInventorySlotContents(slot, ItemStack.EMPTY);
 				}
 			return stack;
 		}
@@ -604,7 +604,7 @@ public class TileEntityAssembler extends TileEntityMultiblockMetal<TileEntityAss
 		{
 			ItemStack stack = getStackInSlot(slot);
 			if (!stack.isEmpty())
-				setInventorySlotContents(slot, null);
+				setInventorySlotContents(slot, ItemStack.EMPTY);
 			return stack;
 		}
 		@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityAssembler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityAssembler.java
@@ -629,7 +629,7 @@ public class TileEntityAssembler extends TileEntityMultiblockMetal<TileEntityAss
 		{
 			InventoryCrafting invC = Utils.InventoryCraftingFalse.createFilledCraftingInventory(3, 3, inv);
 			this.recipe = Utils.findRecipe(invC, tile.getWorld());
-			this.inv.set(9, recipe!=null?recipe.getCraftingResult(invC):null);
+			this.inv.set(9, recipe!=null?recipe.getCraftingResult(invC):ItemStack.EMPTY);
 		}
 		public ArrayList<ItemStack> getTotalPossibleOutputs()
 		{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityBucketWheel.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityBucketWheel.java
@@ -101,7 +101,7 @@ public class TileEntityBucketWheel extends TileEntityMultiblockPart<TileEntityBu
 			if(!particleStack.isEmpty())
 			{
 				ImmersiveEngineering.proxy.spawnBucketWheelFX(this, particleStack);
-				particleStack = null;
+				particleStack = ItemStack.EMPTY;
 			}
 		}
 		else if (active&&world.getTotalWorldTime()%20==0)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityExcavator.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityExcavator.java
@@ -16,6 +16,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -245,7 +246,7 @@ public class TileEntityExcavator extends TileEntityMultiblockMetal<TileEntityExc
 				{
 					ArrayList<ItemStack> items = new ArrayList<ItemStack>();
 					Item bitem = Item.getItemFromBlock(block);
-					if(bitem==null)
+					if(bitem== Items.AIR)
 						return ItemStack.EMPTY;
 					ItemStack itemstack = new ItemStack(bitem, 1, block.getMetaFromState(blockstate));
 					if (!itemstack.isEmpty())
@@ -265,7 +266,7 @@ public class TileEntityExcavator extends TileEntityMultiblockMetal<TileEntityExc
 				}
 				else
 				{
-					block.harvestBlock(world, fakePlayer, pos, blockstate, world.getTileEntity(pos), null);
+					block.harvestBlock(world, fakePlayer, pos, blockstate, world.getTileEntity(pos), ItemStack.EMPTY);
 					world.playEvent(2001, pos, Block.getStateId(blockstate));
 				}
 			}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/stone/TileEntityBlastFurnace.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/stone/TileEntityBlastFurnace.java
@@ -14,6 +14,7 @@ import blusunrize.immersiveengineering.common.util.Utils;
 import blusunrize.immersiveengineering.common.util.inventory.IIEInventory;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -281,7 +282,7 @@ public class TileEntityBlastFurnace extends TileEntityMultiblockPart<TileEntityB
 						}
 						if(startPos.add(xx, yy, zz).equals(getPos()))
 							s = this.getOriginalBlock();
-						if(!s.isEmpty() && Block.getBlockFromItem(s.getItem())!=null)
+						if(!s.isEmpty() && Block.getBlockFromItem(s.getItem())!= Blocks.AIR)
 						{
 							if(startPos.add(xx, yy, zz).equals(getPos()))
 								world.spawnEntity(new EntityItem(world, getPos().getX()+.5,getPos().getY()+.5,getPos().getZ()+.5, s));

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/stone/TileEntityBlastFurnaceAdvanced.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/stone/TileEntityBlastFurnaceAdvanced.java
@@ -135,7 +135,7 @@ public class TileEntityBlastFurnaceAdvanced extends TileEntityBlastFurnace
 							}
 							if(startPos.add(xx, yy, zz).equals(getPos()))
 								s = this.getOriginalBlock();
-							if(!s.isEmpty() && Block.getBlockFromItem(s.getItem())!=null)
+							if(!s.isEmpty() && Block.getBlockFromItem(s.getItem())!=Blocks.AIR)
 							{
 								if(startPos.add(xx, yy, zz).equals(getPos()))
 									world.spawnEntity(new EntityItem(world, getPos().getX()+.5,getPos().getY()+.5,getPos().getZ()+.5, s));

--- a/src/main/java/blusunrize/immersiveengineering/common/crafting/RecipeShapelessIngredient.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/crafting/RecipeShapelessIngredient.java
@@ -112,7 +112,7 @@ public class RecipeShapelessIngredient extends ShapelessOreRecipe
 				{
 					tool.setItemDamage(tool.getItemDamage() + 1);
 					if(tool.getItemDamage() > tool.getMaxDamage())
-						tool = null;
+						tool = ItemStack.EMPTY;
 					remains.set(i, tool);
 				}
 			}

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/EntityIEExplosive.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/EntityIEExplosive.java
@@ -7,6 +7,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.MoverType;
 import net.minecraft.entity.item.EntityTNTPrimed;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
@@ -91,7 +92,7 @@ public class EntityIEExplosive extends EntityTNTPrimed
 		if(this.block!=null && name==null)
 		{
 			ItemStack s = new ItemStack(this.block.getBlock(),1,this.block.getBlock().getMetaFromState(this.block));
-			if(!s.isEmpty() && s.getItem()!=null)
+			if(!s.isEmpty() && s.getItem()!= Items.AIR)
 				name = s.getDisplayName();
 		}
 		if(name!=null)

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemFluorescentTube.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemFluorescentTube.java
@@ -48,7 +48,7 @@ public class ItemFluorescentTube extends ItemIEBase implements IConfigurableTool
 				if (stack.getCount()>0)
 					player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, stack);
 				else
-					player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, null);
+					player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStack.EMPTY);
 			}
 			return EnumActionResult.SUCCESS;
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemIETool.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemIETool.java
@@ -219,7 +219,7 @@ public class ItemIETool extends ItemIEBase implements ITool, IGuiItem
 				else
 				{
 					player.renderBrokenItemStack(stack);
-					player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, null);
+					player.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, ItemStack.EMPTY);
 				}
 			}
 			return EnumActionResult.SUCCESS;

--- a/src/main/java/blusunrize/lib/manual/ManualPages.java
+++ b/src/main/java/blusunrize/lib/manual/ManualPages.java
@@ -9,6 +9,7 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
@@ -490,7 +491,7 @@ public abstract class ManualPages implements IManualPage
 						while(itValidate.hasNext())
 						{
 							ItemStack stVal = itValidate.next();
-							if(stVal.isEmpty() || stVal.getItem()==null || stVal.getDisplayName()==null)
+							if(stVal.isEmpty() || stVal.getItem()== Items.AIR || stVal.getDisplayName()==null)
 								itValidate.remove();
 						}
 					}


### PR DESCRIPTION
Added a remapper as discussed on IRC yesterday. It allows worlds from MC1.10 to load in MC1.11. Also fixed a bunch of null ItemStack issues: The ones in the first commit happened when I tried to load my 1.10 dev world, the other ones where found by having IDEA show all issues related to null's and contant expressions.