### PR TITLE
Add Beetroot Seeds to Squeezer Recipes

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/IEContent.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IEContent.java
@@ -378,6 +378,7 @@ public class IEContent
 		IERecipes.initArcSmeltingRecipes();
 
 		SqueezerRecipe.addRecipe(new FluidStack(fluidPlantoil, 80), ItemStack.EMPTY, Items.WHEAT_SEEDS, 6400);
+		SqueezerRecipe.addRecipe(new FluidStack(fluidPlantoil, 60), ItemStack.EMPTY, Items.BEETROOT_SEEDS, 6400);
 		SqueezerRecipe.addRecipe(new FluidStack(fluidPlantoil, 40), ItemStack.EMPTY, Items.PUMPKIN_SEEDS, 6400);
 		SqueezerRecipe.addRecipe(new FluidStack(fluidPlantoil, 20), ItemStack.EMPTY, Items.MELON_SEEDS, 6400);
 		SqueezerRecipe.addRecipe(new FluidStack(fluidPlantoil, 120), ItemStack.EMPTY, itemSeeds, 6400);


### PR DESCRIPTION
You already have the BEETROOT_SEEDS registered in your ItemStack, but they were not used anywhere. I placed them in my squeezer the other day and it didn't work.

Simple fix and I put them providing 60 mB which is between WHEAT_SEEDS and PUMPKIN_SEEDS. Feel free to change that if needed.