### PR TITLE
Fix a crash if wall Shader Banners are placed directly without NBT, and fix collisions

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/ShaderBannerRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/ShaderBannerRenderer.java
@@ -38,8 +38,11 @@ public class ShaderBannerRenderer extends TileEntityRenderer<ShaderBannerTileEnt
 	{
 		long time = te.getWorldNonnull().getGameTime();
 		GlStateManager.pushMatrix();
+
+		// Check which of the two blocks we are so we can calculate the orientation.
 		if(te.getState().getBlock() == Cloth.shaderBanner)
 		{
+			// Standing banner, we have 16 different rotations.
 			int orientation = te.getState().get(ShaderBannerStandingBlock.ROTATION);
 			GlStateManager.translated((float)x+0.5F, (float)y+0.5F, (float)z+0.5F);
 			float f1 = (float)(orientation*360)/16.0F;
@@ -48,6 +51,9 @@ public class ShaderBannerRenderer extends TileEntityRenderer<ShaderBannerTileEnt
 		}
 		else
 		{
+			// Must be the wall banner, attaches to the side of the block with no support pillar.
+			assert te.getState().getBlock() == Cloth.shaderBannerWall;
+
 			Direction facing = te.getState().get(ShaderBannerWallBlock.FACING);
 			float rotation = facing.getHorizontalAngle();
 

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/ShaderBannerRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/ShaderBannerRenderer.java
@@ -13,6 +13,7 @@ import blusunrize.immersiveengineering.api.shader.ShaderCase;
 import blusunrize.immersiveengineering.api.shader.ShaderLayer;
 import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.client.render.IEShaderLayerCompositeTexture;
+import blusunrize.immersiveengineering.common.blocks.IEBlocks.Cloth;
 import blusunrize.immersiveengineering.common.blocks.cloth.ShaderBannerStandingBlock;
 import blusunrize.immersiveengineering.common.blocks.cloth.ShaderBannerTileEntity;
 import blusunrize.immersiveengineering.common.blocks.cloth.ShaderBannerWallBlock;
@@ -37,7 +38,7 @@ public class ShaderBannerRenderer extends TileEntityRenderer<ShaderBannerTileEnt
 	{
 		long time = te.getWorldNonnull().getGameTime();
 		GlStateManager.pushMatrix();
-		if(!te.wall)
+		if(te.getState().getBlock() == Cloth.shaderBanner)
 		{
 			int orientation = te.getState().get(ShaderBannerStandingBlock.ROTATION);
 			GlStateManager.translated((float)x+0.5F, (float)y+0.5F, (float)z+0.5F);

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/ShaderBannerBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/ShaderBannerBlock.java
@@ -17,6 +17,10 @@ import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.state.IProperty;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IBlockReader;
 
 import javax.annotation.Nonnull;
@@ -24,6 +28,8 @@ import javax.annotation.Nullable;
 
 public abstract class ShaderBannerBlock extends IETileProviderBlock
 {
+	private static VoxelShape SHAPE = Block.makeCuboidShape(4.0D, 0.0D, 4.0D, 12.0D, 16.0D, 12.0D);
+
 	public ShaderBannerBlock(String name, IProperty... stateProps)
 	{
 		super(name, Block.Properties.create(Material.WOOL).hardnessAndResistance(1.0F).sound(SoundType.CLOTH).doesNotBlockMovement(), (b, p) -> null, stateProps);
@@ -35,6 +41,18 @@ public abstract class ShaderBannerBlock extends IETileProviderBlock
 	public TileEntity createTileEntity(@Nonnull BlockState state, @Nonnull IBlockReader world)
 	{
 		return new ShaderBannerTileEntity();
+	}
+
+	@Override
+	public VoxelShape getShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context)
+	{
+		return SHAPE;
+	}
+
+	@Override
+	public VoxelShape getCollisionShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context)
+	{
+		return VoxelShapes.empty();
 	}
 
 	@Nonnull

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/ShaderBannerTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/ShaderBannerTileEntity.java
@@ -15,6 +15,7 @@ import blusunrize.immersiveengineering.api.shader.CapabilityShader.ShaderWrapper
 import blusunrize.immersiveengineering.common.blocks.IEBaseTileEntity;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.ICollisionBounds;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.ITileDrop;
+import blusunrize.immersiveengineering.common.blocks.IEBlocks.Cloth;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -41,7 +42,6 @@ import java.util.Map;
 
 public class ShaderBannerTileEntity extends IEBaseTileEntity implements ICollisionBounds, ITileDrop
 {
-	public boolean wall = false;
 	public ShaderWrapper_Direct shader = new ShaderWrapper_Direct(new ResourceLocation(ImmersiveEngineering.MODID, "banner"));
 
 	public static TileEntityType<BannerTileEntity> TYPE;
@@ -61,7 +61,6 @@ public class ShaderBannerTileEntity extends IEBaseTileEntity implements ICollisi
 	@Override
 	public void readCustomNBT(CompoundNBT nbt, boolean descPacket)
 	{
-		this.wall = nbt.getBoolean("wall");
 		if(nbt.contains("shader", NBT.TAG_COMPOUND))
 		{
 			shader = new ShaderWrapper_Direct(new ResourceLocation(ImmersiveEngineering.MODID, "banner"));
@@ -72,7 +71,6 @@ public class ShaderBannerTileEntity extends IEBaseTileEntity implements ICollisi
 	@Override
 	public void writeCustomNBT(CompoundNBT nbt, boolean descPacket)
 	{
-		nbt.putBoolean("wall", this.wall);
 		nbt.put("shader", shader.serializeNBT());
 	}
 
@@ -80,7 +78,7 @@ public class ShaderBannerTileEntity extends IEBaseTileEntity implements ICollisi
 	@Override
 	public VoxelShape getCollisionShape(ISelectionContext ctx)
 	{
-		if(this.wall)
+		if(getState().getBlock() == Cloth.shaderBannerWall)
 			return WALL_SHAPES.get(getState().get(ShaderBannerWallBlock.FACING));
 		return SHAPE;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/ShaderBannerTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/ShaderBannerTileEntity.java
@@ -13,13 +13,8 @@ import blusunrize.immersiveengineering.api.shader.CapabilityShader;
 import blusunrize.immersiveengineering.api.shader.CapabilityShader.ShaderWrapper;
 import blusunrize.immersiveengineering.api.shader.CapabilityShader.ShaderWrapper_Direct;
 import blusunrize.immersiveengineering.common.blocks.IEBaseTileEntity;
-import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.ICollisionBounds;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.ITileDrop;
-import blusunrize.immersiveengineering.common.blocks.IEBlocks.Cloth;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import net.minecraft.block.Block;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
@@ -28,8 +23,6 @@ import net.minecraft.tileentity.BannerTileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.shapes.ISelectionContext;
-import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.storage.loot.LootContext;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
@@ -38,19 +31,12 @@ import net.minecraftforge.common.util.LazyOptional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Map;
 
-public class ShaderBannerTileEntity extends IEBaseTileEntity implements ICollisionBounds, ITileDrop
+public class ShaderBannerTileEntity extends IEBaseTileEntity implements ITileDrop
 {
 	public ShaderWrapper_Direct shader = new ShaderWrapper_Direct(new ResourceLocation(ImmersiveEngineering.MODID, "banner"));
 
 	public static TileEntityType<BannerTileEntity> TYPE;
-	private static VoxelShape SHAPE = Block.makeCuboidShape(4.0D, 0.0D, 4.0D, 12.0D, 16.0D, 12.0D);
-	private static Map<Direction, VoxelShape> WALL_SHAPES = Maps.newEnumMap(ImmutableMap.of(
-			Direction.NORTH, Block.makeCuboidShape(0.0D, 0.0D, 14.0D, 16.0D, 12.5D, 16.0D),
-			Direction.SOUTH, Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 12.5D, 2.0D),
-			Direction.WEST, Block.makeCuboidShape(14.0D, 0.0D, 0.0D, 16.0D, 12.5D, 16.0D),
-			Direction.EAST, Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 2.0D, 12.5D, 16.0D)));
 
 	public ShaderBannerTileEntity()
 	{
@@ -72,15 +58,6 @@ public class ShaderBannerTileEntity extends IEBaseTileEntity implements ICollisi
 	public void writeCustomNBT(CompoundNBT nbt, boolean descPacket)
 	{
 		nbt.put("shader", shader.serializeNBT());
-	}
-
-	@Nonnull
-	@Override
-	public VoxelShape getCollisionShape(ISelectionContext ctx)
-	{
-		if(getState().getBlock() == Cloth.shaderBannerWall)
-			return WALL_SHAPES.get(getState().get(ShaderBannerWallBlock.FACING));
-		return SHAPE;
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/ShaderBannerWallBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/cloth/ShaderBannerWallBlock.java
@@ -9,15 +9,31 @@
 package blusunrize.immersiveengineering.common.blocks.cloth;
 
 import blusunrize.immersiveengineering.api.IEProperties;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.state.IProperty;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.Rotation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.shapes.ISelectionContext;
+import net.minecraft.util.math.shapes.VoxelShape;
+import net.minecraft.util.math.shapes.VoxelShapes;
+import net.minecraft.world.IBlockReader;
+
+import java.util.Map;
 
 public class ShaderBannerWallBlock extends ShaderBannerBlock
 {
 	public static final IProperty<Direction> FACING = IEProperties.FACING_HORIZONTAL;
+
+	private static Map<Direction, VoxelShape> SHAPES = Maps.newEnumMap(ImmutableMap.of(
+			Direction.NORTH, Block.makeCuboidShape(0.0D, 0.0D, 14.0D, 16.0D, 12.5D, 16.0D),
+			Direction.SOUTH, Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 16.0D, 12.5D, 2.0D),
+			Direction.WEST, Block.makeCuboidShape(14.0D, 0.0D, 0.0D, 16.0D, 12.5D, 16.0D),
+			Direction.EAST, Block.makeCuboidShape(0.0D, 0.0D, 0.0D, 2.0D, 12.5D, 16.0D)));
 
 	public ShaderBannerWallBlock()
 	{
@@ -39,5 +55,11 @@ public class ShaderBannerWallBlock extends ShaderBannerBlock
 		Direction oldFacing = state.get(FACING);
 		Direction newFacing = mirrorIn.mirror(oldFacing);
 		return state.with(FACING, newFacing);
+	}
+
+	@Override
+	public VoxelShape getShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context)
+	{
+		return SHAPES.get(state.get(FACING));
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/items/ShaderItem.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/ShaderItem.java
@@ -102,7 +102,6 @@ public class ShaderItem extends IEBaseItem implements IShaderItem, ITextureOverr
 					tile = world.getTileEntity(pos);
 					if(tile instanceof ShaderBannerTileEntity)
 					{
-						((ShaderBannerTileEntity)tile).wall = wall;
 						((ShaderBannerTileEntity)tile).shader.setShaderItem(Utils.copyStackWithAmount(ctx.getItem(), 1));
 						tile.markDirty();
 						return ActionResultType.SUCCESS;


### PR DESCRIPTION
Shader banners have a `wall` boolean, which identifies which type of banner it is. Now that 1.13+ use two different blocks, this means that if it doesn't match the block it will crash in the renderer. Instead just check the blockstate directly.

The issue can be easily replicated by either doing `/setblock ~ ~ ~ immersiveengineering:shader_banner_wall` or creating a Debug world and flying over to bring it into render range.

I did also notice that the collision shape is inconsistent with vanilla, and so fixed that too. I moved the method to the blocks since the TE no longer affects this. Separate commit if you'd prefer to just cherry-pick the first error