### PR TITLE
Implement #3103: Add JEI "click areas" for GUIs

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/jei/JEIHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/jei/JEIHelper.java
@@ -10,6 +10,7 @@ package blusunrize.immersiveengineering.common.util.compat.jei;
 
 import blusunrize.immersiveengineering.api.crafting.*;
 import blusunrize.immersiveengineering.api.crafting.BlastFurnaceRecipe.BlastFurnaceFuel;
+import blusunrize.immersiveengineering.client.gui.*;
 import blusunrize.immersiveengineering.common.IEContent;
 import blusunrize.immersiveengineering.common.blocks.metal.BlockTypes_MetalMultiblock;
 import blusunrize.immersiveengineering.common.crafting.ArcRecyclingRecipe;
@@ -152,6 +153,22 @@ public class JEIHelper implements IModPlugin
 		})), "ie.arcFurnace");
 		modRegistry.addRecipes(new ArrayList(Collections2.filter(BottlingMachineRecipe.recipeList, input -> input.listInJEI())), "ie.bottlingMachine");
 		modRegistry.addRecipes(new ArrayList(Collections2.filter(MixerRecipe.recipeList, input -> input.listInJEI())), "ie.mixer");
+
+		// Allow jumping to recipies from the block GUIs.
+		modRegistry.addRecipeClickArea(GuiCokeOven.class, 58, 36, 11, 13, "ie.cokeoven");
+		modRegistry.addRecipeClickArea(GuiAlloySmelter.class, 84, 35, 22, 16, "ie.alloysmelter");
+		modRegistry.addRecipeClickArea(GuiBlastFurnace.class, 76, 35, 22, 15, "ie.blastfurnace", "ie.blastfurnace.fuel");
+
+		modRegistry.addRecipeClickArea(GuiSqueezer.class, 110, 19, 20, 51, "ie.squeezer");
+		modRegistry.addRecipeClickArea(GuiFermenter.class, 110, 19, 20, 51, "ie.fermenter");
+		modRegistry.addRecipeClickArea(GuiRefinery.class, 83, 36, 20, 13, "ie.refinery");
+		modRegistry.addRecipeClickArea(GuiArcFurnace.class, 81, 38, 23, 35, "ie.arcFurnace", "ie.arcFurnace.recycling");
+		modRegistry.addRecipeClickArea(GuiMixer.class, 76, 11, 58, 47, "ie.mixer");
+
+		// The assembler has three crafting slots (they don't allow clicking).
+		modRegistry.addRecipeClickArea(GuiAssembler.class, 26, 63, 18, 18, VanillaRecipeCategoryUid.CRAFTING);
+		modRegistry.addRecipeClickArea(GuiAssembler.class, 84, 63, 18, 18, VanillaRecipeCategoryUid.CRAFTING);
+		modRegistry.addRecipeClickArea(GuiAssembler.class, 142, 63, 18, 18, VanillaRecipeCategoryUid.CRAFTING);
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/jei/JEIHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/jei/JEIHelper.java
@@ -169,6 +169,9 @@ public class JEIHelper implements IModPlugin
 		modRegistry.addRecipeClickArea(GuiAssembler.class, 26, 63, 18, 18, VanillaRecipeCategoryUid.CRAFTING);
 		modRegistry.addRecipeClickArea(GuiAssembler.class, 84, 63, 18, 18, VanillaRecipeCategoryUid.CRAFTING);
 		modRegistry.addRecipeClickArea(GuiAssembler.class, 142, 63, 18, 18, VanillaRecipeCategoryUid.CRAFTING);
+
+		modRegistry.addRecipeClickArea(GuiModWorkbench.class, 4, 41, 53, 18, "ie.workbench");
+		modRegistry.addRecipeClickArea(GuiAutoWorkbench.class, 90, 12, 39, 37, "ie.workbench");
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/jei/blastfurnace/BlastFurnaceFuelCategory.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/jei/blastfurnace/BlastFurnaceFuelCategory.java
@@ -9,6 +9,8 @@
 package blusunrize.immersiveengineering.common.util.compat.jei.blastfurnace;
 
 import blusunrize.immersiveengineering.api.crafting.BlastFurnaceRecipe.BlastFurnaceFuel;
+import blusunrize.immersiveengineering.common.IEContent;
+import blusunrize.immersiveengineering.common.blocks.stone.BlockTypes_StoneDevices;
 import blusunrize.immersiveengineering.common.util.compat.jei.IERecipeCategory;
 import blusunrize.immersiveengineering.common.util.compat.jei.JEIHelper;
 import mezz.jei.api.IGuiHelper;
@@ -29,7 +31,7 @@ public class BlastFurnaceFuelCategory extends IERecipeCategory<BlastFurnaceFuel,
 
 	public BlastFurnaceFuelCategory(IGuiHelper helper)
 	{
-		super("blastfurnace.fuel", "gui.immersiveengineering.blastFurnace.fuel", helper.createDrawable(background, 55, 38, 18, 32, 0, 0, 0, 80), BlastFurnaceFuel.class);
+		super("blastfurnace.fuel", "gui.immersiveengineering.blastFurnace.fuel", helper.createDrawable(background, 55, 38, 18, 32, 0, 0, 0, 80), BlastFurnaceFuel.class, new ItemStack(IEContent.blockStoneDevice, 1, BlockTypes_StoneDevices.BLAST_FURNACE.getMeta()), new ItemStack(IEContent.blockStoneDevice, 1, BlockTypes_StoneDevices.BLAST_FURNACE_ADVANCED.getMeta()));
 
 		flame = helper.createDrawable(BlastFurnaceRecipeCategory.background, 176, 0, 14, 14);
 	}


### PR DESCRIPTION
This adds buttons over the arrows in GUIs to lookup recipes for that machine. I also fixed the "blast furnace fuel" category not showing the multiblocks on the left side. The only issue is that some machines don't include arrows or other progress bars in the GUI, so I instead tried to find something else that makes sense:

* For Squeezers, Mixers and Fermenters, I put it over the fluid display (this does produce 2 tooltips though).
* For Assemblers, I added the button over each of the ghost "output" items. This isn't clickable currently, though it'll produce 2 tooltips if an existing recipe is set.
* For the Workbench, I put it on the protruding vise handle.
* For the Automated Workbench, I put it over the drill.

For the two tooltips, one is shown on the left and on the right so they don't overlap.