### PR TITLE
Fix Razor Wire not having collision on upper wall section

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRazorWire.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityRazorWire.java
@@ -108,7 +108,7 @@ public class TileEntityRazorWire extends TileEntityImmersiveConnectable implemen
 	{
 		boolean wallL = renderWall(true);
 		boolean wallR = renderWall(false);
-		if(!isOnGround() || !(wallL||wallR))
+		if((!isOnGround() && !isStacked()) || !(wallL||wallR))
 			return Collections.singletonList(null);
 		List<AxisAlignedBB> list = new ArrayList<>(wallL&&wallR?2:1);
 		if(wallL)


### PR DESCRIPTION
If you place a 2-high Razor Wire fence, the upper wooden posts don't have collision.