### PR TITLE
Fix spawn interdictors (Electric Lanterns, etc) not being removed on unload

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockFakeLight.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockFakeLight.java
@@ -141,10 +141,16 @@ public class BlockFakeLight extends BlockIETileProvider<BlockTypes_FakeLight>
 		public void invalidate()
 		{
 			synchronized (EventHandler.interdictionTiles) {
-				if (EventHandler.interdictionTiles.contains(this))
-					EventHandler.interdictionTiles.remove(this);
+				EventHandler.interdictionTiles.remove(this);
 			}
 			super.invalidate();
+		}
+		@Override
+		public void onChunkUnload(){
+			synchronized (EventHandler.interdictionTiles) {
+				EventHandler.interdictionTiles.remove(this);
+			}
+			super.onChunkUnload();
 		}
 		@Override
 		public void readCustomNBT(NBTTagCompound nbt, boolean descPacket)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityElectricLantern.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityElectricLantern.java
@@ -73,12 +73,19 @@ public class TileEntityElectricLantern extends TileEntityImmersiveConnectable im
 	public void invalidate()
 	{
 		synchronized (EventHandler.interdictionTiles) {
-			if (EventHandler.interdictionTiles.contains(this))
-				EventHandler.interdictionTiles.remove(this);
+			EventHandler.interdictionTiles.remove(this);
 		}
 		super.invalidate();
 	}
-	
+
+	@Override
+	public void onChunkUnload(){
+		synchronized (EventHandler.interdictionTiles) {
+			EventHandler.interdictionTiles.remove(this);
+		}
+		super.onChunkUnload();
+	}
+
 	@Override
 	public void readCustomNBT(NBTTagCompound nbt, boolean descPacket)
 	{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFloodlight.java
@@ -268,10 +268,17 @@ public class TileEntityFloodlight extends TileEntityImmersiveConnectable impleme
 	public void invalidate()
 	{
 		synchronized (EventHandler.interdictionTiles) {
-			if (EventHandler.interdictionTiles.contains(this))
-				EventHandler.interdictionTiles.remove(this);
+			EventHandler.interdictionTiles.remove(this);
 		}
 		super.invalidate();
+	}
+
+	@Override
+	public void onChunkUnload(){
+		synchronized (EventHandler.interdictionTiles) {
+			EventHandler.interdictionTiles.remove(this);
+		}
+		super.onChunkUnload();
 	}
 
 	@Override


### PR DESCRIPTION
My mob spawners weren't working. I noticed they were in range of the
electric lantern and removed it. The spawners continued to not work.
I set a breakpoint in `onEntitySpawnCheck` and saw the lantern was still
in the `interdictionTiles` list, preventing mob spawns and consuming
memory.

Also removes pointless calls to `ArrayList.contains`, improving
performance; the docs for `remove` state that "If the list does not
contain the element, it is unchanged."