### PR TITLE
Added indicator for sheetmetal tank content

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/OneProbeHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/OneProbeHelper.java
@@ -15,6 +15,7 @@ import blusunrize.immersiveengineering.api.energy.immersiveflux.IFluxProvider;
 import blusunrize.immersiveengineering.api.energy.immersiveflux.IFluxReceiver;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces;
 import blusunrize.immersiveengineering.common.blocks.TileEntityMultiblockPart;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntitySheetmetalTank;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityTeslaCoil;
 import com.google.common.base.Function;
 import mcjty.theoneprobe.Tools;
@@ -65,8 +66,35 @@ public class OneProbeHelper extends IECompatModule implements Function<ITheOnePr
 		input.registerProvider(new ProcessProvider());
 		input.registerProvider(new TeslaCoilProvider());
 		input.registerProvider(new SideConfigProvider());
+		input.registerProvider(new FluidInfoProvider());
 		input.registerBlockDisplayOverride(new MultiblockDisplayOverride());
 		return null;
+	}
+
+	public static class FluidInfoProvider implements IProbeInfoProvider
+	{
+
+		@Override
+		public String getID() {
+			return ImmersiveEngineering.MODID+":"+"FluidInfo";
+		}
+
+		@Override
+		public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data) {
+			TileEntity te = world.getTileEntity(data.getPos());
+			if(te instanceof TileEntitySheetmetalTank) {
+				TileEntitySheetmetalTank master = ((TileEntitySheetmetalTank) te).master();
+				int current = master.tank.getFluidAmount();
+				int max = master.tank.getCapacity();
+
+				if(current > 0) {
+					probeInfo.progress(current, max,
+							probeInfo.defaultProgressStyle()
+								.suffix("mB")
+								.numberFormat(NumberFormat.COMPACT));
+				}
+			}
+		}
 	}
 
 


### PR DESCRIPTION
The indicator only appears if there is actually content within the tank. I can change that behaviour however. 
I thought about making the colors dynamic and use the fluid color as fill color. But I have no idea how to get a matching text color so they have enough contrast in between. 
The other option would be to use the same style as the IF indicator.
![Screenshot](https://user-images.githubusercontent.com/5113257/34387254-55121b6c-eb2d-11e7-954a-2d4050c8099e.png) Screenshot of the indicator.
Resolves  #2690.


Edit: Just wanted to try dynamic colors out. Looks like `master.tank.getFluid().getFluid().getColor()` doesn't work as I expected. It always returns `0xffffffff`.