### PR TITLE
Reset for transferCooldown in Extracting Conveyors on Redstone High

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorExtract.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorExtract.java
@@ -217,13 +217,12 @@ public class ConveyorExtract extends ConveyorBasic
 	{
 		if(!tile.getWorld().isRemote)
 		{
-			if(isPowered(tile))
+			if(this.transferCooldown > 0)
 			{
-				this.transferCooldown = 1;
+				this.transferCooldown--;
 			}
-			else if(this.transferCooldown-- <= 0)
+			if(!isPowered(tile) && this.transferCooldown <= 0)
 			{
-				this.transferCooldown = 0;
 				World world = tile.getWorld();
 				BlockPos neighbour = tile.getPos().offset(this.extractDirection);
 				if(!world.isAirBlock(neighbour))

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorExtract.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorExtract.java
@@ -215,31 +215,38 @@ public class ConveyorExtract extends ConveyorBasic
 	@Override
 	public void onUpdate(TileEntity tile, EnumFacing facing)
 	{
-		if(!tile.getWorld().isRemote&&!isPowered(tile)&&this.transferCooldown-- <= 0)
+		if(!tile.getWorld().isRemote)
 		{
-			this.transferCooldown = 0;
-			World world = tile.getWorld();
-			BlockPos neighbour = tile.getPos().offset(this.extractDirection);
-			if(!world.isAirBlock(neighbour))
+			if(isPowered(tile))
 			{
-				TileEntity neighbourTile = world.getTileEntity(neighbour);
-				if(neighbourTile!=null&&neighbourTile.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, this.extractDirection.getOpposite()))
+				this.transferCooldown = 1;
+			}
+			else if(this.transferCooldown-- <= 0)
+			{
+				this.transferCooldown = 0;
+				World world = tile.getWorld();
+				BlockPos neighbour = tile.getPos().offset(this.extractDirection);
+				if(!world.isAirBlock(neighbour))
 				{
-					IItemHandler itemHandler = neighbourTile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, this.extractDirection.getOpposite());
-					for(int i = 0; i < itemHandler.getSlots(); i++)
+					TileEntity neighbourTile = world.getTileEntity(neighbour);
+					if(neighbourTile!=null&&neighbourTile.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, this.extractDirection.getOpposite()))
 					{
-						ItemStack extractItem = itemHandler.extractItem(i, 1, true);
-						if(!extractItem.isEmpty())
+						IItemHandler itemHandler = neighbourTile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, this.extractDirection.getOpposite());
+						for(int i = 0; i < itemHandler.getSlots(); i++)
 						{
-							extractItem = itemHandler.extractItem(i, 1, false);
-							EntityItem entity = new EntityItem(world, tile.getPos().getX()+.5, tile.getPos().getY()+.1875, tile.getPos().getZ()+.5, extractItem);
-							entity.motionX = 0;
-							entity.motionY = 0;
-							entity.motionZ = 0;
-							world.spawnEntity(entity);
-							this.onItemDeployed(tile, entity, facing);
-							this.transferCooldown = this.transferTickrate;
-							return;
+							ItemStack extractItem = itemHandler.extractItem(i, 1, true);
+							if(!extractItem.isEmpty())
+							{
+								extractItem = itemHandler.extractItem(i, 1, false);
+								EntityItem entity = new EntityItem(world, tile.getPos().getX()+.5, tile.getPos().getY()+.1875, tile.getPos().getZ()+.5, extractItem);
+								entity.motionX = 0;
+								entity.motionY = 0;
+								entity.motionZ = 0;
+								world.spawnEntity(entity);
+								this.onItemDeployed(tile, entity, facing);
+								this.transferCooldown = this.transferTickrate;
+								return;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
The proposed change resets the transferCooldown when the conveyor is toggled off by a redstone signal.
This makes it so the time from disabling the redstone signal to item extraction is now constant.
The previous behaviour paused the count, resulting in an uncertain "time-to-extract" which could lead to eventual over-/underflows in systems that try to extract an exact number of items by disabling the redstone signal for a timed amount, unless the timing matched perfectly with the transferTickrate.