### PR TITLE
Make tall grass drop hemp seeds again

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
@@ -58,11 +58,10 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
+import net.minecraft.world.storage.loot.LootPool;
+import net.minecraft.world.storage.loot.TableLootEntry;
 import net.minecraftforge.common.DimensionManager;
-import net.minecraftforge.event.AnvilUpdateEvent;
-import net.minecraftforge.event.AttachCapabilitiesEvent;
-import net.minecraftforge.event.TagsUpdatedEvent;
-import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.*;
 import net.minecraftforge.event.TickEvent.WorldTickEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.living.*;
@@ -94,6 +93,8 @@ public class EventHandler
 	public static HashSet<IEExplosion> currentExplosions = new HashSet<IEExplosion>();
 	public static final Queue<Pair<DimensionType, BlockPos>> requestedBlockUpdates = new LinkedList<>();
 	public static final Set<TileEntity> REMOVE_FROM_TICKING = new HashSet<>();
+
+	private static final ResourceLocation TALL_GRASS_DROP = new ResourceLocation("minecraft", "blocks/tall_grass");
 
 	@SubscribeEvent
 	public void onLoad(WorldEvent.Load event)
@@ -176,6 +177,14 @@ public class EventHandler
 			new ResourceLocation(ImmersiveEngineering.MODID, "chests/village_blacksmith")
 	);
 	private static Field f_lootEntries;
+
+	@SubscribeEvent
+	public void lootTableLoad(LootTableLoadEvent event) {
+		if (event.getName().equals(TALL_GRASS_DROP))
+			event.getTable().addPool(LootPool.builder()
+					.addEntry(TableLootEntry.builder(new ResourceLocation(ImmersiveEngineering.MODID, "blocks/grass_drops")))
+					.name("ie_grass_drops").build());
+	}
 
 	/*TODO I think this can be done data-driven now?
 	@SubscribeEvent

--- a/src/main/resources/data/immersiveengineering/loot_tables/blocks/grass_drops.json
+++ b/src/main/resources/data/immersiveengineering/loot_tables/blocks/grass_drops.json
@@ -1,0 +1,43 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"name": "ie_grass_drops",
+			"rolls": 1,
+			"conditions": [
+				{
+					"condition": "minecraft:random_chance",
+					"chance": 0.2
+				},
+				{
+					"condition": "minecraft:inverted",
+					"term": {
+						"condition": "minecraft:match_tool",
+						"predicate": {
+							"item": "minecraft:shears"
+						}
+					}
+				}
+			],
+			"functions": [
+				{
+					"function": "minecraft:explosion_decay"
+				},
+				{
+					"function": "minecraft:set_count",
+					"count": {
+						"min": 0.0,
+						"max": 1.0,
+						"type": "minecraft:uniform"
+					}
+				}
+			],
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "immersiveengineering:seed"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Rather ugly but functional implementation to modify the loot table for tall grass to drop hemp seeds in addition to anything else it may drop, like vanilla wheat seeds.
Using one of the vanilla hoes increases drop chances by a factor of five.

Referring #3769, because @iammeeper and @BluSunrize may want to know it's not exactly impossible to make tall grass drop seeds again, but doing it _cleanly_ certainly requires a lot more effort and competence than I put into this initial "solution". Maybe it's a sufficient stop-gap measure for the next 1.14.4 release, though, or a starting point for someone more familiar with loot table shenanigans.