### PR TITLE
[BWM Compat] Add Drill to shovel toolclass to comply with HCPiles

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/items/ItemDrill.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ItemDrill.java
@@ -397,7 +397,7 @@ public class ItemDrill extends ItemUpgradeableTool implements IAdvancedFluidItem
 	public Set<String> getToolClasses(ItemStack stack)
 	{
 		if(!getHead(stack).isEmpty() && !isDrillBroken(stack))
-			return ImmutableSet.of("pickaxe");
+			return ImmutableSet.of("pickaxe", "shovel");
 		return super.getToolClasses(stack);
 	}
 


### PR DESCRIPTION
Due to a feature in Better With Mods dirt, gravel and other soils don't drop their full block unless mined by a "shovel" toolclass. By adding the drill to this class it shouldn't change anything but make it interact with BWM correctly