### PR TITLE
Craft tweaker diesel

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/energy/DieselHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/energy/DieselHandler.java
@@ -66,4 +66,14 @@ public class DieselHandler
 	{
 		return fuel != null && drillFuel.contains(fuel);
 	}
+	
+	public static void removeFuel(Fluid fuel){
+		if(fuel != null){
+			dieselGenBurnTime.remove(fuel.getName());
+		}
+	}
+	
+	public static void removeDrillFuel(Fluid fuel){
+		drillFuel.remove(fuel);
+	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/CraftTweakerHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/CraftTweakerHelper.java
@@ -30,6 +30,7 @@ public class CraftTweakerHelper extends IECompatModule
 		CraftTweakerAPI.registerClass(BottlingMachine.class);
 		CraftTweakerAPI.registerClass(MetalPress.class);
 		CraftTweakerAPI.registerClass(Mixer.class);
+		CraftTweakerAPI.registerClass(DieselHelper.class);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/DieselHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/DieselHelper.java
@@ -13,29 +13,21 @@ import stanhebben.zenscript.annotations.ZenMethod;
 public class DieselHelper
 {
     @ZenMethod
-    public static void addFuel(ILiquidStack fuel, int time, boolean drill)
-    {
-    	
-        CraftTweakerAPI.apply(new Add(fuel, time, drill));
-    }
-    
-    @ZenMethod
     public static void addFuel(ILiquidStack fuel, int time)
     {
-        addFuel(fuel, time, false);
+    	
+        CraftTweakerAPI.apply(new AddFuel(fuel, time));
     }
-
-    private static class Add implements IAction
+    
+    private static class AddFuel implements IAction
     {
         private final ILiquidStack fuel;
         private final int time;
-        private final boolean drill;
 
-        public Add(ILiquidStack fuel, int time, boolean drill)
+        public AddFuel(ILiquidStack fuel, int time)
         {
             this.fuel = fuel;
             this.time = time;
-            this.drill = drill;
         }
 
         @Override
@@ -43,15 +35,41 @@ public class DieselHelper
         {
         	Fluid fuelFluid = FluidRegistry.getFluid(fuel.getName());
         	DieselHandler.registerFuel(fuelFluid, time);
-            if(drill){
-            	DieselHandler.registerDrillFuel(fuelFluid);
-            }
         }
 
         @Override
         public String describe()
         {
-            return "Registering Fuel " + fuel.getDisplayName();
+            return "Registering Diesel Generator Fuel " + fuel.getDisplayName();
+        }
+    }
+    
+    @ZenMethod
+    public static void addDrillFuel(ILiquidStack fuel)
+    {
+    	CraftTweakerAPI.apply(new AddDrillFuel(fuel));
+    }
+    
+    private static class AddDrillFuel implements IAction
+    {
+        private final ILiquidStack fuel;
+
+        public AddDrillFuel(ILiquidStack fuel)
+        {
+            this.fuel = fuel;
+        }
+
+        @Override
+        public void apply()
+        {
+        	Fluid fuelFluid = FluidRegistry.getFluid(fuel.getName());    
+        	DieselHandler.registerDrillFuel(fuelFluid);
+        }
+
+        @Override
+        public String describe()
+        {
+            return "Registering Drill Fuel " + fuel.getDisplayName();
         }
     }
 

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/DieselHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/DieselHelper.java
@@ -1,0 +1,58 @@
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker;
+
+import blusunrize.immersiveengineering.api.energy.DieselHandler;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
+import crafttweaker.api.liquid.ILiquidStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.immersiveengineering.DieselHandler")
+public class DieselHelper
+{
+    @ZenMethod
+    public static void addFuel(ILiquidStack fuel, int time, boolean drill)
+    {
+    	
+        CraftTweakerAPI.apply(new Add(fuel, time, drill));
+    }
+    
+    @ZenMethod
+    public static void addFuel(ILiquidStack fuel, int time)
+    {
+        addFuel(fuel, time, false);
+    }
+
+    private static class Add implements IAction
+    {
+        private final ILiquidStack fuel;
+        private final int time;
+        private final boolean drill;
+
+        public Add(ILiquidStack fuel, int time, boolean drill)
+        {
+            this.fuel = fuel;
+            this.time = time;
+            this.drill = drill;
+        }
+
+        @Override
+        public void apply()
+        {
+        	Fluid fuelFluid = FluidRegistry.getFluid(fuel.getName());
+        	DieselHandler.registerFuel(fuelFluid, time);
+            if(drill){
+            	DieselHandler.registerDrillFuel(fuelFluid);
+            }
+        }
+
+        @Override
+        public String describe()
+        {
+            return "Registering Fuel " + fuel.getDisplayName();
+        }
+    }
+
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/DieselHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/DieselHelper.java
@@ -72,5 +72,62 @@ public class DieselHelper
             return "Registering Drill Fuel " + fuel.getDisplayName();
         }
     }
+    
+    @ZenMethod
+    public static void removeFuel(ILiquidStack fuel){
+    	CraftTweakerAPI.apply(new RemoveFuel(fuel));
+    }
+    
+    private static class RemoveFuel implements IAction
+    {
+        private final ILiquidStack fuel;
+
+        public RemoveFuel(ILiquidStack fuel)
+        {
+            this.fuel = fuel;
+        }
+
+        @Override
+        public void apply()
+        {
+        	Fluid fuelFluid = FluidRegistry.getFluid(fuel.getName());    
+        	DieselHandler.removeFuel(fuelFluid);
+        }
+
+        @Override
+        public String describe()
+        {
+            return "Removing Fuel " + fuel.getDisplayName();
+        }
+    }
+    
+    @ZenMethod
+    public static void removeDrillFuel(ILiquidStack fuel){
+    	CraftTweakerAPI.apply(new RemoveDrillFuel(fuel));
+    }
+    
+    private static class RemoveDrillFuel implements IAction
+    {
+        private final ILiquidStack fuel;
+
+        public RemoveDrillFuel(ILiquidStack fuel)
+        {
+            this.fuel = fuel;
+        }
+
+        @Override
+        public void apply()
+        {
+        	Fluid fuelFluid = FluidRegistry.getFluid(fuel.getName());    
+        	DieselHandler.removeDrillFuel(fuelFluid);
+        }
+
+        @Override
+        public String describe()
+        {
+            return "Removing Drill Fuel " + fuel.getDisplayName();
+        }
+    }
+
 
 }


### PR DESCRIPTION
Exposes the addFuel and addDrillFuel to craftweaker so players can have their DieselGenerators burn whatever they want.

Here's an example script you can use to test these functions/demonstrate usage. 
`
mods.immersiveengineering.DieselHandler.addFuel(<liquid:lava>, 100);
mods.immersiveengineering.DieselHandler.addDrillFuel(<liquid:water>);
`