### PR TITLE
Fix obstructed connections not rendering or disappearing too fast on LAN server

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/ApiUtils.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/ApiUtils.java
@@ -22,6 +22,7 @@ import blusunrize.immersiveengineering.common.IESaveData;
 import blusunrize.immersiveengineering.common.util.ItemNBTHelper;
 import blusunrize.immersiveengineering.common.util.Utils;
 import blusunrize.immersiveengineering.common.util.chickenbones.Matrix4;
+import blusunrize.immersiveengineering.common.util.network.MessageObstructedConnection;
 import com.google.common.util.concurrent.AtomicDouble;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -51,6 +52,7 @@ import net.minecraftforge.client.model.pipeline.IVertexConsumer;
 import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
@@ -725,7 +727,9 @@ public class ApiUtils
 									else
 									{
 										player.sendStatusMessage(new TextComponentTranslation(Lib.CHAT_WARN+"cantSee"), true);
-										ImmersiveEngineering.proxy.addFailedConnection(tmpConn, failedReason, player);
+										ImmersiveEngineering.packetHandler.sendToAllAround(new MessageObstructedConnection(tmpConn, failedReason, player.world),
+											new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.posX, player.posY, player.posZ,
+												64));
 									}
 								}
 							}

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientEventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientEventHandler.java
@@ -136,58 +136,60 @@ public class ClientEventHandler implements IResourceManagerReloadListener
 	@SubscribeEvent
 	public void onPlayerTick(TickEvent.PlayerTickEvent event)
 	{
-		if(event.side.isClient()&&event.phase==Phase.START&&event.player!=null&&event.player==ClientUtils.mc().getRenderViewEntity())
-		{
-			skyhookGrabableConnections.clear();
-			EntityPlayer player = event.player;
-			ItemStack stack = player.getActiveItemStack();
-			if(!stack.isEmpty()&&stack.getItem() instanceof ItemSkyhook)
+	    if(event.side.isClient()&&event.player!=null&&event.player==ClientUtils.mc().getRenderViewEntity())
+	    {
+	    	if(event.phase==Phase.START)
 			{
-				Connection line = ApiUtils.getTargetConnection(player.getEntityWorld(), player, null, 0);
-				if(line!=null)
-					skyhookGrabableConnections.add(line);
-			}
-		}
-
-		FAILED_CONNECTIONS.entrySet().removeIf(entry -> entry.getValue().getValue().decrementAndGet() <= 0);
-
-		if(event.side.isClient()&&event.phase==Phase.END&&event.player!=null)
-		{
-			if(this.shieldToggleTimer > 0)
-				this.shieldToggleTimer--;
-			if(ClientProxy.keybind_magnetEquip.isKeyDown()&&!this.shieldToggleButton)
-				if(this.shieldToggleTimer <= 0)
-					this.shieldToggleTimer = 7;
-				else
+				skyhookGrabableConnections.clear();
+				EntityPlayer player = event.player;
+				ItemStack stack = player.getActiveItemStack();
+				if(!stack.isEmpty()&&stack.getItem() instanceof ItemSkyhook)
 				{
-					EntityPlayer player = event.player;
-					ItemStack held = player.getHeldItem(EnumHand.OFF_HAND);
-					if(!held.isEmpty()&&held.getItem() instanceof ItemIEShield)
-					{
-						if(((ItemIEShield)held.getItem()).getUpgrades(held).getBoolean("magnet")&&((ItemIEShield)held.getItem()).getUpgrades(held).hasKey("prevSlot"))
-							ImmersiveEngineering.packetHandler.sendToServer(new MessageMagnetEquip(-1));
-					}
+					Connection line = ApiUtils.getTargetConnection(player.getEntityWorld(), player, null, 0);
+					if(line!=null)
+						skyhookGrabableConnections.add(line);
+				}
+			}
+
+			if(event.phase==Phase.END)
+			{
+				if(this.shieldToggleTimer > 0)
+					this.shieldToggleTimer--;
+				if(ClientProxy.keybind_magnetEquip.isKeyDown()&&!this.shieldToggleButton)
+					if(this.shieldToggleTimer <= 0)
+						this.shieldToggleTimer = 7;
 					else
 					{
-						for(int i = 0; i < player.inventory.mainInventory.size(); i++)
+						EntityPlayer player = event.player;
+						ItemStack held = player.getHeldItem(EnumHand.OFF_HAND);
+						if(!held.isEmpty()&&held.getItem() instanceof ItemIEShield)
 						{
-							ItemStack s = player.inventory.mainInventory.get(i);
-							if(!s.isEmpty()&&s.getItem() instanceof ItemIEShield&&((ItemIEShield)s.getItem()).getUpgrades(s).getBoolean("magnet"))
-								ImmersiveEngineering.packetHandler.sendToServer(new MessageMagnetEquip(i));
+							if(((ItemIEShield)held.getItem()).getUpgrades(held).getBoolean("magnet")&&((ItemIEShield)held.getItem()).getUpgrades(held).hasKey("prevSlot"))
+								ImmersiveEngineering.packetHandler.sendToServer(new MessageMagnetEquip(-1));
+						}
+						else
+						{
+							for(int i = 0; i < player.inventory.mainInventory.size(); i++)
+							{
+								ItemStack s = player.inventory.mainInventory.get(i);
+								if(!s.isEmpty()&&s.getItem() instanceof ItemIEShield&&((ItemIEShield)s.getItem()).getUpgrades(s).getBoolean("magnet"))
+									ImmersiveEngineering.packetHandler.sendToServer(new MessageMagnetEquip(i));
+							}
 						}
 					}
+				if(this.shieldToggleButton!=ClientUtils.mc().gameSettings.keyBindBack.isKeyDown())
+					this.shieldToggleButton = ClientUtils.mc().gameSettings.keyBindBack.isKeyDown();
+
+
+				if(ClientProxy.keybind_chemthrowerSwitch.isPressed())
+				{
+					ItemStack held = event.player.getHeldItem(EnumHand.MAIN_HAND);
+					if(held.getItem() instanceof ItemChemthrower&&((ItemChemthrower)held.getItem()).getUpgrades(held).getBoolean("multitank"))
+						ImmersiveEngineering.packetHandler.sendToServer(new MessageChemthrowerSwitch(true));
 				}
-			if(this.shieldToggleButton!=ClientUtils.mc().gameSettings.keyBindBack.isKeyDown())
-				this.shieldToggleButton = ClientUtils.mc().gameSettings.keyBindBack.isKeyDown();
-
-
-			if(ClientProxy.keybind_chemthrowerSwitch.isPressed())
-			{
-				ItemStack held = event.player.getHeldItem(EnumHand.MAIN_HAND);
-				if(held.getItem() instanceof ItemChemthrower&&((ItemChemthrower)held.getItem()).getUpgrades(held).getBoolean("multitank"))
-					ImmersiveEngineering.packetHandler.sendToServer(new MessageChemthrowerSwitch(true));
 			}
 		}
+
 //		if(event.side.isClient() && event.phase == Phase.END && event.player!=null)
 //		{
 //			EntityPlayer player = event.player;
@@ -203,6 +205,12 @@ public class ClientEventHandler implements IResourceManagerReloadListener
 //			}
 //
 //		}
+	}
+
+	@SubscribeEvent
+	public void onClientTick(TickEvent.ClientTickEvent event)
+	{
+		FAILED_CONNECTIONS.entrySet().removeIf(entry -> entry.getValue().getValue().decrementAndGet() <= 0);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
@@ -1700,13 +1700,6 @@ public class ClientProxy extends CommonProxy
 		ConnModelReal.cache.invalidateAll();
 	}
 
-	@Override
-	public void addFailedConnection(ImmersiveNetHandler.Connection connection, BlockPos reason, EntityPlayer player)
-	{
-		ClientEventHandler.FAILED_CONNECTIONS.put(connection,
-				new ImmutablePair<>(reason, new AtomicInteger(200)));
-	}
-
 	static
 	{
 		IEApi.renderCacheClearers.add(IESmartObjModel.modelCache::clear);

--- a/src/main/java/blusunrize/immersiveengineering/common/CommonProxy.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/CommonProxy.java
@@ -232,11 +232,4 @@ public class CommonProxy implements IGuiHandler
 	public void clearRenderCaches()
 	{
 	}
-
-	public void addFailedConnection(Connection connection, BlockPos reason, EntityPlayer player)
-	{
-		ImmersiveEngineering.packetHandler.sendToAllAround(new MessageObstructedConnection(connection, reason, player.world),
-				new TargetPoint(player.world.provider.getDimension(), player.posX, player.posY, player.posZ,
-						64));
-	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/util/network/MessageObstructedConnection.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/network/MessageObstructedConnection.java
@@ -11,6 +11,7 @@ package blusunrize.immersiveengineering.common.util.network;
 import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.energy.wires.ImmersiveNetHandler;
 import blusunrize.immersiveengineering.api.energy.wires.WireType;
+import blusunrize.immersiveengineering.client.ClientEventHandler;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.math.BlockPos;
@@ -20,6 +21,9 @@ import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class MessageObstructedConnection implements IMessage
 {
@@ -71,7 +75,8 @@ public class MessageObstructedConnection implements IMessage
 				ImmersiveNetHandler.Connection conn = new ImmersiveNetHandler.Connection(message.startB, message.endB, message.wireType,
 						(int)Math.sqrt(message.startB.distanceSq(message.endB)));
 				conn.getSubVertices(message.start, message.end);
-				ImmersiveEngineering.proxy.addFailedConnection(conn, message.blocking, null);
+				ClientEventHandler.FAILED_CONNECTIONS.put(conn,
+					new ImmutablePair<>(message.blocking, new AtomicInteger(200)));
 			});
 			return null;
 		}


### PR DESCRIPTION
I believe the intended behavior is an obstructed connection created by a player should be rendered for all players.

Using the current version of IE, the following happens on a LAN server: https://streamable.com/v8zco
The obstructed connection is not rendering for the player that created it. In addition, the obstructed connection disappears twice as fast when there are two players on the LAN server.

With these changes, the following happens: https://streamable.com/xmzsm
The connection renders for both players, and disappears when it should.

This coincidentally also resolves a rare potential concurrency issue where the server thread would mutate `FAILED_CONNECTIONS` while the client is iterating over it.
I have also ensured that the client sided player tick logic for magnets and chemthrower switching only runs for the client player.

I didn't want this fix to be more invasive than necessary, but I did notice the use of AtomicInteger and a HashMap is unnecessary. I could switch to a more efficient and cleaner data structure for the obstructed connections if you would like that.