### PR TITLE
Capability reference invalidation proposal

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/IEBlockInterfaces.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/IEBlockInterfaces.java
@@ -449,4 +449,15 @@ public class IEBlockInterfaces
 		IModelData getModelData(@Nonnull IEnviromentBlockReader world, @Nonnull BlockPos pos, @Nonnull BlockState state,
 								@Nonnull IModelData tileData);
 	}
+
+	public interface ICapabilityReferenceHolder
+	{
+		void invalidateCapabilityReference(@Nullable Direction side);
+
+		default void invalidateCapabilityReferences()
+		{
+			invalidateCapabilityReference(null);
+		}
+	}
+
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/IETileProviderBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/IETileProviderBlock.java
@@ -36,6 +36,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.IBlockReader;
+import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -312,6 +313,16 @@ public abstract class IETileProviderBlock extends IEBaseBlock implements IColour
 			if(tile instanceof INeighbourChangeTile&&!tile.getWorld().isRemote)
 				((INeighbourChangeTile)tile).onNeighborBlockChange(fromPos);
 		}
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public BlockState updatePostPlacement(BlockState state, Direction facing, BlockState facingState, IWorld world, BlockPos currentPos, BlockPos facingPos)
+	{
+		TileEntity tile = world.getTileEntity(currentPos);
+		if(tile instanceof ICapabilityReferenceHolder)
+			((ICapabilityReferenceHolder)tile).invalidateCapabilityReference(facing);
+		return state;
 	}
 
 	public IETileProviderBlock setHasColours()

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WoodenBarrelTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WoodenBarrelTileEntity.java
@@ -52,7 +52,7 @@ import static blusunrize.immersiveengineering.api.IEEnums.IOSideConfig.NONE;
 import static blusunrize.immersiveengineering.api.IEEnums.IOSideConfig.OUTPUT;
 import static net.minecraftforge.fluids.capability.CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY;
 
-public class WoodenBarrelTileEntity extends IEBaseTileEntity implements ITickableTileEntity, IBlockOverlayText, IConfigurableSides, IPlayerInteraction, ITileDrop, IComparatorOverride
+public class WoodenBarrelTileEntity extends IEBaseTileEntity implements ITickableTileEntity, IBlockOverlayText, IConfigurableSides, IPlayerInteraction, ITileDrop, IComparatorOverride, ICapabilityReferenceHolder
 {
 	public static final int IGNITION_TEMPERATURE = 573;
 	public static TileEntityType<WoodenBarrelTileEntity> TYPE;
@@ -363,5 +363,14 @@ public class WoodenBarrelTileEntity extends IEBaseTileEntity implements ITickabl
 	public int getComparatorInputOverride()
 	{
 		return (int)(15*(tank.getFluidAmount()/(float)tank.getCapacity()));
+	}
+
+	@Override
+	public void invalidateCapabilityReference(@Nullable Direction side)
+	{
+		if(side==null)
+			neighbors.values().forEach(CapabilityReference::invalidate);
+		else if(neighbors.containsKey(side))
+			neighbors.get(side).invalidate();
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/util/CapabilityReference.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/CapabilityReference.java
@@ -58,6 +58,8 @@ public abstract class CapabilityReference<T>
 
 	public abstract boolean isPresent();
 
+	public abstract void invalidate();
+
 	private static class TECapReference<T> extends CapabilityReference<T>
 	{
 		private final Supplier<World> world;
@@ -87,6 +89,12 @@ public abstract class CapabilityReference<T>
 		{
 			updateLazyOptional();
 			return currentCap.isPresent();
+		}
+
+		@Override
+		public void invalidate()
+		{
+			lastWorld = null;
 		}
 
 		private void updateLazyOptional()


### PR DESCRIPTION
Prevents capability references from inhibiting neighbour TEs to be properly removed by invalidating the references when a post placement update is invoked from the neighbour block.

Test setup: Barrel on the ground, above a valve, above another barrel. The valve block is broken while filling, and placed again (multiple times).

a) with IE .95, the log shows `fill()` calls in the neighbour fluid handler.
b) patched: the capability is checked again after valve block updates, resolving the issue.

[a-dangling-fluidhandler-tracelog.zip](https://github.com/BluSunrize/ImmersiveEngineering/files/4402036/a-dangling-fluidhandler-tracelog.zip)

[b-with-cap-ref-invalidation.zip](https://github.com/BluSunrize/ImmersiveEngineering/files/4402037/b-with-cap-ref-invalidation.zip)
