### PR TITLE
Updated en_us.lang

### DIFF
--- a/src/main/resources/assets/immersiveengineering/lang/en_us.lang
+++ b/src/main/resources/assets/immersiveengineering/lang/en_us.lang
@@ -1028,7 +1028,7 @@ ie.manual.entry.cokeovenBlock=To form a Coke Oven, arrange 27 of these blocks in
 
 ie.manual.entry.alloysmelter.name=Alloy Kiln
 ie.manual.entry.alloysmelter.subtext=Mixin' Metals
-ie.manual.entry.alloysmelter0=The Alloy Kiln is a simple furnace made out of heat resistant sandstone and bricks. Within it, temperatures are high enough to allow metals to be melted into a fluid state and mixed, creating an <link;alloys;§o§nalloy§r>.<br>This allows the creation of important alloys like Electrum and Constantan without requiring  the tedious mixing of dusts.
+ie.manual.entry.alloysmelter0=The Alloy Kiln is a simple furnace made out of heat resistant sandstone and bricks. Within it, temperatures are high enough to allow metals to be melted into a fluid state and mixed, creating an <link;alloys;§o§nalloy§r>.<br>This allows the creation of important alloys like Electrum and Constantan without requiring the tedious mixing of dusts.
 ie.manual.entry.alloysmelter1=To form the Kiln, arrange 8 of the Kiln Bricks in a 2x2x2 cube, as shown above, and rightclick one of the sides' blocks with an Engineer's Hammer.
 
 ie.manual.entry.treatedwood.name=Treated Wood

--- a/src/main/resources/assets/immersiveengineering/lang/en_us.lang
+++ b/src/main/resources/assets/immersiveengineering/lang/en_us.lang
@@ -1028,7 +1028,7 @@ ie.manual.entry.cokeovenBlock=To form a Coke Oven, arrange 27 of these blocks in
 
 ie.manual.entry.alloysmelter.name=Alloy Kiln
 ie.manual.entry.alloysmelter.subtext=Mixin' Metals
-ie.manual.entry.alloysmelter0=The Alloy Kiln is a simple furnace mate out of heatresistant sandstone and bricks. Within it, temperatures are high enough to allow metals to be melted into a fluid state and mixed, creating an <link;alloys;§o§nalloy§r>.<br>This allows the creation of important alloys like Electrum and Constantan without requiring tedious mixing of dusts.
+ie.manual.entry.alloysmelter0=The Alloy Kiln is a simple furnace made out of heat resistant sandstone and bricks. Within it, temperatures are high enough to allow metals to be melted into a fluid state and mixed, creating an <link;alloys;§o§nalloy§r>.<br>This allows the creation of important alloys like Electrum and Constantan without requiring  the tedious mixing of dusts.
 ie.manual.entry.alloysmelter1=To form the Kiln, arrange 8 of the Kiln Bricks in a 2x2x2 cube, as shown above, and rightclick one of the sides' blocks with an Engineer's Hammer.
 
 ie.manual.entry.treatedwood.name=Treated Wood


### PR DESCRIPTION
changed `..furnace mate out of heatresistant...` to `...furnace made out of heat resistant`.
changed `...without requiring tedious mixing of dusts.` to `...without requiring the tedious mixing of dusts.`

`heatresistant` is not a a compound word that I am aware of, and just looks awkward
Im pretty sure `mate` is used incorrectly here, and `made` fits much better
added 'the' for emphasis and clarity, imho it reads better.

