### PR TITLE
Adding an OC driver for the garden cloche / belljar

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityBelljar.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityBelljar.java
@@ -255,6 +255,14 @@ public class TileEntityBelljar extends TileEntityIEBase implements ITickable, ID
 		return curPlantHandler;
 	}
 
+	public boolean shouldGrow()
+	{
+		ItemStack soil = inventory.get(SLOT_SOIL);
+		ItemStack seed = inventory.get(SLOT_SEED);
+		IPlantHandler handler = getCurrentPlantHandler();
+		return (energyStorage.getEnergyStored() > IEConfig.Machines.belljar_consumption&&fertilizerAmount > 0&&handler!=null&&handler.isCorrectSoil(seed, soil)&&fertilizerAmount > 0);
+	}
+
 	protected void sendSyncPacket(int type)
 	{
 		NBTTagCompound nbt = new NBTTagCompound();

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/BellJarDriver.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/BellJarDriver.java
@@ -1,0 +1,105 @@
+package blusunrize.immersiveengineering.common.util.compat.opencomputers;
+
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityBelljar;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class BellJarDriver extends DriverSidedTileEntity {
+
+    @Override
+    public ManagedEnvironment createEnvironment(World w, BlockPos bp, EnumFacing facing)
+    {
+        TileEntity te = w.getTileEntity(bp);
+        if(te instanceof TileEntityBelljar)
+        {
+            TileEntityBelljar belljar = (TileEntityBelljar)te;
+            return new BelljarEnvironment(w, belljar.getPos());
+        }
+        return null;
+    }
+
+    @Override
+    public Class<?> getTileEntityClass()
+    {
+        return TileEntityBelljar.class;
+    }
+
+    public class BelljarEnvironment extends ManagedEnvironmentIE<TileEntityBelljar>
+    {
+        public BelljarEnvironment(World w, BlockPos bp)
+        {
+            super(w, bp, TileEntityBelljar.class);
+        }
+
+        @Callback(doc = "function():int -- returns the maximum amount of energy stored")
+        public Object[] getMaxEnergyStored(Context context, Arguments args)
+        {
+            return new Object[]{getTileEntity().energyStorage.getMaxEnergyStored()};
+        }
+
+        @Callback(doc = "function():int -- returns the amount of energy stored")
+        public Object[] getEnergyStored(Context context, Arguments args)
+        {
+            return new Object[]{getTileEntity().energyStorage.getEnergyStored()};
+        }
+
+        @Callback(doc = "function():table -- returns the water tank")
+        public Object[] getWater(Context context, Arguments args)
+        {
+            return new Object[]{getTileEntity().tank.getInfo()};
+        }
+
+        @Callback(doc = "function(slot:int):table -- returns the stack in the specified output slot (1 - 4)")
+        public Object[] getOutputStack(Context context, Arguments args)
+        {
+            int slot = args.checkInteger(0);
+            if(slot < 1||slot > 4)
+                throw new IllegalArgumentException("Output slots are 1-4");
+            return new Object[]{getTileEntity().getInventory().get(slot + 2)};
+        }
+
+        @Callback(doc = "function():table -- returns the current fertilizer")
+        public Object[] getFertilizerStack(Context context, Arguments args)
+        {
+            return new Object[]{getTileEntity().getInventory().get(TileEntityBelljar.SLOT_FERTILIZER)};
+        }
+
+        @Callback(doc = "function():table -- returns the current soil stack")
+        public Object[] getSoilStack(Context context, Arguments args)
+        {
+            return new Object[]{getTileEntity().getInventory().get(TileEntityBelljar.SLOT_SOIL)};
+        }
+
+        @Callback(doc = "function():table -- returns the currently planted seed stack")
+        public Object[] getSeedStack(Context context, Arguments args)
+        {
+            return new Object[]{getTileEntity().getInventory().get(TileEntityBelljar.SLOT_SEED)};
+        }
+
+        @Callback(doc = "function():boolean -- returns whether the cloche is currently growing")
+        public Object[] isGrowing(Context context, Arguments args)
+        {
+            return new Object[]{getTileEntity().shouldGrow()};
+        }
+
+        @Override
+        public String preferredName()
+        {
+            return "ie_belljar";
+        }
+
+        @Override
+        public int priority()
+        {
+            return 1000;
+        }
+
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/OCHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/opencomputers/OCHelper.java
@@ -30,6 +30,7 @@ public class OCHelper extends IECompatModule
 		API.driver.add(new EnergyMeterDriver());
 		API.driver.add(new TeslaCoilDriver());
 		API.driver.add(new MixerDriver());
+		API.driver.add(new BellJarDriver());
 	}
 
 	@Override


### PR DESCRIPTION
While many IE machines have an OpenComputers driver, the Garden Cloche / Bell Jar presently lacks one. This adds a small, read-only OpenComputers driver for same; I also added a `TileEntityBellJar#shouldGrow` method to permit the driver to easily ascertain whether or not the device is in a valid state to grow (correct soil & seed, fertilizer, power). I thought about DRY-ing up the `TileEntityBellJar#update` method to use the same one, but didn't want to fiddle with the existing implementation too much given that this is intended as a purely additive change.