### PR TITLE
Clean up references to the fermenter in SqueezerDriver

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/SqueezerDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/SqueezerDriver.java
@@ -22,10 +22,10 @@ public class SqueezerDriver extends DriverSidedTileEntity
 		TileEntity te = w.getTileEntity(bp);
 		if(te instanceof TileEntitySqueezer)
 		{
-			TileEntitySqueezer ferment = (TileEntitySqueezer)te;
-			TileEntitySqueezer master = ferment.master();
-			if(master!=null&&ferment.isRedstonePos())
-				return new FermenterEnvironment(w, master.getPos());
+			TileEntitySqueezer squeezer = (TileEntitySqueezer)te;
+			TileEntitySqueezer master = squeezer.master();
+			if(master!=null&&squeezer.isRedstonePos())
+				return new SqueezerEnvironment(w, master.getPos());
 		}
 		return null;
 	}
@@ -37,10 +37,10 @@ public class SqueezerDriver extends DriverSidedTileEntity
 	}
 
 
-	public class FermenterEnvironment extends ManagedEnvironmentIE.ManagedEnvMultiblock<TileEntitySqueezer>
+	public class SqueezerEnvironment extends ManagedEnvironmentIE.ManagedEnvMultiblock<TileEntitySqueezer>
 	{
 
-		public FermenterEnvironment(World w, BlockPos bp)
+		public SqueezerEnvironment(World w, BlockPos bp)
 		{
 			super(w, bp, TileEntitySqueezer.class);
 		}
@@ -105,7 +105,7 @@ public class SqueezerDriver extends DriverSidedTileEntity
 			return new Object[]{getTileEntity().energyStorage.getEnergyStored()};
 		}
 
-		@Callback(doc = "function():boolean -- returns whether the fermenter is running")
+		@Callback(doc = "function():boolean -- returns whether the squeezer is running")
 		public Object[] isActive(Context context, Arguments args)
 		{
 			return new Object[]{getTileEntity().shouldRenderAsActive()};
@@ -128,7 +128,7 @@ public class SqueezerDriver extends DriverSidedTileEntity
 		@Override
 		public String preferredName()
 		{
-			return "ie_fermenter";
+			return "ie_squeezer";
 		}
 
 		@Override


### PR DESCRIPTION
When connecting to a Squeezer with OpenComputers, the component currently appears as an "ie_fermenter", as if the machine is a Fermenter. This makes it difficult to tell the two machines apart when connecting to both, for example when using OpenComputers to monitor a biodiesel production system.

This PR will make it appear as an "ie_squeezer" instead.

