### PR TITLE
[1.14.4] re-add torch and string recipes

### DIFF
--- a/src/generated/resources/data/immersiveengineering/advancements/recipes/decorations/torch.json
+++ b/src/generated/resources/data/immersiveengineering/advancements/recipes/decorations/torch.json
@@ -1,0 +1,54 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "immersiveengineering:torch"
+    ]
+  },
+  "criteria": {
+    "has_wool": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "minecraft:wool"
+          }
+        ]
+      }
+    },
+    "has_stick": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:rods/wooden"
+          }
+        ]
+      }
+    },
+    "has_creosote": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "immersiveengineering:creosote_bucket"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "immersiveengineering:torch"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_wool",
+      "has_stick",
+      "has_creosote",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/immersiveengineering/advancements/recipes/misc/string.json
+++ b/src/generated/resources/data/immersiveengineering/advancements/recipes/misc/string.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "immersiveengineering:string"
+    ]
+  },
+  "criteria": {
+    "has_hemp_fiber": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "immersiveengineering:hemp_fiber"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "immersiveengineering:string"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_hemp_fiber",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/immersiveengineering/recipes/string.json
+++ b/src/generated/resources/data/immersiveengineering/recipes/string.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "forge:fiber_hemp"
+    },
+    {
+      "tag": "forge:fiber_hemp"
+    },
+    {
+      "tag": "forge:fiber_hemp"
+    }
+  ],
+  "result": {
+    "item": "minecraft:string"
+  }
+}

--- a/src/generated/resources/data/immersiveengineering/recipes/torch.json
+++ b/src/generated/resources/data/immersiveengineering/recipes/torch.json
@@ -1,0 +1,24 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "wc ",
+    "sss"
+  ],
+  "key": {
+    "w": {
+      "tag": "minecraft:wool"
+    },
+    "c": {
+      "amount": 1000,
+      "fluid": "immersiveengineering:creosote",
+      "type": "immersiveengineering:fluid"
+    },
+    "s": {
+      "tag": "forge:rods/wooden"
+    }
+  },
+  "result": {
+    "item": "minecraft:torch",
+    "count": 12
+  }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/data/Recipes.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/data/Recipes.java
@@ -148,6 +148,7 @@ public class Recipes extends RecipeProvider
 
 		recipesTools(out);
 		recipesIngredients(out);
+		recipesVanilla(out);
 		recipesWeapons(out);
 		recipesMisc(out);
 
@@ -1569,6 +1570,23 @@ public class Recipes extends RecipeProvider
 				.key('p', Items.PAPER)
 				.addCriterion("has_"+toPath(Items.PAPER), hasItem(Items.PAPER))
 				.build(buildBlueprint(out, "molds"), rl("blueprint_molds"));
+	}
+
+	private void recipesVanilla(@Nonnull Consumer<IFinishedRecipe> out) {
+		ShapedRecipeBuilder.shapedRecipe(Items.TORCH, 12)
+				.patternLine("wc ")
+				.patternLine("sss")
+				.key('w', ItemTags.WOOL)
+				.key('c', new IngredientFluidStack(IEContent.fluidCreosote, 1000))
+				.key('s', Tags.Items.RODS_WOODEN)
+				.addCriterion("has_wool", hasItem(ItemTags.WOOL))
+				.addCriterion("has_stick", hasItem(Tags.Items.RODS_WOODEN))
+				.addCriterion("has_creosote", hasItem(IEContent.fluidCreosote.getFilledBucket()))
+				.build(out, toRL(toPath(Items.TORCH)));
+		ShapelessRecipeBuilder.shapelessRecipe(Items.STRING)
+				.addIngredient(Ingredient.fromTag(IETags.fiberHemp), 3)
+				.addCriterion("has_hemp_fiber", hasItem(Ingredients.hempFiber))
+				.build(out, toRL(toPath(Items.STRING)));
 	}
 
 	private Consumer<IFinishedRecipe> buildBlueprint(Consumer<IFinishedRecipe> out, String blueprint)

--- a/src/main/java/blusunrize/immersiveengineering/common/data/Recipes.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/data/Recipes.java
@@ -1530,12 +1530,6 @@ public class Recipes extends RecipeProvider
 				.addIngredient(Ingredient.fromItems(Items.SHEARS, Tools.wirecutter))
 				.addCriterion("has_steel_ingot", hasItem(IETags.getTagsFor(EnumMetals.STEEL).ingot))
 				.build(out);
-		ShapelessRecipeBuilder.shapelessRecipe(Items.GUNPOWDER)
-				.addIngredient(Ingredient.fromTag(IETags.saltpeterDust), 4)
-				.addIngredient(IETags.sulfurDust)
-				.addIngredient(Items.CHARCOAL)
-				.addCriterion("has_sulfur", hasItem(IETags.sulfurDust))
-				.build(out, toRL("gunpowder_from_dusts"));
 
 		ShapelessRecipeBuilder.shapelessRecipe(Metals.dusts.get(EnumMetals.ELECTRUM))
 				.addIngredient(IETags.getTagsFor(EnumMetals.GOLD).dust)
@@ -1587,6 +1581,12 @@ public class Recipes extends RecipeProvider
 				.addIngredient(Ingredient.fromTag(IETags.fiberHemp), 3)
 				.addCriterion("has_hemp_fiber", hasItem(Ingredients.hempFiber))
 				.build(out, toRL(toPath(Items.STRING)));
+		ShapelessRecipeBuilder.shapelessRecipe(Items.GUNPOWDER)
+				.addIngredient(Ingredient.fromTag(IETags.saltpeterDust), 4)
+				.addIngredient(IETags.sulfurDust)
+				.addIngredient(Items.CHARCOAL)
+				.addCriterion("has_sulfur", hasItem(IETags.sulfurDust))
+				.build(out, toRL("gunpowder_from_dusts"));
 	}
 
 	private Consumer<IFinishedRecipe> buildBlueprint(Consumer<IFinishedRecipe> out, String blueprint)


### PR DESCRIPTION
Like @iammeeper realized in issue #3769, the hemp fiber to string recipe got thrown under the bus with commit d3728ee7, as well as the recipe to craft torches from wool, wooden rods and creosote. I also really like those recipies as early/mid-game sinks for creosote and hemp fiber.

This PR re-adds both recipies, validated manual and assembler crafting.