### PR TITLE
Wirepickpatch

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
@@ -207,12 +207,10 @@ public class BlockConnector extends BlockIETileProvider<BlockTypes_Connector>
 						{
 							IWireCoil coilItem = (IWireCoil)s.getItem();
 							wire = coilItem.getWireType(s);
-							System.out.println(Item.REGISTRY.getIDForObject(s.getItem()) + " : " + s.getMetadata());
 							if(connectable.canConnectCable(wire, subTarget, pos.subtract(masterPos)) && coilItem.canConnectCable(s, te))
 							{
 								ItemStack coil = wire.getWireCoil();
 								boolean unique = true;
-								boolean foundFamily = false;
 								int insertIndex = applicableWires.size();
 								for (int j = 0; j < applicableWires.size(); j++)
 								{
@@ -224,22 +222,23 @@ public class BlockConnector extends BlockIETileProvider<BlockTypes_Connector>
 											unique = false;
 											break;
 										}
-										if(coil.getMetadata() < priorWire.getMetadata() && j < insertIndex)
-												insertIndex = j;
-										else if(j+1 > insertIndex)
-												insertIndex = j+1;
-										foundFamily = true;
+										if(coil.getMetadata() < priorWire.getMetadata())
+										{
+											insertIndex = j;
+											break;
+										}
 									}
 									/*sort different item by itemID (can't guarantee a static list otherwise. switching items by pickBlock changes the order in which things are looked at,
 									making for scenarios in which applicable wires are possibly skipped when 3 or more wire Items are present)*/
-									else if(!foundFamily)   
+									else  
 									{
 										int coilID = Item.REGISTRY.getIDForObject(coil.getItem());
 										int priorID = Item.REGISTRY.getIDForObject(priorWire.getItem());
-										if(coilID < priorID && j < insertIndex)
+										if(coilID < priorID)
+										{
 											insertIndex = j;
-										else if(j+1 > insertIndex)
-											insertIndex = j+1;
+											break;
+										}
 									}
 								}
 								if(unique)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
@@ -191,7 +191,7 @@ public class BlockConnector extends BlockIETileProvider<BlockTypes_Connector>
 				BlockPos masterPos = ((IImmersiveConnectable)te).getConnectionMaster(null, subTarget);
 				if(masterPos!=pos)
 					te = world.getTileEntity(masterPos);
-				if(te instanceof TileEntityImmersiveConnectable)
+				if(te instanceof IImmersiveConnectable)
 				{
 					IImmersiveConnectable connectable = (IImmersiveConnectable)te;
 					WireType wire = connectable.getCableLimiter(subTarget);

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
@@ -197,7 +197,6 @@ public class BlockConnector extends BlockIETileProvider<BlockTypes_Connector>
 					WireType wire = connectable.getCableLimiter(subTarget);
 					if(wire!=null)
 						return wire.getWireCoil();
-
 					ArrayList<ItemStack> applicableWires = new ArrayList<ItemStack>();
 					NonNullList<ItemStack> pInventory = player.inventory.mainInventory;
 					for(int i = 0; i < pInventory.size(); i++)
@@ -246,7 +245,6 @@ public class BlockConnector extends BlockIETileProvider<BlockTypes_Connector>
 						}
 						return applicableWires.get(0);
 					}
-						
 				}
 			}
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BlockConnector.java
@@ -8,7 +8,6 @@
 
 package blusunrize.immersiveengineering.common.blocks.metal;
 
-import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.IEProperties;
 import blusunrize.immersiveengineering.api.IPostBlock;
 import blusunrize.immersiveengineering.api.TargetingInfo;
@@ -19,8 +18,6 @@ import blusunrize.immersiveengineering.api.energy.wires.WireType;
 import blusunrize.immersiveengineering.client.models.IOBJModelCallback;
 import blusunrize.immersiveengineering.common.blocks.BlockIETileProvider;
 import blusunrize.immersiveengineering.common.blocks.ItemBlockIEBase;
-import blusunrize.immersiveengineering.common.items.ItemIEShield;
-import blusunrize.immersiveengineering.common.util.network.MessageMagnetEquip;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.EnumPushReaction;
 import net.minecraft.block.material.Material;


### PR DESCRIPTION
This makes it so picking wiretypes from a connector with shift+middlemousebutton is now possible without requiring the connector to already have a wire attached.
It also allows to cycle through all applicable wires with subsequent picks.
A caveat is that both the picking-from-unconnected-connectors and the cycling requires the player to already have applicable wires in the inventory, so it won't work perfectly in creative.