### PR TITLE
Kobalt Tweaks

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/IERecipes.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IERecipes.java
@@ -80,10 +80,10 @@ public class IERecipes
 		addOredictRecipe(new ItemStack(IEContent.itemMaterial,1,15), " I ","ICI"," I ", 'I',"ingotSteel",'C',componentIron);
 		addOredictRecipe(new ItemStack(IEContent.itemMaterial,1,16), "I  ","II "," II", 'I',"ingotSteel");
 
-		addShapelessIngredientRecipe(new ItemStack(IEContent.itemMaterial, 1, 20), "plateCopper", cutters).setToolDamageRecipe(1);
-		addShapelessIngredientRecipe(new ItemStack(IEContent.itemMaterial, 1, 21), "plateElectrum", cutters).setToolDamageRecipe(1);
-		addShapelessIngredientRecipe(new ItemStack(IEContent.itemMaterial, 1, 22), "plateAluminum", cutters).setToolDamageRecipe(1);
-		addShapelessIngredientRecipe(new ItemStack(IEContent.itemMaterial, 1, 23), "plateSteel", cutters).setToolDamageRecipe(1);
+		addShapelessIngredientRecipe(new ItemStack(IEContent.itemMaterial, 4, 20), "plateCopper", cutters).setToolDamageRecipe(1);
+		addShapelessIngredientRecipe(new ItemStack(IEContent.itemMaterial, 4, 21), "plateElectrum", cutters).setToolDamageRecipe(1);
+		addShapelessIngredientRecipe(new ItemStack(IEContent.itemMaterial, 4, 22), "plateAluminum", cutters).setToolDamageRecipe(1);
+		addShapelessIngredientRecipe(new ItemStack(IEContent.itemMaterial, 4, 23), "plateSteel", cutters).setToolDamageRecipe(1);
 
 		//		addOredictRecipe(new ItemStack(IEContent.itemMaterial,4,14), "I","I", 'I',"ingotIron");
 		//		addOredrrictRecipe(new ItemStack(IEContent.itemMaterial,4,15), "I","I", 'I',"ingotSteel");
@@ -623,7 +623,7 @@ public class IERecipes
 					if(ApiUtils.isExistingOreName("ingot"+ore))
 					{
 						registeredMoldBases.putAll("wire",OreDictionary.getOres(name));
-						MetalPressRecipe.addRecipe(Utils.copyStackWithAmount(IEApi.getPreferredOreStack(name),2), "ingot"+ore, new ItemStack(IEContent.itemMold,1,4), 2400);
+						MetalPressRecipe.addRecipe(Utils.copyStackWithAmount(IEApi.getPreferredOreStack(name),8), "ingot"+ore, new ItemStack(IEContent.itemMold,1,4), 2400);
 					}
 				}
 		if(registeredMoldBases.containsKey("plate"))

--- a/src/main/java/blusunrize/immersiveengineering/common/IERecipes.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IERecipes.java
@@ -502,6 +502,7 @@ public class IERecipes
 			oreOutputModifier.put("Firestone", new ItemStack(item));
 		oreOutputSecondaries.put("Nikolite", new Object[]{Items.DIAMOND,.025f});
 
+		addCrusherRecipe(new ItemStack(Items.MELON, 7), Blocks.MELON_BLOCK, 800);
 		addCrusherRecipe(new ItemStack(Blocks.GRAVEL), "cobblestone", 1600);
 		addCrusherRecipe(new ItemStack(Blocks.SAND), Blocks.GRAVEL, 1600);
 		addCrusherRecipe(new ItemStack(Blocks.SAND), "itemSlag", 1600);

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/TileEntityWoodenBarrel.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/TileEntityWoodenBarrel.java
@@ -72,15 +72,7 @@ public class TileEntityWoodenBarrel extends TileEntityIEBase implements ITickabl
 	@Override
 	public String[] getOverlayText(EntityPlayer player, RayTraceResult mop, boolean hammer)
 	{
-		if(Utils.isFluidRelatedItemStack(player.getHeldItem(EnumHand.MAIN_HAND)))
-		{
-			String s = null;
-			if(tank.getFluid()!=null)
-				s = tank.getFluid().getLocalizedName()+": "+tank.getFluidAmount()+"mB";
-			else
-				s = I18n.format(Lib.GUI+"empty");
-			return new String[]{s};
-		}
+
 		if(hammer && IEConfig.colourblindSupport && mop.sideHit.getAxis()==Axis.Y)
 		{
 			int i = sideConfig[Math.min(sideConfig.length-1, mop.sideHit.ordinal())];
@@ -92,7 +84,14 @@ public class TileEntityWoodenBarrel extends TileEntityIEBase implements ITickabl
 							+": "+ I18n.format(Lib.DESC_INFO+"blockSide.connectFluid."+j)
 			};
 		}
-		return null;
+
+        String s = null;
+        if(tank.getFluid()!=null)
+            s = tank.getFluid().getLocalizedName()+": "+tank.getFluidAmount()+"mB";
+        else
+            s = I18n.format(Lib.GUI+"empty");
+        return new String[]{s};
+
 	}
 	@Override
 	public boolean useNixieFont(EntityPlayer player, RayTraceResult mop)


### PR DESCRIPTION
Minor tweaks and game balance adjustments.
-Crusher will now 'crush' melons into melon slices
-The barrel (wooden and metal) will now show their contents regardless of what you are holding.
-Yield from crafting wires was adjusted to feel more balanced. This is also reflected on the metal press, allowing it to remain the most cost effective way of producing it.