### PR TITLE
Added crusher NBT tag 'Active'

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityCrusher.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityCrusher.java
@@ -81,6 +81,7 @@ public class TileEntityCrusher extends TileEntityMultiblockMetal<TileEntityCrush
 	public void writeCustomNBT(NBTTagCompound nbt, boolean descPacket)
 	{
 		super.writeCustomNBT(nbt, descPacket);
+		nbt.setBoolean("active", shouldRenderAsActive());
 		if(!descPacket)
 		{
 			NBTTagList invList = new NBTTagList();


### PR DESCRIPTION
The NBT tag "active" has been added to the Fermenter multiblock machine. This is for comparatility with other mods like Pollution of the Realms.