### PR TITLE
Show fluid amount in barrel with TOP

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/OneProbeHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/OneProbeHelper.java
@@ -17,6 +17,7 @@ import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces;
 import blusunrize.immersiveengineering.common.blocks.TileEntityMultiblockPart;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntitySheetmetalTank;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityTeslaCoil;
+import blusunrize.immersiveengineering.common.blocks.wooden.TileEntityWoodenBarrel;
 import com.google.common.base.Function;
 import mcjty.theoneprobe.Tools;
 import mcjty.theoneprobe.api.*;
@@ -93,6 +94,17 @@ public class OneProbeHelper extends IECompatModule implements Function<ITheOnePr
 								.suffix("mB")
 								.numberFormat(NumberFormat.COMPACT));
 				}
+			}
+			if(te instanceof TileEntityWoodenBarrel) {
+				TileEntityWoodenBarrel barrel = (TileEntityWoodenBarrel) te;
+				int current = barrel.tank.getFluidAmount();
+				int capacity = barrel.tank.getCapacity();
+				if (current>0) {
+                    			probeInfo.progress(current, capacity,
+                            			probeInfo.defaultProgressStyle()
+	                                    	.suffix("mB")
+                                    		.numberFormat(NumberFormat.COMPACT));
+		                }
 			}
 		}
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/OneProbeHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/OneProbeHelper.java
@@ -18,10 +18,12 @@ import blusunrize.immersiveengineering.common.blocks.TileEntityMultiblockPart;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntitySheetmetalTank;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityTeslaCoil;
 import blusunrize.immersiveengineering.common.blocks.wooden.TileEntityWoodenBarrel;
+import blusunrize.immersiveengineering.common.util.IELogger;
 import com.google.common.base.Function;
 import mcjty.theoneprobe.Tools;
 import mcjty.theoneprobe.api.*;
 import mcjty.theoneprobe.config.Config;
+import net.minecraft.block.material.MapColor;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -30,6 +32,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
 
 import javax.annotation.Nullable;
@@ -98,13 +101,18 @@ public class OneProbeHelper extends IECompatModule implements Function<ITheOnePr
 			if(te instanceof TileEntityWoodenBarrel) {
 				TileEntityWoodenBarrel barrel = (TileEntityWoodenBarrel) te;
 				int current = barrel.tank.getFluidAmount();
-				int capacity = barrel.tank.getCapacity();
-				if (current>0) {
-                    			probeInfo.progress(current, capacity,
-                            			probeInfo.defaultProgressStyle()
-	                                    	.suffix("mB")
-                                    		.numberFormat(NumberFormat.COMPACT));
-		                }
+				if (current > 0) {
+					int capacity = barrel.tank.getCapacity();
+					MapColor fluidMapColor = barrel.tank.getFluid().getFluid().getBlock().getDefaultState().getMaterial().getMaterialMapColor();
+					int color = 0xFF000000 | fluidMapColor.colorValue;
+					probeInfo.progress(current, capacity,
+                            probeInfo.defaultProgressStyle()
+                                .suffix("mB")
+                                .numberFormat(NumberFormat.COMPACT)
+								.filledColor(color)
+								.alternateFilledColor(color)
+					);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I feel a little bit inconvenient to check the amount of fluid in barrel that you have to hold a bucket or something when I play. So I add it to TOP.

I also tried to get a proper fill color for the fluid as you mentioned  at #2697, but `barrel.tank.getFluid().getFluid().getColor(barrel.tank.getFluid())` seems always return `-1`.

![1](https://user-images.githubusercontent.com/14210201/34470631-b374b132-ef70-11e7-9562-78e42a2b3990.png)