### PR TITLE
emit crop sound on breaking planted hemp

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/HempBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/HempBlock.java
@@ -39,6 +39,7 @@ public class HempBlock extends BushBlock implements IGrowable
 	public HempBlock(String name)
 	{
 		super(Block.Properties.create(Material.PLANTS)
+				.sound(SoundType.CROP)
 				.doesNotBlockMovement()
 				.hardnessAndResistance(0)
 				.tickRandomly());


### PR DESCRIPTION
Change block break sound from default stone sound to crop. Addresses issue #3767. 