### PR TITLE
Fix (potential) model issues being caused by handling ItemBlocks twice

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
@@ -97,6 +97,7 @@ import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
@@ -319,6 +320,8 @@ public class ClientProxy extends CommonProxy
 
 		for(Item item : IEContent.registeredIEItems)
 		{
+			if(item instanceof ItemBlock)
+				continue;
 			if(item instanceof ItemIEBase)
 			{
 				ItemIEBase ieMetaItem = (ItemIEBase)item;


### PR DESCRIPTION
It seems that your adjustments for the 1.12 registry rewrite caused some unexpected model issues. Namely, the item representations of blocks are now part of `IEContent.registeredIEItems`, so `ClientProxy.registerModels` would try to register model definitions for all blocks twice. This was only noticeable ingame for the fluid block items, but might have occurred elsewhere as well. As such, this fixes #2320. I quite honestly don't understand why you're using a `ItemMeshDefinition` for the fluids, considering you could do the same with `setCustomModelResourceLocation`, but I didn't change it because you probably have your reasons and I wanted to keep the changes to a minimum.