### PR TITLE
Improve item orientations for various items.

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/tool/ConveyorHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/tool/ConveyorHandler.java
@@ -452,6 +452,21 @@ public class ConveyorHandler
 		{
 			return baseModel;
 		}
+
+		enum TransformOrient {
+			HORIZONAL,
+			VERTICAL
+		}
+
+		/**
+		 * Called to get the orientations used for the item form.
+		 * HORIZONTAL holds it flat, at the back side.
+		 * VERTICAL holds it from the bottom-front of the vertical conveyor.
+		 */
+		@SideOnly(Side.CLIENT)
+		default TransformOrient getModelTransform() {
+			return TransformOrient.HORIZONAL;
+		}
 	}
 
 	public enum ConveyorDirection

--- a/src/main/java/blusunrize/immersiveengineering/client/models/ModelConveyor.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/ModelConveyor.java
@@ -15,6 +15,7 @@ import blusunrize.immersiveengineering.api.tool.ConveyorHandler.ConveyorDirectio
 import blusunrize.immersiveengineering.api.tool.ConveyorHandler.IConveyorBelt;
 import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.common.blocks.metal.BlockConveyor;
+import blusunrize.immersiveengineering.common.blocks.metal.conveyors.ConveyorVertical;
 import blusunrize.immersiveengineering.common.util.ItemNBTHelper;
 import blusunrize.immersiveengineering.common.util.Utils;
 import blusunrize.immersiveengineering.common.util.chickenbones.Matrix4;
@@ -382,23 +383,35 @@ public class ModelConveyor implements IBakedModel
 		}
 	};
 
-	static HashMap<TransformType, Matrix4> transformationMap = new HashMap<TransformType, Matrix4>();
+	static HashMap<TransformType, Matrix4> horizTransformationMap = new HashMap<>();
+	static HashMap<TransformType, Matrix4> vertTransformationMap = new HashMap<>();
 
 	static
 	{
-		transformationMap.put(TransformType.FIRST_PERSON_LEFT_HAND, new Matrix4().scale(.5, .5, .5).translate(0, .25, 0).rotate(Math.toRadians(-45), 0, 1, 0));
-		transformationMap.put(TransformType.FIRST_PERSON_RIGHT_HAND, new Matrix4().scale(.5, .5, .5).translate(0, .25, 0).rotate(Math.toRadians(-45), 0, 1, 0));
-		transformationMap.put(TransformType.THIRD_PERSON_LEFT_HAND, new Matrix4().translate(0, .0625, -.125).scale(.3125, .3125, .3125).rotate(Math.toRadians(30), 1, 0, 0).rotate(Math.toRadians(130), 0, 1, 0));
-		transformationMap.put(TransformType.THIRD_PERSON_RIGHT_HAND, new Matrix4().translate(0, .0625, -.125).scale(.3125, .3125, .3125).rotate(Math.toRadians(30), 1, 0, 0).rotate(Math.toRadians(130), 0, 1, 0));
-		transformationMap.put(TransformType.GUI, new Matrix4().scale(.625, .625, .625).rotate(Math.toRadians(-45), 0, 1, 0).rotate(Math.toRadians(-20), 0, 0, 1).rotate(Math.toRadians(20), 1, 0, 0));
-		transformationMap.put(TransformType.FIXED, new Matrix4().scale(.625, .625, .625).rotate(Math.PI, 0, 1, 0).translate(0, 0, .3125));
-		transformationMap.put(TransformType.GROUND, new Matrix4().scale(.25, .25, .25));
+		horizTransformationMap.put(TransformType.FIRST_PERSON_LEFT_HAND, new Matrix4().scale(.5, .5, .5).translate(0.25, .5, 0));
+		horizTransformationMap.put(TransformType.FIRST_PERSON_RIGHT_HAND, new Matrix4().scale(.5, .5, .5).translate(0.25, .5, 0));
+		horizTransformationMap.put(TransformType.THIRD_PERSON_LEFT_HAND, new Matrix4().translate(0, .125, .125).scale(.3125, .3125, .3125).rotate(Math.toRadians(80), 1, 0, 0));
+		horizTransformationMap.put(TransformType.THIRD_PERSON_RIGHT_HAND, new Matrix4().translate(0, .125, .125).scale(.3125, .3125, .3125).rotate(Math.toRadians(80), 1, 0, 0));
+
+		horizTransformationMap.put(TransformType.GUI, new Matrix4().scale(.625, .625, .625).rotate(Math.toRadians(-45), 0, 1, 0).rotate(Math.toRadians(-20), 0, 0, 1).rotate(Math.toRadians(20), 1, 0, 0));
+		horizTransformationMap.put(TransformType.FIXED, new Matrix4().scale(.625, .625, .625).rotate(Math.PI, 0, 1, 0).translate(0, 0, .3125));
+		horizTransformationMap.put(TransformType.GROUND, new Matrix4().scale(.25, .25, .25));
+
+		vertTransformationMap.put(TransformType.FIRST_PERSON_LEFT_HAND, new Matrix4().translate(0, .25, .25).scale(.3125, .3125, .3125).rotate(Math.toRadians(-25), 1, 0, 0).rotate(Math.toRadians(0), 0, 0, 1));
+		vertTransformationMap.put(TransformType.FIRST_PERSON_RIGHT_HAND, new Matrix4().translate(0, .25, .25).scale(.3125, .3125, .3125).rotate(Math.toRadians(-25), 1, 0, 0).rotate(Math.toRadians(0), 0, 0, 1));
+		vertTransformationMap.put(TransformType.THIRD_PERSON_LEFT_HAND, new Matrix4().translate(0, 0, .225).scale(.3125, .3125, .3125).rotate(Math.toRadians(35), 1, 0, 0));
+		vertTransformationMap.put(TransformType.THIRD_PERSON_RIGHT_HAND, new Matrix4().translate(0, 0, .225).scale(.3125, .3125, .3125).rotate(Math.toRadians(35), 1, 0, 0));
+
+		vertTransformationMap.put(TransformType.GUI, horizTransformationMap.get(TransformType.GUI));
+		vertTransformationMap.put(TransformType.FIXED, horizTransformationMap.get(TransformType.FIXED));
+		vertTransformationMap.put(TransformType.GROUND, horizTransformationMap.get(TransformType.GROUND));
 	}
 
 	@Override
 	public Pair<? extends IBakedModel, Matrix4f> handlePerspective(TransformType cameraTransformType)
 	{
-		Matrix4 matrix = transformationMap.containsKey(cameraTransformType)?transformationMap.get(cameraTransformType): new Matrix4();
+		HashMap<TransformType, Matrix4> transformationMap = conveyor instanceof ConveyorVertical ? vertTransformationMap : horizTransformationMap;
+		Matrix4 matrix = transformationMap.containsKey(cameraTransformType) ? transformationMap.get(cameraTransformType) : new Matrix4();
 		return Pair.of(this, matrix.toMatrix4f());
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/client/models/ModelConveyor.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/ModelConveyor.java
@@ -15,7 +15,6 @@ import blusunrize.immersiveengineering.api.tool.ConveyorHandler.ConveyorDirectio
 import blusunrize.immersiveengineering.api.tool.ConveyorHandler.IConveyorBelt;
 import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.common.blocks.metal.BlockConveyor;
-import blusunrize.immersiveengineering.common.blocks.metal.conveyors.ConveyorVertical;
 import blusunrize.immersiveengineering.common.util.ItemNBTHelper;
 import blusunrize.immersiveengineering.common.util.Utils;
 import blusunrize.immersiveengineering.common.util.chickenbones.Matrix4;
@@ -383,35 +382,49 @@ public class ModelConveyor implements IBakedModel
 		}
 	};
 
-	static HashMap<TransformType, Matrix4> horizTransformationMap = new HashMap<>();
-	static HashMap<TransformType, Matrix4> vertTransformationMap = new HashMap<>();
+	static HashMap<Pair<TransformType, IConveyorBelt.TransformOrient>, Matrix4> transformationMap = new HashMap<>();
 
 	static
 	{
-		horizTransformationMap.put(TransformType.FIRST_PERSON_LEFT_HAND, new Matrix4().scale(.5, .5, .5).translate(0.25, .5, 0));
-		horizTransformationMap.put(TransformType.FIRST_PERSON_RIGHT_HAND, new Matrix4().scale(.5, .5, .5).translate(0.25, .5, 0));
-		horizTransformationMap.put(TransformType.THIRD_PERSON_LEFT_HAND, new Matrix4().translate(0, .125, .125).scale(.3125, .3125, .3125).rotate(Math.toRadians(80), 1, 0, 0));
-		horizTransformationMap.put(TransformType.THIRD_PERSON_RIGHT_HAND, new Matrix4().translate(0, .125, .125).scale(.3125, .3125, .3125).rotate(Math.toRadians(80), 1, 0, 0));
+		Matrix4 mat;
+		mat = new Matrix4().scale(.5, .5, .5).translate(0.25, .5, 0);
+		transformationMap.put(Pair.of(TransformType.FIRST_PERSON_LEFT_HAND, IConveyorBelt.TransformOrient.HORIZONAL), mat);
+		transformationMap.put(Pair.of(TransformType.FIRST_PERSON_RIGHT_HAND, IConveyorBelt.TransformOrient.HORIZONAL), mat);
 
-		horizTransformationMap.put(TransformType.GUI, new Matrix4().scale(.625, .625, .625).rotate(Math.toRadians(-45), 0, 1, 0).rotate(Math.toRadians(-20), 0, 0, 1).rotate(Math.toRadians(20), 1, 0, 0));
-		horizTransformationMap.put(TransformType.FIXED, new Matrix4().scale(.625, .625, .625).rotate(Math.PI, 0, 1, 0).translate(0, 0, .3125));
-		horizTransformationMap.put(TransformType.GROUND, new Matrix4().scale(.25, .25, .25));
+		mat = new Matrix4().translate(0, .125, .125).scale(.3125, .3125, .3125).rotate(Math.toRadians(80), 1, 0, 0);
+		transformationMap.put(Pair.of(TransformType.THIRD_PERSON_LEFT_HAND, IConveyorBelt.TransformOrient.HORIZONAL), mat);
+		transformationMap.put(Pair.of(TransformType.THIRD_PERSON_RIGHT_HAND, IConveyorBelt.TransformOrient.HORIZONAL), mat);
 
-		vertTransformationMap.put(TransformType.FIRST_PERSON_LEFT_HAND, new Matrix4().translate(0, .25, .25).scale(.3125, .3125, .3125).rotate(Math.toRadians(-25), 1, 0, 0).rotate(Math.toRadians(0), 0, 0, 1));
-		vertTransformationMap.put(TransformType.FIRST_PERSON_RIGHT_HAND, new Matrix4().translate(0, .25, .25).scale(.3125, .3125, .3125).rotate(Math.toRadians(-25), 1, 0, 0).rotate(Math.toRadians(0), 0, 0, 1));
-		vertTransformationMap.put(TransformType.THIRD_PERSON_LEFT_HAND, new Matrix4().translate(0, 0, .225).scale(.3125, .3125, .3125).rotate(Math.toRadians(35), 1, 0, 0));
-		vertTransformationMap.put(TransformType.THIRD_PERSON_RIGHT_HAND, new Matrix4().translate(0, 0, .225).scale(.3125, .3125, .3125).rotate(Math.toRadians(35), 1, 0, 0));
+		mat = new Matrix4().translate(0, .25, .25).scale(.3125, .3125, .3125).rotate(Math.toRadians(-25), 1, 0, 0).rotate(Math.toRadians(0), 0, 0, 1);
+		transformationMap.put(Pair.of(TransformType.FIRST_PERSON_LEFT_HAND, IConveyorBelt.TransformOrient.VERTICAL), mat);
+		transformationMap.put(Pair.of(TransformType.FIRST_PERSON_RIGHT_HAND, IConveyorBelt.TransformOrient.VERTICAL), mat);
 
-		vertTransformationMap.put(TransformType.GUI, horizTransformationMap.get(TransformType.GUI));
-		vertTransformationMap.put(TransformType.FIXED, horizTransformationMap.get(TransformType.FIXED));
-		vertTransformationMap.put(TransformType.GROUND, horizTransformationMap.get(TransformType.GROUND));
+		mat = new Matrix4().translate(0, 0, .225).scale(.3125, .3125, .3125).rotate(Math.toRadians(35), 1, 0, 0);
+		transformationMap.put(Pair.of(TransformType.THIRD_PERSON_LEFT_HAND, IConveyorBelt.TransformOrient.VERTICAL), mat);
+		transformationMap.put(Pair.of(TransformType.THIRD_PERSON_RIGHT_HAND, IConveyorBelt.TransformOrient.VERTICAL), mat);
+
+		mat = new Matrix4().scale(.625, .625, .625).rotate(Math.toRadians(-45), 0, 1, 0).rotate(Math.toRadians(-20), 0, 0, 1).rotate(Math.toRadians(20), 1, 0, 0);
+		transformationMap.put(Pair.of(TransformType.GUI, IConveyorBelt.TransformOrient.HORIZONAL), mat);
+		transformationMap.put(Pair.of(TransformType.GUI, IConveyorBelt.TransformOrient.VERTICAL), mat);
+		mat = new Matrix4().scale(.625, .625, .625).rotate(Math.PI, 0, 1, 0).translate(0, 0, .3125);
+		transformationMap.put(Pair.of(TransformType.FIXED, IConveyorBelt.TransformOrient.HORIZONAL), mat);
+		transformationMap.put(Pair.of(TransformType.FIXED, IConveyorBelt.TransformOrient.VERTICAL), mat);
+
+		mat = new Matrix4().scale(.25, .25, .25);
+		transformationMap.put(Pair.of(TransformType.GROUND, IConveyorBelt.TransformOrient.HORIZONAL), mat);
+		transformationMap.put(Pair.of(TransformType.GROUND, IConveyorBelt.TransformOrient.VERTICAL), mat);
 	}
 
 	@Override
 	public Pair<? extends IBakedModel, Matrix4f> handlePerspective(TransformType cameraTransformType)
 	{
-		HashMap<TransformType, Matrix4> transformationMap = conveyor instanceof ConveyorVertical ? vertTransformationMap : horizTransformationMap;
-		Matrix4 matrix = transformationMap.containsKey(cameraTransformType) ? transformationMap.get(cameraTransformType) : new Matrix4();
+		IConveyorBelt.TransformOrient orient = conveyor == null ?
+			IConveyorBelt.TransformOrient.HORIZONAL :
+			conveyor.getModelTransform();
+		Pair<TransformType, IConveyorBelt.TransformOrient> key = Pair.of(cameraTransformType, orient);
+		Matrix4 matrix = transformationMap.containsKey(key) ?
+			transformationMap.get(key) :
+			new Matrix4();
 		return Pair.of(this, matrix.toMatrix4f());
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorVertical.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorVertical.java
@@ -61,6 +61,10 @@ public class ConveyorVertical extends ConveyorBasic
 		return false;
 	}
 
+	@Override
+	public TransformOrient getModelTransform() {
+		return TransformOrient.VERTICAL;
+	}
 
 	@Override
 	public String getModelCacheKey(TileEntity tile, EnumFacing facing)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorVerticalCovered.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorVerticalCovered.java
@@ -61,6 +61,12 @@ public class ConveyorVerticalCovered extends ConveyorVertical
 	}
 
 	@Override
+	public TransformOrient getModelTransform() {
+		// With the full-block cover, the horizontal form looks nicer.
+		return TransformOrient.HORIZONAL;
+	}
+
+	@Override
 	public void onEntityCollision(TileEntity tile, Entity entity, EnumFacing facing)
 	{
 		super.onEntityCollision(tile, entity, facing);

--- a/src/main/resources/assets/immersiveengineering/blockstates/metal_ladder.json
+++ b/src/main/resources/assets/immersiveengineering/blockstates/metal_ladder.json
@@ -10,10 +10,8 @@
 	{
 		"inventory,type=normal": [{
 			"transform": "forge:default-item",
-			"model": "minecraft:ladder",
-			"textures": {
-				"texture": "immersiveengineering:blocks/metal_ladder"
-			}}],
+			"model": "immersiveengineering:ie_ladder_inv"
+			}],
 		"inventory,type=covered_steel": [{
 			"model": "immersiveengineering:ie_scaffoldladder",
 			"textures": {

--- a/src/main/resources/assets/immersiveengineering/models/block/ie_ladder_inv.json
+++ b/src/main/resources/assets/immersiveengineering/models/block/ie_ladder_inv.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "immersiveengineering:blocks/metal_ladder"
+    }
+}

--- a/src/main/resources/assets/immersiveengineering/models/item/tool/wirecutter.json
+++ b/src/main/resources/assets/immersiveengineering/models/item/tool/wirecutter.json
@@ -5,13 +5,13 @@
 	},
 	"display": {
 		"thirdperson_righthand": {
-			"rotation": [ 270, 180, -45 ],
-			"translation": [ 0, -0.5, -2 ],
+			"rotation": [ 0, 0, -45 ],
+			"translation": [ 0, 0.25, -0.5 ],
 			"scale": [ 0.45, 0.45, 0.45 ]
 		},
 		"thirdperson_lefthand": {
-			"rotation": [ 270, 180, 45 ],
-			"translation": [ 0, -0.5, -2 ],
+			"rotation": [ 0, 0, 45 ],
+			"translation": [ 0, 0.25, -0.5 ],
 			"scale": [ 0.45, 0.45, 0.45 ]
 		},
 		"firstperson_righthand": {

--- a/src/main/resources/assets/immersiveengineering/models/item/tool/wirecutter.json
+++ b/src/main/resources/assets/immersiveengineering/models/item/tool/wirecutter.json
@@ -2,5 +2,27 @@
 	"parent":"item/handheld",
 	"textures": {
 		"layer0":"immersiveengineering:items/tool_wirecutter"
-	}
+	},
+    "display": {
+	    "thirdperson_righthand": {
+	        "rotation": [ 270, 180, -45 ],
+	        "translation": [ 0, -0.5, -2 ],
+	        "scale": [ 0.45, 0.45, 0.45 ]
+	    },
+	    "thirdperson_lefthand": {
+	        "rotation": [ 270, 180, 45 ],
+	        "translation": [ 0, -0.5, -2 ],
+	        "scale": [ 0.45, 0.45, 0.45 ]
+	    },
+	    "firstperson_righthand": {
+	        "rotation": [ -15, 150, -45 ],
+	        "translation": [ 1.13, 3.2, 1.13 ],
+	        "scale": [ 0.68, 0.68, 0.68 ]
+	    },
+	    "firstperson_lefthand": {
+	        "rotation": [ -25, 150, 45 ],
+	        "translation": [ 1.13, 3.2, 1.13 ],
+	        "scale": [ 0.68, 0.68, 0.68 ]
+	    }
+    }
 }

--- a/src/main/resources/assets/immersiveengineering/models/item/tool/wirecutter.json
+++ b/src/main/resources/assets/immersiveengineering/models/item/tool/wirecutter.json
@@ -3,26 +3,26 @@
 	"textures": {
 		"layer0":"immersiveengineering:items/tool_wirecutter"
 	},
-    "display": {
-	    "thirdperson_righthand": {
-	        "rotation": [ 270, 180, -45 ],
-	        "translation": [ 0, -0.5, -2 ],
-	        "scale": [ 0.45, 0.45, 0.45 ]
-	    },
-	    "thirdperson_lefthand": {
-	        "rotation": [ 270, 180, 45 ],
-	        "translation": [ 0, -0.5, -2 ],
-	        "scale": [ 0.45, 0.45, 0.45 ]
-	    },
-	    "firstperson_righthand": {
-	        "rotation": [ -15, 150, -45 ],
-	        "translation": [ 1.13, 3.2, 1.13 ],
-	        "scale": [ 0.68, 0.68, 0.68 ]
-	    },
-	    "firstperson_lefthand": {
-	        "rotation": [ -25, 150, 45 ],
-	        "translation": [ 1.13, 3.2, 1.13 ],
-	        "scale": [ 0.68, 0.68, 0.68 ]
-	    }
-    }
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [ 270, 180, -45 ],
+			"translation": [ 0, -0.5, -2 ],
+			"scale": [ 0.45, 0.45, 0.45 ]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [ 270, 180, 45 ],
+			"translation": [ 0, -0.5, -2 ],
+			"scale": [ 0.45, 0.45, 0.45 ]
+		},
+		"firstperson_righthand": {
+			"rotation": [ -15, 150, -45 ],
+			"translation": [ 1.13, 3.2, 1.13 ],
+			"scale": [ 0.68, 0.68, 0.68 ]
+		},
+		"firstperson_lefthand": {
+			"rotation": [ -25, 150, 45 ],
+			"translation": [ 1.13, 3.2, 1.13 ],
+			"scale": [ 0.68, 0.68, 0.68 ]
+		}
+	}
 }


### PR DESCRIPTION
Add custom position transforms for a number of items / blocks:

* Wirecutters are now held vertically in the hand.
* Conveyors are held facing forwards, or vertically on the front side for the vertical type.
  This required adding a method to `IConveyorBelt` to choose the right transformation, but it's got a default implementation.
* For uncovered metal ladders, make it look identical to the vanilla wood ladder (3D sprite).