### PR TITLE
Fix inconsistencies with fluids in OC drivers

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/AssemblerDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/AssemblerDriver.java
@@ -3,7 +3,6 @@ package blusunrize.immersiveengineering.common.util.compat.opencomputers;
 import blusunrize.immersiveengineering.api.tool.AssemblerHandler;
 import blusunrize.immersiveengineering.common.blocks.TileEntityIEBase;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityAssembler;
-import blusunrize.immersiveengineering.common.util.Utils;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
@@ -110,7 +109,7 @@ public class AssemblerDriver extends DriverSidedTileEntity
 			int tank = args.checkInteger(0);
 			if(tank > 3||tank < 1)
 				throw new IllegalArgumentException("Only tanks 1-3 are available");
-			return new Object[]{Utils.saveFluidTank(getTileEntity().tanks[tank-1])};
+			return new Object[]{getTileEntity().tanks[tank-1].getInfo()};
 		}
 
 		@Callback(doc = "function():int -- returns the maximum amount of energy that can be stored")

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/FermenterDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/FermenterDriver.java
@@ -2,7 +2,6 @@ package blusunrize.immersiveengineering.common.util.compat.opencomputers;
 
 import blusunrize.immersiveengineering.api.crafting.FermenterRecipe;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityFermenter;
-import blusunrize.immersiveengineering.common.util.Utils;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
@@ -78,7 +77,7 @@ public class FermenterDriver extends DriverSidedTileEntity
 		@Callback(doc = "function():table -- returns the output fluid tank")
 		public Object[] getFluid(Context context, Arguments args)
 		{
-			return new Object[]{Utils.saveFluidTank(getTileEntity().tanks[0])};
+			return new Object[]{getTileEntity().tanks[0].getInfo()};
 		}
 
 		@Callback(doc = "function():table -- returns the stack in the empty cannisters slot")

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/SqueezerDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/SqueezerDriver.java
@@ -2,7 +2,6 @@ package blusunrize.immersiveengineering.common.util.compat.opencomputers;
 
 import blusunrize.immersiveengineering.api.crafting.SqueezerRecipe;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntitySqueezer;
-import blusunrize.immersiveengineering.common.util.Utils;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
@@ -78,7 +77,7 @@ public class SqueezerDriver extends DriverSidedTileEntity
 		@Callback(doc = "function():table -- returns the output fluid tank")
 		public Object[] getFluid(Context context, Arguments args)
 		{
-			return new Object[]{Utils.saveFluidTank(getTileEntity().tanks[0])};
+			return new Object[]{getTileEntity().tanks[0].getInfo()};
 		}
 
 		@Callback(doc = "function():table -- returns the stack in the empty cannisters slot")


### PR DESCRIPTION
Currently, the format received when polling for a fluid tank state is inconsistent. The assembler, fermenter, and squeezer have one format, while other machines with internal fluid tanks have another format. 

For example, the empty state of the fermenter vs refinery: 
![before-empty](https://user-images.githubusercontent.com/1320357/48678785-b01c2600-eb3c-11e8-8318-3a77a6eca0da.png)

And the filled state of the same machines: 
![before-filled](https://user-images.githubusercontent.com/1320357/48678790-bb6f5180-eb3c-11e8-9a6a-bf7e39bcc52e.png)

This PR will standardize it to always output a `FluidTankInfo` object. It should remain backwards compatible with most player scripts, except for scripts that depend on oddities like the fluid name always being prefixed with "fluid."

Examples: 
![after-empty](https://user-images.githubusercontent.com/1320357/48678797-cfb34e80-eb3c-11e8-983c-eb847c12923f.png)
![after-filled](https://user-images.githubusercontent.com/1320357/48678798-d17d1200-eb3c-11e8-810c-b61110a5e328.png)
