### PR TITLE
Update TileEntityMultiblockMetal.java

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityMultiblockMetal.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityMultiblockMetal.java
@@ -560,7 +560,10 @@ public abstract class TileEntityMultiblockMetal<T extends TileEntityMultiblockMe
 				averageInsertion = multiblock.energyStorage.extractEnergy(averageInsertion, true);
 				if(averageInsertion > energyExtracted)
 				{
-					int possibleTicks = Math.min(averageInsertion/energyPerTick, Math.min(this.recipe.getMultipleProcessTicks(), this.maxTicks-this.processTick));
+					if(energyPerTick > 0)
+						int possibleTicks = Math.min(averageInsertion/energyPerTick, Math.min(this.recipe.getMultipleProcessTicks(), this.maxTicks-this.processTick));
+					else
+						int possibleTicks = Math.min(Math.min(this.recipe.getMultipleProcessTicks(), this.maxTicks-this.processTick));
 					if(possibleTicks > 1)
 					{
 						ticksAdded = possibleTicks;


### PR DESCRIPTION
This should fix the bug where settting the totalProcessEnergy for a custom crusher recipe to low(below 25) or messing with the crusher_timeModifier in the config can result in a division by zero during entity ticks. 

This should fix the following issues:
#3417
#3826
#3854
ICannt/Netherending-Ores#24

I fixed it by just checking for zero beforhand and then preventing the division.
This would cause the crushing to not consume any energy though, so feel free to use another workaround. 

This fix could also be applied to the 1.14 version in the file:
ImmersiveEngineering/src/main/java/blusunrize/immersiveengineering/common/blocks/generic/PoweredMultiblockTileEntity.java
in line 467