### PR TITLE
Add overridable methods for IEBaseBlock

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockItemIE.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/BlockItemIE.java
@@ -42,7 +42,7 @@ public class BlockItemIE extends BlockItem
 
 	public BlockItemIE(Block b)
 	{
-		this(b, new Item.Properties().group(ImmersiveEngineering.itemGroup));
+		this(b, new Item.Properties().group(b.getItemGroup()));
 		setRegistryName(b.getRegistryName());
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/IEBaseBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/IEBaseBlock.java
@@ -75,7 +75,7 @@ public class IEBaseBlock extends Block implements IIEBlock, IWaterLoggable
 		setRegistryName(registryName);
 
 		IEContent.registeredIEBlocks.add(this);
-		Item item = createItemBlock.apply(this, new Item.Properties().group(ImmersiveEngineering.itemGroup));
+		Item item = createItemBlock.apply(this, new Item.Properties().group(getItemGroup()));
 		if(item!=null)
 		{
 			item.setRegistryName(registryName);
@@ -256,6 +256,11 @@ public class IEBaseBlock extends Block implements IIEBlock, IWaterLoggable
 	public ResourceLocation createRegistryName()
 	{
 		return new ResourceLocation(ImmersiveEngineering.MODID, name);
+	}
+	
+	public ItemGroup getItemGroup()
+	{
+		return ImmersiveEngineering.itemGroup;
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/IEBaseBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/IEBaseBlock.java
@@ -74,12 +74,14 @@ public class IEBaseBlock extends Block implements IIEBlock, IWaterLoggable
 		ResourceLocation registryName = createRegistryName();
 		setRegistryName(registryName);
 
-		IEContent.registeredIEBlocks.add(this);
+		if(shouldRegisterBlock())
+			IEContent.registeredIEBlocks.add(this);
 		Item item = createItemBlock.apply(this, new Item.Properties().group(getItemGroup()));
 		if(item!=null)
 		{
 			item.setRegistryName(registryName);
-			IEContent.registeredIEItems.add(item);
+			if(shouldRegisterItem())
+				IEContent.registeredIEItems.add(item);
 		}
 		lightOpacity = 15;
 	}
@@ -261,6 +263,16 @@ public class IEBaseBlock extends Block implements IIEBlock, IWaterLoggable
 	public ItemGroup getItemGroup()
 	{
 		return ImmersiveEngineering.itemGroup;
+	}
+	
+	public boolean shouldRegisterBlock()
+	{
+		return true;
+	}
+	
+	public boolean shouldRegisterItem()
+	{
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
Adding these methods gives addons for IE the ability to re-use classes that extends IEBaseBlock (and IEBaseBlock itself) without having to resort to hacks to get the block and blockitem out of IE. This was already half-way there with the `createRegistryName()` method.

I decided to separate the block and blockitem registration boolean methods just in case, but they could just as well be merged into one method, as if you're registering one with IE you'll probably want to register both anyways.