### PR TITLE
Use VBOs for some tile renders

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/api/client/IVertexBufferHolder.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/client/IVertexBufferHolder.java
@@ -1,0 +1,40 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ *
+ */
+
+package blusunrize.immersiveengineering.api.client;
+
+import blusunrize.immersiveengineering.api.utils.SetRestrictedField;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.model.BakedQuad;
+import net.minecraftforge.common.util.NonNullSupplier;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Used to render models in TERs using VBOs. For complex models this is significantly more efficient than rendering
+ * the model directly. Make sure to always call {@link IVertexBufferHolder#reset()} if a vertex buffer is not going to be
+ * used again. If VBOs are disabled in the IE config {@link IVertexBufferHolder#render(RenderType, int, int, IRenderTypeBuffer, MatrixStack)}
+ * will render to the given render type buffer instead of actually using VBOs.
+ */
+public interface IVertexBufferHolder
+{
+	SetRestrictedField<Function<NonNullSupplier<List<BakedQuad>>, IVertexBufferHolder>> CREATE = new SetRestrictedField<>();
+
+	static IVertexBufferHolder create(NonNullSupplier<List<BakedQuad>> getQuads)
+	{
+		return CREATE.getValue().apply(getQuads);
+	}
+
+	void render(RenderType type, int light, int overlay, IRenderTypeBuffer directOut, MatrixStack transform);
+
+	void reset();
+}

--- a/src/main/java/blusunrize/immersiveengineering/api/utils/ResettableLazy.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/utils/ResettableLazy.java
@@ -1,4 +1,13 @@
-package blusunrize.immersiveengineering.client.utils;
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ *
+ */
+
+package blusunrize.immersiveengineering.api.utils;
 
 import net.minecraftforge.common.util.NonNullConsumer;
 import net.minecraftforge.common.util.NonNullSupplier;

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
@@ -37,6 +37,7 @@ import blusunrize.immersiveengineering.client.render.IEOBJItemRenderer;
 import blusunrize.immersiveengineering.client.render.entity.*;
 import blusunrize.immersiveengineering.client.render.tile.*;
 import blusunrize.immersiveengineering.client.render.tile.DynamicModel.ModelType;
+import blusunrize.immersiveengineering.client.utils.VertexBufferHolder;
 import blusunrize.immersiveengineering.common.CommonProxy;
 import blusunrize.immersiveengineering.common.IEConfig;
 import blusunrize.immersiveengineering.common.IEContent;
@@ -153,6 +154,7 @@ public class ClientProxy extends CommonProxy
 			ModelLoaderRegistry.registerLoader(MultiLayerLoader.LOCATION, new MultiLayerLoader());
 			ModelLoaderRegistry.registerLoader(FeedthroughLoader.LOCATION, new FeedthroughLoader());
 			ModelLoaderRegistry.registerLoader(SplitModelLoader.LOCATION, new SplitModelLoader());
+			VertexBufferHolder.addToAPI();
 
 			((IReloadableResourceManager)mc().getResourceManager()).addReloadListener(new IEFontReloadListener());
 			requestModelsAndTextures();

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientProxy.java
@@ -591,6 +591,7 @@ public class ClientProxy extends CommonProxy
 		IEApi.renderCacheClearers.add(ClocheRenderer::reset);
 		IEApi.renderCacheClearers.add(WatermillRenderer::reset);
 		IEApi.renderCacheClearers.add(WindmillRenderer::reset);
+		IEApi.renderCacheClearers.add(BucketWheelRenderer::reset);
 		IEApi.renderCacheClearers.add(ModelCoresample::clearCache);
 		IEApi.renderCacheClearers.add(ModelItemDynamicOverride.modelCache::clear);
 		IEApi.renderCacheClearers.add(ModelPowerpack.catenaryCacheLeft::invalidateAll);

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientUtils.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientUtils.java
@@ -1178,47 +1178,26 @@ public class ClientUtils
 		return (val/scale)*(val/scale);
 	}
 
-	public static void renderModelTESRFast(List<BakedQuad> quads, IVertexBuilder renderer, MatrixStack transform, int light)
+	public static void renderModelTESRFast(List<BakedQuad> quads, IVertexBuilder renderer, MatrixStack transform,
+										   int light, int overlay)
 	{
-		renderModelTESRFast(quads, renderer, transform, -1, light);
+		renderModelTESRFast(quads, renderer, transform, -1, light, overlay);
 	}
 
-	public static void renderModelTESRFast(List<BakedQuad> quads, IVertexBuilder renderer, MatrixStack transform, int color, int light)
+	public static void renderModelTESRFast(List<BakedQuad> quads, IVertexBuilder renderer, MatrixStack transform,
+										   int color, int light, int overlay)
 	{
-		int[] rgba = {255, 255, 255, 255};
+		float red = 1;
+		float green = 1;
+		float blue = 1;
 		if(color >= 0)
 		{
-			rgba[0] = color >> 16&255;
-			rgba[1] = color >> 8&255;
-			rgba[2] = color&255;
+			red = (color >> 16&255)/255F;
+			green = (color >> 8&255)/255F;
+			blue = (color&255)/255F;
 		}
-		VertexFormat format = DefaultVertexFormats.BLOCK;
-		int size = format.getIntegerSize();
-		int uv = findTextureOffset(format);
-		int position = findPositionOffset(format);
-		int normal = findOffset(format, Usage.NORMAL, Type.BYTE);
 		for(BakedQuad quad : quads)
-		{
-			int[] vData = quad.getVertexData();
-			for(int i = 0; i < 4; ++i)
-			{
-				int normalPacked = vData[size*i+normal];
-				float normalX = (normalPacked&255)/255F;
-				float normalY = ((normalPacked >> 8)&255)/255F;
-				float normalZ = ((normalPacked >> 16)&255)/255F;
-				renderer
-						.pos(transform.getLast().getMatrix(),
-								Float.intBitsToFloat(vData[size*i+position]),
-								Float.intBitsToFloat(vData[size*i+position+1]),
-								Float.intBitsToFloat(vData[size*i+position+2]))
-						.color(rgba[0], rgba[1], rgba[2], rgba[3])
-						.tex(Float.intBitsToFloat(vData[size*i+uv]), Float.intBitsToFloat(vData[size*i+uv+1]))
-						.lightmap(light)
-						.normal(transform.getLast().getNormal(), normalX, normalY, normalZ)
-						.endVertex();
-			}
-
-		}
+			renderer.addQuad(transform.getLast(), quad, red, green, blue, light, overlay);
 	}
 
 	public static boolean isSneakKeyPressed()

--- a/src/main/java/blusunrize/immersiveengineering/client/ClientUtils.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/ClientUtils.java
@@ -1221,17 +1221,6 @@ public class ClientUtils
 		}
 	}
 
-	public static void setLightmapDisabled(boolean disabled)
-	{
-		//TODO
-		throw new UnsupportedOperationException();
-	}
-
-	public static void toggleLightmap(boolean pre, boolean disabled)
-	{
-		throw new UnsupportedOperationException();
-	}
-
 	public static boolean isSneakKeyPressed()
 	{
 		if(Minecraft.getInstance().gameSettings==null)

--- a/src/main/java/blusunrize/immersiveengineering/client/models/obj/IEOBJModel.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/obj/IEOBJModel.java
@@ -9,6 +9,7 @@
 package blusunrize.immersiveengineering.client.models.obj;
 
 import blusunrize.immersiveengineering.api.IEProperties.IEObjState;
+import com.google.common.collect.ImmutableMap;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.renderer.model.*;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -39,7 +40,8 @@ public class IEOBJModel implements IModelGeometry<IEOBJModel>
 							IModelTransform modelTransform, ItemOverrideList overrides, ResourceLocation modelLocation)
 	{
 		IBakedModel baseBaked = base.bake(owner, bakery, spriteGetter, modelTransform, overrides, modelLocation);
-		return new IESmartObjModel(base, baseBaked, owner, bakery, spriteGetter, modelTransform, state, dynamic);
+		return new IESmartObjModel(base, baseBaked, owner, bakery, spriteGetter, modelTransform, state, dynamic,
+				ImmutableMap.of());
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/client/models/obj/IESmartObjModel.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/obj/IESmartObjModel.java
@@ -366,7 +366,6 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 		RenderCacheKey key = getKey(blockState, modelData, addAnimationAndTex, visibility, tex);
 		try
 		{
-			modelCache.invalidateAll();
 			List<BakedQuad> quads = modelCache.get(key, () ->
 			{
 				IESmartObjModel model;
@@ -449,7 +448,7 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 		if(sCase!=null)
 			objCacheKey += ";"+sCase.getShaderType().toString();
 		Pair<String, String> cacheKey = Pair.of(groupName, objCacheKey);
-		if(allowCaching&&false)
+		if(allowCaching)
 		{
 			List<ShadedQuads> cached = groupCache.getIfPresent(cacheKey);
 			if(cached!=null)

--- a/src/main/java/blusunrize/immersiveengineering/client/models/obj/IESmartObjModel.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/obj/IESmartObjModel.java
@@ -83,6 +83,7 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 	public static LivingEntity tempEntityStatic;
 	public TransformType lastCameraTransform;
 	public boolean isDynamic;
+	private final Map<String, String> texReplacements;
 
 	public final OBJModel baseModel;
 	private final IBakedModel baseBaked;
@@ -95,7 +96,7 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 
 	public IESmartObjModel(OBJModel baseModel, IBakedModel baseBaked, IModelConfiguration owner, ModelBakery bakery,
 						   Function<Material, TextureAtlasSprite> spriteGetter, IModelTransform sprite,
-						   IEObjState state, boolean dynamic)
+						   IEObjState state, boolean dynamic, Map<String, String> texReplacements)
 	{
 
 		this.baseModel = baseModel;
@@ -106,6 +107,7 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 		this.sprite = sprite;
 		this.state = state;
 		this.isDynamic = dynamic;
+		this.texReplacements = texReplacements;
 	}
 
 	@Override
@@ -259,7 +261,7 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 
 					model = new IESmartObjModel(smrtModel.baseModel, smrtModel.baseBaked, smrtModel.owner, smrtModel.bakery,
 							smrtModel.spriteGetter, smrtModel.sprite,
-							smrtModel.state, smrtModel.isDynamic);
+							smrtModel.state, smrtModel.isDynamic, ImmutableMap.of());
 					((IESmartObjModel)model).tempStack = stack;
 					((IESmartObjModel)model).tempEntity = entity;
 				}
@@ -364,13 +366,14 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 		RenderCacheKey key = getKey(blockState, modelData, addAnimationAndTex, visibility, tex);
 		try
 		{
+			modelCache.invalidateAll();
 			List<BakedQuad> quads = modelCache.get(key, () ->
 			{
 				IESmartObjModel model;
 				if(visibility!=null)
-					model = new IESmartObjModel(baseModel, baseBaked, owner, bakery, spriteGetter, sprite, visibility, isDynamic);
+					model = new IESmartObjModel(baseModel, baseBaked, owner, bakery, spriteGetter, sprite, visibility, isDynamic, tex);
 				else
-					model = new IESmartObjModel(baseModel, baseBaked, owner, bakery, spriteGetter, sprite, this.state, isDynamic);
+					model = new IESmartObjModel(baseModel, baseBaked, owner, bakery, spriteGetter, sprite, this.state, isDynamic, tex);
 
 				model.tempState = blockState;
 				return model.buildQuads(modelData);
@@ -478,11 +481,12 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 					coordinateRemapper.setRenderPass(pass);
 					//g.addQuads(owner, new QuadListAdder(quads::add, transform), bakery, spriteGetter, sprite, format);
 					IModelBuilder modelBuilder = new QuadListAdder(quads::add, transform);
-					addModelObjectQuads(g, owner, modelBuilder, spriteGetter, colorGetter, coordinateRemapper, optionalTransform);
+					Optional<String> texOverride = Optional.ofNullable(texReplacements.get(groupName));
+					addModelObjectQuads(g, owner, modelBuilder, spriteGetter, colorGetter, coordinateRemapper, optionalTransform, texOverride);
 					final TransformationMatrix finalTransform = optionalTransform;
 					g.getParts().stream().filter(part -> owner.getPartVisibility(part)&&part instanceof ModelObject)
 							.forEach(part -> addModelObjectQuads((ModelObject)part, owner, modelBuilder, spriteGetter,
-									colorGetter, coordinateRemapper, finalTransform));
+									colorGetter, coordinateRemapper, finalTransform, texOverride));
 					ShaderLayer layer = sCase!=null?sCase.getLayers()[pass]: new ShaderLayer(new ResourceLocation("missing/no"), -1)
 					{
 						@Override
@@ -504,7 +508,7 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 	private void addModelObjectQuads(ModelObject modelObject, IModelConfiguration owner, IModelBuilder<?> modelBuilder,
 									 MaterialSpriteGetter<?> spriteGetter, MaterialColorGetter<?> colorGetter,
 									 TextureCoordinateRemapper coordinateRemapper,
-									 TransformationMatrix transform)
+									 TransformationMatrix transform, Optional<String> textureOverride)
 	{
 		List<MeshWrapper> meshes = OBJHelper.getMeshes(modelObject);
 		for(MeshWrapper mesh : meshes)
@@ -514,7 +518,7 @@ public class IESmartObjModel implements ICacheKeyProvider<RenderCacheKey>
 				continue;
 			TextureAtlasSprite texture = spriteGetter.apply(
 					mat.name,
-					ModelLoaderRegistry.resolveTexture(mat.diffuseColorMap, owner)
+					ModelLoaderRegistry.resolveTexture(textureOverride.orElse(mat.diffuseColorMap), owner)
 			);
 			int tintIndex = mat.diffuseTintIndex;
 			Vector4f colorTint = colorGetter.apply(mat.name, mat.diffuseColor);

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/BottlingMachineRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/BottlingMachineRenderer.java
@@ -21,18 +21,21 @@ import blusunrize.immersiveengineering.common.blocks.metal.BottlingMachineTileEn
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.vertex.IVertexBuilder;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.*;
-import net.minecraft.client.renderer.model.IBakedModel;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.Quaternion;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Vector3f;
+import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.ItemCameraTransforms.TransformType;
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import net.minecraftforge.client.model.data.IModelData;
 import net.minecraftforge.fluids.FluidStack;
+
+import java.util.List;
 
 public class BottlingMachineRenderer extends TileEntityRenderer<BottlingMachineTileEntity>
 {
@@ -50,12 +53,11 @@ public class BottlingMachineRenderer extends TileEntityRenderer<BottlingMachineT
 			return;
 
 		//Grab model
-		final BlockRendererDispatcher blockRenderer = Minecraft.getInstance().getBlockRendererDispatcher();
 		BlockPos blockPos = te.getPos();
 		BlockState state = te.getWorld().getBlockState(blockPos);
 		if(state.getBlock()!=Multiblocks.bottlingMachine)
 			return;
-		IBakedModel model = DYNAMIC.get(te.getFacing());
+		Direction facing = te.getFacing();
 
 		//Outer GL Wrapping, initial translation
 		matrixStack.push();
@@ -117,12 +119,12 @@ public class BottlingMachineRenderer extends TileEntityRenderer<BottlingMachineT
 		matrixStack.push();
 
 		matrixStack.translate(0, lift, 0);
-		renderModelPart(blockRenderer, matrixStack, solidBuilder, te.getWorldNonnull(), state, model, blockPos, combinedOverlayIn, "lift");
+		renderModelPart(matrixStack, solidBuilder, facing, combinedLightIn, combinedOverlayIn, "lift");
 		matrixStack.translate(0, -lift, 0);
 
 		matrixStack.pop();
 
-		float dir = te.getFacing()==Direction.SOUTH?180: te.getFacing()==Direction.NORTH?0: te.getFacing()==Direction.EAST?-90: 90;
+		float dir = facing==Direction.SOUTH?180: facing==Direction.NORTH?0: facing==Direction.EAST?-90: 90;
 		matrixStack.rotate(new Quaternion(0, dir, 0, true));
 
 		float scale = .0625f;
@@ -190,15 +192,14 @@ public class BottlingMachineRenderer extends TileEntityRenderer<BottlingMachineT
 		matrixStack.pop();
 	}
 
-	public static void renderModelPart(final BlockRendererDispatcher blockRenderer, MatrixStack matrixStack,
-									   IVertexBuilder builder, World world, BlockState state, IBakedModel model,
-									   BlockPos pos, int combinedOverlayIn, String... parts)
+	public static void renderModelPart(MatrixStack matrixStack, IVertexBuilder builder, Direction facing,
+									   int combinedLightIn, int combinedOverlayIn, String... parts)
 	{
 		IModelData data = new SinglePropertyModelData<>(new IEObjState(VisibilityList.show(parts)), Model.IE_OBJ_STATE);
 		matrixStack.push();
 		matrixStack.translate(-.5, -.5, -.5);
-		blockRenderer.getBlockModelRenderer().renderModel(world, model, state, pos, matrixStack, builder, true, world.rand, 0,
-				combinedOverlayIn, data);
+		List<BakedQuad> quads = DYNAMIC.getNullQuads(facing, Multiblocks.bottlingMachine.getDefaultState(), data);
+		ClientUtils.renderModelTESRFast(quads, builder, matrixStack, combinedLightIn, combinedOverlayIn);
 		matrixStack.pop();
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/BucketWheelRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/BucketWheelRenderer.java
@@ -11,13 +11,14 @@ package blusunrize.immersiveengineering.client.render.tile;
 import blusunrize.immersiveengineering.api.IEProperties.IEObjState;
 import blusunrize.immersiveengineering.api.IEProperties.VisibilityList;
 import blusunrize.immersiveengineering.client.ClientUtils;
-import blusunrize.immersiveengineering.client.models.IOBJModelCallback;
 import blusunrize.immersiveengineering.client.models.obj.IESmartObjModel;
-import blusunrize.immersiveengineering.client.utils.SinglePropertyModelData;
+import blusunrize.immersiveengineering.client.utils.VertexBufferHolder;
 import blusunrize.immersiveengineering.common.IEConfig;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.Multiblocks;
 import blusunrize.immersiveengineering.common.blocks.metal.BucketWheelTileEntity;
 import blusunrize.immersiveengineering.common.util.Utils;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.Lists;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.vertex.IVertexBuilder;
@@ -25,14 +26,19 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.Quaternion;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Vector3f;
 import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Direction;
-import net.minecraftforge.client.model.data.IModelData;
+import net.minecraftforge.client.model.data.EmptyModelData;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,25 +58,37 @@ public class BucketWheelRenderer extends TileEntityRenderer<BucketWheelTileEntit
 	{
 		if(!tile.formed||!tile.getWorldNonnull().isBlockLoaded(tile.getPos())||tile.isDummy())
 			return;
-		final BlockRendererDispatcher blockRenderer = Minecraft.getInstance().getBlockRendererDispatcher();
 		BlockState state = tile.getWorldNonnull().getBlockState(tile.getPos());
 		if(state.getBlock()!=Multiblocks.bucketWheel)
 			return;
 		IBakedModel model = WHEEL.get(null);
 		Map<String, String> texMap = new HashMap<>();
 		List<String> list = Lists.newArrayList("bucketWheel");
+		List<String> textures = new ArrayList<>(8);
+		int offset = 0;
 		synchronized(tile.digStacks)
 		{
 			for(int i = 0; i < tile.digStacks.size(); i++)
 				if(!tile.digStacks.get(i).isEmpty())
 				{
+					offset = i;
+					break;
+				}
+			for(int i = 0; i < tile.digStacks.size(); i++)
+			{
+				int realIndex = (i+offset)%tile.digStacks.size();
+				ItemStack stackAtIndex = tile.digStacks.get(realIndex);
+				if(!stackAtIndex.isEmpty())
+				{
 					list.add("dig"+i);
-					Block b = Block.getBlockFromItem(tile.digStacks.get(i).getItem());
+					Block b = Block.getBlockFromItem(stackAtIndex.getItem());
 					BlockState digState = b!=Blocks.AIR?b.getDefaultState(): Blocks.COBBLESTONE.getDefaultState();
 					IBakedModel digModel = Minecraft.getInstance().getBlockRendererDispatcher().getBlockModelShapes().getModel(digState);
-					digModel.getParticleTexture();
-					texMap.put("dig"+i, digModel.getParticleTexture().getName().toString());
+					String texture = digModel.getParticleTexture().getName().toString();
+					texMap.put("dig"+i, texture);
+					textures.add(texture);
 				}
+			}
 		}
 		IEObjState objState = new IEObjState(VisibilityList.show(list));
 
@@ -80,18 +98,16 @@ public class BucketWheelRenderer extends TileEntityRenderer<BucketWheelTileEntit
 		bufferIn = TileRenderUtils.mirror(tile, matrixStack, bufferIn);
 		float dir = tile.getFacing()==Direction.SOUTH?90: tile.getFacing()==Direction.NORTH?-90: tile.getFacing()==Direction.EAST?180: 0;
 		matrixStack.rotate(new Quaternion(new Vector3f(0, 1, 0), dir, true));
-		float rot = tile.rotation+(float)(tile.active?IEConfig.MACHINES.excavator_speed.get()*partialTicks: 0);
+		float rot = tile.rotation-45*offset+(float)(tile.active?IEConfig.MACHINES.excavator_speed.get()*partialTicks: 0);
 		matrixStack.rotate(new Quaternion(new Vector3f(1, 0, 0), rot, true));
 
 		matrixStack.translate(-.5, -.5, -.5);
 		IVertexBuilder builder = bufferIn.getBuffer(RenderType.getSolid());
-		IModelData modelData = new SinglePropertyModelData<>(tile, IOBJModelCallback.PROPERTY);
 		List<BakedQuad> quads;
 		if(model instanceof IESmartObjModel)
-			quads = ((IESmartObjModel)model).getQuads(state, objState, texMap,
-					true, modelData);
+			quads = ((IESmartObjModel)model).getQuads(state, objState, texMap, true, EmptyModelData.INSTANCE);
 		else
-			quads = model.getQuads(state, null, Utils.RAND, modelData);
+			quads = model.getQuads(state, null, Utils.RAND, EmptyModelData.INSTANCE);
 		ClientUtils.renderModelTESRFast(quads, builder, matrixStack, combinedLightIn);
 		matrixStack.pop();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/BucketWheelRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/BucketWheelRenderer.java
@@ -10,8 +10,8 @@ package blusunrize.immersiveengineering.client.render.tile;
 
 import blusunrize.immersiveengineering.api.IEProperties.IEObjState;
 import blusunrize.immersiveengineering.api.IEProperties.VisibilityList;
+import blusunrize.immersiveengineering.api.client.IVertexBufferHolder;
 import blusunrize.immersiveengineering.client.models.obj.IESmartObjModel;
-import blusunrize.immersiveengineering.client.utils.VertexBufferHolder;
 import blusunrize.immersiveengineering.common.IEConfig;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.Multiblocks;
 import blusunrize.immersiveengineering.common.blocks.metal.BucketWheelTileEntity;
@@ -46,10 +46,10 @@ import java.util.concurrent.TimeUnit;
 public class BucketWheelRenderer extends TileEntityRenderer<BucketWheelTileEntity>
 {
 	public static DynamicModel<Void> WHEEL;
-	private static final Cache<List<String>, VertexBufferHolder> CACHED_BUFFERS = CacheBuilder.newBuilder()
+	private static final Cache<List<String>, IVertexBufferHolder> CACHED_BUFFERS = CacheBuilder.newBuilder()
 			.maximumSize(100)
 			.expireAfterAccess(1, TimeUnit.MINUTES)
-			.<Object, VertexBufferHolder>removalListener(rem -> rem.getValue().reset())
+			.<Object, IVertexBufferHolder>removalListener(rem -> rem.getValue().reset())
 			.build();
 
 	public BucketWheelRenderer(TileEntityRendererDispatcher rendererDispatcherIn)
@@ -102,7 +102,7 @@ public class BucketWheelRenderer extends TileEntityRenderer<BucketWheelTileEntit
 		matrixStack.translate(-.5, -.5, -.5);
 		try
 		{
-			CACHED_BUFFERS.get(textures, () -> new VertexBufferHolder(() -> {
+			CACHED_BUFFERS.get(textures, () -> IVertexBufferHolder.create(() -> {
 				IBakedModel model = WHEEL.get(null);
 				BlockState state = Multiblocks.bucketWheel.getDefaultState();
 				List<String> list = Lists.newArrayList("bucketWheel");

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/CrusherRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/CrusherRenderer.java
@@ -8,19 +8,20 @@
 
 package blusunrize.immersiveengineering.client.render.tile;
 
+import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.Multiblocks;
 import blusunrize.immersiveengineering.common.blocks.metal.CrusherTileEntity;
 import com.mojang.blaze3d.matrix.MatrixStack;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.*;
-import net.minecraft.client.renderer.model.IBakedModel;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.Quaternion;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Vector3f;
+import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
-import net.minecraft.util.math.BlockPos;
-import net.minecraftforge.client.model.data.EmptyModelData;
+
+import java.util.List;
 
 public class CrusherRenderer extends TileEntityRenderer<CrusherTileEntity>
 {
@@ -37,13 +38,7 @@ public class CrusherRenderer extends TileEntityRenderer<CrusherTileEntity>
 		if(!te.formed||te.isDummy()||!te.getWorldNonnull().isBlockLoaded(te.getPos()))
 			return;
 
-		final BlockRendererDispatcher blockRenderer = Minecraft.getInstance().getBlockRendererDispatcher();
-		BlockPos blockPos = te.getPos();
-		BlockState state = te.getWorld().getBlockState(blockPos);
-		if(state.getBlock()!=Multiblocks.crusher)
-			return;
 		Direction dir = te.getFacing();
-		IBakedModel model = BARREL.get(dir);
 
 		boolean b = te.shouldRenderAsActive();
 		float angle = te.animation_barrelRotation+(b?18*partialTicks: 0);
@@ -55,26 +50,24 @@ public class CrusherRenderer extends TileEntityRenderer<CrusherTileEntity>
 
 		matrixStack.push();
 		matrixStack.rotate(new Quaternion(new Vector3f(-te.getFacing().getZOffset(), 0, te.getFacing().getXOffset()), angle, true));
-		renderPart(matrixStack, bufferIn, blockPos, blockRenderer, te, model, state, combinedOverlayIn);
+		renderBarrel(matrixStack, bufferIn, dir, combinedLightIn, combinedOverlayIn);
 		matrixStack.pop();
 
 		matrixStack.push();
 		matrixStack.translate(te.getFacing().getXOffset()*-1, 0, te.getFacing().getZOffset()*-1);
 		matrixStack.rotate(new Quaternion(new Vector3f(-te.getFacing().getZOffset(), 0, te.getFacing().getXOffset()), -angle, true));
-		renderPart(matrixStack, bufferIn, blockPos, blockRenderer, te, model, state, combinedOverlayIn);
+		renderBarrel(matrixStack, bufferIn, dir, combinedLightIn, combinedOverlayIn);
 		matrixStack.pop();
 
 		matrixStack.pop();
 	}
 
-	private void renderPart(MatrixStack matrix, IRenderTypeBuffer buffer, BlockPos pos, BlockRendererDispatcher blockRenderer,
-							TileEntity te, IBakedModel model, BlockState state, int overlay)
+	private void renderBarrel(MatrixStack matrix, IRenderTypeBuffer buffer, Direction facing, int light, int overlay)
 	{
 		matrix.push();
 		matrix.translate(-.5, -.5, -.5);
-		blockRenderer.getBlockModelRenderer().renderModel(te.getWorld(), model, state, pos, matrix,
-				buffer.getBuffer(RenderType.getSolid()), true, te.getWorld().rand,
-				0, overlay, EmptyModelData.INSTANCE);
+		List<BakedQuad> quads = BARREL.getNullQuads(facing, Multiblocks.crusher.getDefaultState());
+		ClientUtils.renderModelTESRFast(quads, buffer.getBuffer(RenderType.getSolid()), matrix, light, overlay);
 		matrix.pop();
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/DieselGeneratorRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/DieselGeneratorRenderer.java
@@ -8,19 +8,23 @@
 
 package blusunrize.immersiveengineering.client.render.tile;
 
+import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.Multiblocks;
 import blusunrize.immersiveengineering.common.blocks.metal.DieselGeneratorTileEntity;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.*;
-import net.minecraft.client.renderer.model.IBakedModel;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.Quaternion;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Vector3f;
+import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraftforge.client.model.data.EmptyModelData;
+
+import java.util.List;
 
 public class DieselGeneratorRenderer extends TileEntityRenderer<DieselGeneratorTileEntity>
 {
@@ -37,12 +41,10 @@ public class DieselGeneratorRenderer extends TileEntityRenderer<DieselGeneratorT
 		if(!te.formed||te.isDummy()||!te.getWorldNonnull().isBlockLoaded(te.getPos()))
 			return;
 
-		final BlockRendererDispatcher blockRenderer = Minecraft.getInstance().getBlockRendererDispatcher();
 		BlockPos blockPos = te.getPos();
 		BlockState state = te.getWorld().getBlockState(blockPos);
 		if(state.getBlock()!=Multiblocks.dieselGenerator)
 			return;
-		IBakedModel model = FAN.get(te.getFacing());
 
 		matrixStack.push();
 		matrixStack.translate(0, .6875, 0);
@@ -52,9 +54,9 @@ public class DieselGeneratorRenderer extends TileEntityRenderer<DieselGeneratorT
 				te.animation_fanRotation+(te.animation_fanRotationStep*partialTicks), true));
 		matrixStack.translate(-0.5, 0, -0.5);
 
-		blockRenderer.getBlockModelRenderer().renderModel(te.getWorldNonnull(), model, state, blockPos, matrixStack,
-				bufferIn.getBuffer(RenderType.getSolid()), true, te.getWorld().rand, 0, combinedOverlayIn,
-				EmptyModelData.INSTANCE);
+		List<BakedQuad> quads = FAN.getNullQuads(te.getFacing(), state);
+		ClientUtils.renderModelTESRFast(quads, bufferIn.getBuffer(RenderType.getSolid()), matrixStack, combinedLightIn,
+				combinedOverlayIn);
 
 		matrixStack.pop();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/DynamicModel.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/DynamicModel.java
@@ -11,18 +11,26 @@ package blusunrize.immersiveengineering.client.render.tile;
 import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.client.DynamicModelLoader;
 import blusunrize.immersiveengineering.client.DynamicModelLoader.ModelRequest;
+import net.minecraft.block.BlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BlockRendererDispatcher;
+import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.model.ModelResourceLocation;
 import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.data.EmptyModelData;
+import net.minecraftforge.client.model.data.IModelData;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 public abstract class DynamicModel<T>
 {
+	private static final Random RAND = new Random();
+
 	public abstract IBakedModel get(T key);
 
 	public static DynamicModel<Void> createSimple(ResourceLocation model, String key, ModelType type)
@@ -35,14 +43,22 @@ public abstract class DynamicModel<T>
 		return new SidedDynamicModel(model, key, type);
 	}
 
+	public List<BakedQuad> getNullQuads(T key, BlockState state)
+	{
+		return getNullQuads(key, state, EmptyModelData.INSTANCE);
+	}
+
+	public List<BakedQuad> getNullQuads(T key, BlockState state, IModelData data)
+	{
+		return get(key).getQuads(state, null, RAND, data);
+	}
+
 	private static class SidedDynamicModel extends DynamicModel<Direction>
 	{
 		private final Map<Direction, ModelResourceLocation> names = new HashMap<>();
-		private final ResourceLocation modelLocation;
 
 		private SidedDynamicModel(ResourceLocation name, String desc, ModelType type)
 		{
-			this.modelLocation = name;
 			ResourceLocation baseLoc = new ResourceLocation(ImmersiveEngineering.MODID, "dynamic/"+desc);
 			for(Direction d : Direction.BY_HORIZONTAL_INDEX)
 			{
@@ -64,11 +80,9 @@ public abstract class DynamicModel<T>
 	private static class SimpleDynamicModel extends DynamicModel<Void>
 	{
 		private final ModelResourceLocation name;
-		private final ResourceLocation modelLocation;
 
 		private SimpleDynamicModel(ResourceLocation name, String desc, ModelType type)
 		{
-			this.modelLocation = name;
 			ResourceLocation baseLoc = new ResourceLocation(ImmersiveEngineering.MODID, "dynamic/"+desc);
 			this.name = new ModelResourceLocation(baseLoc, "");
 			DynamicModelLoader.requestModel( DynamicModel.getRequest(type, name, 0), this.name);

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/SampleDrillRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/SampleDrillRenderer.java
@@ -14,7 +14,10 @@ import blusunrize.immersiveengineering.common.blocks.IEBlocks.MetalDevices;
 import blusunrize.immersiveengineering.common.blocks.metal.SampleDrillTileEntity;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.Quaternion;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.Vector3f;
 import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
@@ -59,8 +62,6 @@ public class SampleDrillRenderer extends TileEntityRenderer<SampleDrillTileEntit
 		ClientUtils.renderModelTESRFast(
 				quads, bufferIn.getBuffer(RenderType.getSolid()), matrixStack, combinedLightIn, combinedOverlayIn
 		);
-		matrixStack.translate(1, 0, 0);
 		matrixStack.pop();
-		RenderHelper.enableStandardItemLighting();
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/SampleDrillRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/SampleDrillRenderer.java
@@ -8,17 +8,18 @@
 
 package blusunrize.immersiveengineering.client.render.tile;
 
+import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.common.IEConfig;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.MetalDevices;
 import blusunrize.immersiveengineering.common.blocks.metal.SampleDrillTileEntity;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.block.BlockState;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.*;
-import net.minecraft.client.renderer.model.IBakedModel;
+import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
-import net.minecraftforge.client.model.data.EmptyModelData;
+
+import java.util.List;
 
 public class SampleDrillRenderer extends TileEntityRenderer<SampleDrillTileEntity>
 {
@@ -36,9 +37,7 @@ public class SampleDrillRenderer extends TileEntityRenderer<SampleDrillTileEntit
 		if(tile.isDummy()||!tile.getWorldNonnull().isBlockLoaded(tile.getPos()))
 			return;
 
-		final BlockRendererDispatcher blockRenderer = Minecraft.getInstance().getBlockRendererDispatcher();
 		BlockState state = tile.getWorldNonnull().getBlockState(tile.getPos());
-		IBakedModel model = DRILL.get(null);
 		if(state.getBlock()!=MetalDevices.sampleDrill)
 			return;
 
@@ -56,8 +55,11 @@ public class SampleDrillRenderer extends TileEntityRenderer<SampleDrillTileEntit
 		}
 
 		matrixStack.translate(-0.5, -0.5, -0.5);
-		blockRenderer.getBlockModelRenderer().renderModel(tile.getWorldNonnull(), model, state, tile.getPos(), matrixStack,
-				bufferIn.getBuffer(RenderType.getSolid()), true, tile.getWorld().rand, 0, combinedOverlayIn, EmptyModelData.INSTANCE);
+		List<BakedQuad> quads = DRILL.getNullQuads(null, state);
+		ClientUtils.renderModelTESRFast(
+				quads, bufferIn.getBuffer(RenderType.getSolid()), matrixStack, combinedLightIn, combinedOverlayIn
+		);
+		matrixStack.translate(1, 0, 0);
 		matrixStack.pop();
 		RenderHelper.enableStandardItemLighting();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/WatermillRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/WatermillRenderer.java
@@ -9,7 +9,7 @@
 package blusunrize.immersiveengineering.client.render.tile;
 
 import blusunrize.immersiveengineering.api.IEProperties;
-import blusunrize.immersiveengineering.client.utils.VertexBufferHolder;
+import blusunrize.immersiveengineering.api.client.IVertexBufferHolder;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.WoodenDevices;
 import blusunrize.immersiveengineering.common.blocks.wooden.WatermillTileEntity;
 import blusunrize.immersiveengineering.common.util.Utils;
@@ -27,7 +27,7 @@ import net.minecraftforge.client.model.data.EmptyModelData;
 public class WatermillRenderer extends TileEntityRenderer<WatermillTileEntity>
 {
 	public static DynamicModel<Void> MODEL;
-	private static final VertexBufferHolder MODEL_BUFFER = new VertexBufferHolder(() -> {
+	private static final IVertexBufferHolder MODEL_BUFFER = IVertexBufferHolder.create(() -> {
 		BlockState state = WoodenDevices.watermill.getDefaultState()
 				.with(IEProperties.FACING_HORIZONTAL, Direction.NORTH);
 		return MODEL.get(null).getQuads(state, null, Utils.RAND, EmptyModelData.INSTANCE);

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/WatermillRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/WatermillRenderer.java
@@ -9,29 +9,29 @@
 package blusunrize.immersiveengineering.client.render.tile;
 
 import blusunrize.immersiveengineering.api.IEProperties;
-import blusunrize.immersiveengineering.client.ClientUtils;
+import blusunrize.immersiveengineering.client.utils.VertexBufferHolder;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.WoodenDevices;
 import blusunrize.immersiveengineering.common.blocks.wooden.WatermillTileEntity;
 import blusunrize.immersiveengineering.common.util.Utils;
 import com.mojang.blaze3d.matrix.MatrixStack;
-import com.mojang.blaze3d.vertex.IVertexBuilder;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.Quaternion;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.Vector3f;
-import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.util.Direction;
 import net.minecraftforge.client.model.data.EmptyModelData;
 
-import java.util.List;
-
 public class WatermillRenderer extends TileEntityRenderer<WatermillTileEntity>
 {
-	private static List<BakedQuad> quads;
 	public static DynamicModel<Void> MODEL;
+	private static final VertexBufferHolder MODEL_BUFFER = new VertexBufferHolder(() -> {
+		BlockState state = WoodenDevices.watermill.getDefaultState()
+				.with(IEProperties.FACING_HORIZONTAL, Direction.NORTH);
+		return MODEL.get(null).getQuads(state, null, Utils.RAND, EmptyModelData.INSTANCE);
+	});
 
 	public WatermillRenderer(TileEntityRendererDispatcher rendererDispatcherIn)
 	{
@@ -39,33 +39,24 @@ public class WatermillRenderer extends TileEntityRenderer<WatermillTileEntity>
 	}
 
 	@Override
-	public void render(WatermillTileEntity tile, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer bufferIn, int combinedLightIn, int combinedOverlayIn)
+	public void render(WatermillTileEntity tile, float partialTicks, MatrixStack transform, IRenderTypeBuffer bufferIn,
+					   int combinedLightIn, int combinedOverlayIn)
 	{
 		if(tile.isDummy()||!tile.getWorldNonnull().isBlockLoaded(tile.getPos()))
 			return;
-		if(quads==null)
-		{
-			BlockState state = tile.getWorldNonnull().getBlockState(tile.getPos());
-			if(state.getBlock()!=WoodenDevices.watermill)
-				return;
-			state = state.with(IEProperties.FACING_HORIZONTAL, Direction.NORTH);
-			quads = MODEL.get(null).getQuads(state, null, Utils.RAND, EmptyModelData.INSTANCE);
-		}
-		matrixStack.push();
-
-		matrixStack.translate(.5, .5, .5);
+		transform.push();
+		transform.translate(.5, .5, .5);
 		final float dir = (tile.getFacing().getHorizontalAngle()+180)%180;
 		float wheelRotation = 360*(tile.rotation+(!tile.canTurn||tile.rotation==0?0: partialTicks)*(float)tile.perTick);
-		matrixStack.rotate(new Quaternion(new Vector3f(0, 1, 0), dir, true));
-		matrixStack.rotate(new Quaternion(new Vector3f(0, 0, 1), wheelRotation, true));
-		matrixStack.translate(-.5, -.5, -.5);
-		IVertexBuilder builder = bufferIn.getBuffer(RenderType.getCutout());
-		ClientUtils.renderModelTESRFast(quads, builder, matrixStack, combinedLightIn);
-		matrixStack.pop();
+		transform.rotate(new Quaternion(new Vector3f(0, 1, 0), dir, true));
+		transform.rotate(new Quaternion(new Vector3f(0, 0, 1), wheelRotation, true));
+		transform.translate(-.5, -.5, -.5);
+		MODEL_BUFFER.render(RenderType.getCutoutMipped(), combinedLightIn, combinedOverlayIn, bufferIn, transform);
+		transform.pop();
 	}
 
 	public static void reset()
 	{
-		quads = null;
+		MODEL_BUFFER.reset();
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/WindmillRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/WindmillRenderer.java
@@ -11,8 +11,8 @@ package blusunrize.immersiveengineering.client.render.tile;
 import blusunrize.immersiveengineering.api.IEProperties;
 import blusunrize.immersiveengineering.api.IEProperties.IEObjState;
 import blusunrize.immersiveengineering.api.IEProperties.VisibilityList;
+import blusunrize.immersiveengineering.api.client.IVertexBufferHolder;
 import blusunrize.immersiveengineering.client.utils.SinglePropertyModelData;
-import blusunrize.immersiveengineering.client.utils.VertexBufferHolder;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.WoodenDevices;
 import blusunrize.immersiveengineering.common.blocks.wooden.WindmillTileEntity;
 import blusunrize.immersiveengineering.common.util.Utils;
@@ -35,17 +35,17 @@ import java.util.List;
 public class WindmillRenderer extends TileEntityRenderer<WindmillTileEntity>
 {
 	public static DynamicModel<Void> MODEL;
-	private static final VertexBufferHolder[] BUFFERS = new VertexBufferHolder[9];
+	private static final IVertexBufferHolder[] BUFFERS = new IVertexBufferHolder[9];
 
 	public WindmillRenderer(TileEntityRendererDispatcher rendererDispatcherIn)
 	{
 		super(rendererDispatcherIn);
 	}
 
-	private static VertexBufferHolder getBufferHolder(int sails)
+	private static IVertexBufferHolder getBufferHolder(int sails)
 	{
 		if(BUFFERS[sails]==null)
-			BUFFERS[sails] = new VertexBufferHolder(() -> {
+			BUFFERS[sails] = IVertexBufferHolder.create(() -> {
 				IBakedModel model = MODEL.get(null);
 				List<String> parts = new ArrayList<>();
 				parts.add("base");
@@ -81,7 +81,7 @@ public class WindmillRenderer extends TileEntityRenderer<WindmillTileEntity>
 
 	public static void reset()
 	{
-		for(VertexBufferHolder vbo : BUFFERS)
+		for(IVertexBufferHolder vbo : BUFFERS)
 			if(vbo!=null)
 				vbo.reset();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/WindmillRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/WindmillRenderer.java
@@ -11,80 +11,98 @@ package blusunrize.immersiveengineering.client.render.tile;
 import blusunrize.immersiveengineering.api.IEProperties;
 import blusunrize.immersiveengineering.api.IEProperties.IEObjState;
 import blusunrize.immersiveengineering.api.IEProperties.VisibilityList;
-import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.client.utils.SinglePropertyModelData;
+import blusunrize.immersiveengineering.client.utils.VertexBufferHolder;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.WoodenDevices;
 import blusunrize.immersiveengineering.common.blocks.wooden.WindmillTileEntity;
 import blusunrize.immersiveengineering.common.util.Utils;
 import com.mojang.blaze3d.matrix.MatrixStack;
-import com.mojang.blaze3d.vertex.IVertexBuilder;
-import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
 import net.minecraft.client.renderer.Quaternion;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.Vector3f;
-import net.minecraft.client.renderer.model.BakedQuad;
 import net.minecraft.client.renderer.model.IBakedModel;
 import net.minecraft.client.renderer.tileentity.TileEntityRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Direction.Axis;
-import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.client.model.data.IModelData;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 //TODO maybe replace with Forge animations?
 public class WindmillRenderer extends TileEntityRenderer<WindmillTileEntity>
 {
-	private static List<BakedQuad>[] quads = new List[9];
 	public static DynamicModel<Void> MODEL;
+	private static final Map<ModelKey, VertexBufferHolder> buffers = new HashMap<>();
 
 	public WindmillRenderer(TileEntityRendererDispatcher rendererDispatcherIn)
 	{
 		super(rendererDispatcherIn);
 	}
 
-	@Override
-	public void render(WindmillTileEntity tile, float partialTicks, MatrixStack matrixStack, IRenderTypeBuffer bufferIn, int combinedLightIn, int combinedOverlayIn)
+	private static VertexBufferHolder getBufferHolder(ModelKey key)
 	{
-		if(!tile.getWorldNonnull().isBlockLoaded(tile.getPos()))
-			return;
-		BlockPos blockPos = tile.getPos();
-		if(quads[tile.sails]==null)
-		{
-			BlockState state = tile.getWorld().getBlockState(blockPos);
-			if(state.getBlock()!=WoodenDevices.windmill)
-				return;
-			state = state.with(IEProperties.FACING_HORIZONTAL, Direction.NORTH);
-			IBakedModel model = this.MODEL.get(null);
+		return buffers.computeIfAbsent(key, k -> new VertexBufferHolder(() -> {
+			IBakedModel model = MODEL.get(null);
 			List<String> parts = new ArrayList<>();
 			parts.add("base");
-			for(int i = 1; i <= tile.sails; i++)
+			for(int i = 1; i <= k.sails; i++)
 				parts.add("sail_"+i);
 			IModelData data = new SinglePropertyModelData<>(
 					new IEObjState(VisibilityList.show(parts)), IEProperties.Model.IE_OBJ_STATE);
-			quads[tile.sails] = model.getQuads(state, null, Utils.RAND, data);
-		}
-		matrixStack.push();
-		matrixStack.translate(.5, .5, .5);
+			return model.getQuads(WoodenDevices.windmill.getDefaultState(), null, Utils.RAND, data);
+		}));
+	}
+
+	@Override
+	public void render(WindmillTileEntity tile, float partialTicks, MatrixStack transform, IRenderTypeBuffer bufferIn,
+					   int combinedLightIn, int combinedOverlayIn)
+	{
+		if(!tile.getWorldNonnull().isBlockLoaded(tile.getPos()))
+			return;
+		transform.push();
+		transform.translate(.5, .5, .5);
 
 		float dir = tile.getFacing()==Direction.SOUTH?0: tile.getFacing()==Direction.NORTH?180: tile.getFacing()==Direction.EAST?90: -90;
 		float rot = 360*(tile.rotation+(!tile.canTurn||tile.rotation==0?0: partialTicks)*tile.perTick);
 
-		matrixStack.rotate(new Quaternion(new Vector3f(tile.getFacing().getAxis()==Axis.X?1: 0, 0, tile.getFacing().getAxis()==Axis.Z?1: 0), rot, true));
-		matrixStack.rotate(new Quaternion(new Vector3f(0, 1, 0), dir, true));
+		transform.rotate(new Quaternion(new Vector3f(tile.getFacing().getAxis()==Axis.X?1: 0, 0, tile.getFacing().getAxis()==Axis.Z?1: 0), rot, true));
+		transform.rotate(new Quaternion(new Vector3f(0, 1, 0), dir, true));
 
-		matrixStack.translate(-.5, -.5, -.5);
-		IVertexBuilder builder = bufferIn.getBuffer(RenderType.getCutout());
-		ClientUtils.renderModelTESRFast(quads[tile.sails], builder, matrixStack, combinedLightIn);
-		matrixStack.pop();
+		transform.translate(-.5, -.5, -.5);
+		getBufferHolder(new ModelKey(tile.sails))
+				.render(RenderType.getCutoutMipped(), combinedLightIn, combinedOverlayIn, bufferIn, transform);
+		transform.pop();
 	}
 
 	public static void reset()
 	{
-		Arrays.fill(quads, null);
+		buffers.values().forEach(VertexBufferHolder::reset);
+	}
+
+	private static class ModelKey
+	{
+		private final int sails;
+
+		private ModelKey(int sails)
+		{
+			this.sails = sails;
+		}
+
+		@Override
+		public boolean equals(Object o)
+		{
+			if(this==o) return true;
+			if(o==null||getClass()!=o.getClass()) return false;
+			ModelKey modelKey = (ModelKey)o;
+			return sails==modelKey.sails;
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return Objects.hash(sails);
+		}
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/client/utils/ResettableLazy.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/utils/ResettableLazy.java
@@ -1,0 +1,45 @@
+package blusunrize.immersiveengineering.client.utils;
+
+import net.minecraftforge.common.util.NonNullConsumer;
+import net.minecraftforge.common.util.NonNullSupplier;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.Supplier;
+
+public class ResettableLazy<T> implements Supplier<T>
+{
+	private final NonNullSupplier<T> getter;
+	private final NonNullConsumer<T> destructor;
+	@Nullable
+	private T cached;
+
+	public ResettableLazy(NonNullSupplier<T> getter)
+	{
+		this(getter, v -> {
+		});
+	}
+
+	public ResettableLazy(NonNullSupplier<T> getter, NonNullConsumer<T> destructor)
+	{
+		this.getter = getter;
+		this.destructor = destructor;
+	}
+
+	@Nonnull
+	public T get()
+	{
+		if(cached==null)
+			cached = getter.get();
+		return cached;
+	}
+
+	public void reset()
+	{
+		if(cached!=null)
+		{
+			destructor.accept(cached);
+			cached = null;
+		}
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/client/utils/VertexBufferHolder.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/utils/VertexBufferHolder.java
@@ -1,0 +1,114 @@
+package blusunrize.immersiveengineering.client.utils;
+
+import blusunrize.immersiveengineering.common.IEConfig;
+import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.IVertexBuilder;
+import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.model.BakedQuad;
+import net.minecraft.client.renderer.vertex.VertexBuffer;
+import net.minecraft.client.renderer.vertex.VertexFormat;
+import net.minecraftforge.common.util.NonNullSupplier;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static net.minecraft.client.renderer.vertex.DefaultVertexFormats.*;
+
+public class VertexBufferHolder
+{
+	public static final VertexFormat BUFFER_FORMAT = new VertexFormat(ImmutableList.of(
+			POSITION_3F, COLOR_4UB, TEX_2F, NORMAL_3B, PADDING_1B
+	));
+	//TODO also sort by buffer to get rid of bindBuffer calls?
+	private static final Map<RenderType, List<BufferedJob>> JOBS = new IdentityHashMap<>();
+	private final ResettableLazy<VertexBuffer> buffer;
+	private final ResettableLazy<List<BakedQuad>> quads;
+
+	public VertexBufferHolder(NonNullSupplier<List<BakedQuad>> quads)
+	{
+		this.quads = new ResettableLazy<>(quads);
+		this.buffer = new ResettableLazy<>(
+				() -> {
+					VertexBuffer vb = new VertexBuffer(BUFFER_FORMAT);
+					Tessellator tes = Tessellator.getInstance();
+					BufferBuilder bb = tes.getBuffer();
+					bb.begin(GL11.GL_QUADS, BUFFER_FORMAT);
+					renderToBuilder(bb, new MatrixStack(), 0, 0);
+					bb.finishDrawing();
+					vb.upload(bb);
+					return vb;
+				},
+				VertexBuffer::close
+		);
+	}
+
+	public void render(RenderType type, int light, int overlay, IRenderTypeBuffer directOut, MatrixStack transform)
+	{
+		if(IEConfig.GENERAL.enableVBOs.get())
+			JOBS.computeIfAbsent(type, t -> new ArrayList<>())
+					.add(new BufferedJob(this, light, overlay, transform));
+		else
+			renderToBuilder(directOut.getBuffer(type), transform, light, overlay);
+	}
+
+	public void reset()
+	{
+		buffer.reset();
+		quads.reset();
+	}
+
+	private void renderToBuilder(IVertexBuilder builder, MatrixStack transform, int light, int overlay)
+	{
+		for(BakedQuad quad : quads.get())
+			builder.addQuad(transform.getLast(), quad, 1, 1, 1, light, overlay);
+	}
+
+	//Called from aftertesr.js
+	public static void afterTERRendering()
+	{
+		if(!JOBS.isEmpty())
+		{
+			//ClientUtils.mc().getModelManager().getAtlasTexture(AtlasTexture.LOCATION_BLOCKS_TEXTURE);
+			for(Entry<RenderType, List<BufferedJob>> typeEntry : JOBS.entrySet())
+			{
+				RenderType type = typeEntry.getKey();
+				type.setupRenderState();
+				for(BufferedJob job : typeEntry.getValue())
+				{
+					RenderSystem.glMultiTexCoord2f(33986, 16*LightTexture.getLightBlock(job.light), 16*LightTexture.getLightSky(job.light));
+					RenderSystem.glMultiTexCoord2f(33985, job.overlay&0xffff, job.overlay >>> 16);
+					VertexBuffer buffer = job.buffer.buffer.get();
+					buffer.bindBuffer();
+					BUFFER_FORMAT.setupBufferState(0);
+					buffer.draw(job.transform, GL11.GL_QUADS);
+				}
+				type.clearRenderState();
+			}
+			VertexBuffer.unbindBuffer();
+			BUFFER_FORMAT.clearBufferState();
+			JOBS.clear();
+		}
+	}
+
+	private static class BufferedJob
+	{
+		private final VertexBufferHolder buffer;
+		private final int light;
+		private final int overlay;
+		private final Matrix4f transform;
+
+		private BufferedJob(VertexBufferHolder buffer, int light, int overlay, MatrixStack transform)
+		{
+			this.buffer = buffer;
+			this.light = light;
+			this.overlay = overlay;
+			this.transform = transform.getLast().getMatrix();
+		}
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/client/utils/VertexBufferHolder.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/utils/VertexBufferHolder.java
@@ -74,7 +74,6 @@ public class VertexBufferHolder
 	{
 		if(!JOBS.isEmpty())
 		{
-			//ClientUtils.mc().getModelManager().getAtlasTexture(AtlasTexture.LOCATION_BLOCKS_TEXTURE);
 			for(Entry<RenderType, List<BufferedJob>> typeEntry : JOBS.entrySet())
 			{
 				RenderType type = typeEntry.getKey();

--- a/src/main/java/blusunrize/immersiveengineering/client/utils/VertexBufferHolder.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/utils/VertexBufferHolder.java
@@ -1,5 +1,16 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ *
+ */
+
 package blusunrize.immersiveengineering.client.utils;
 
+import blusunrize.immersiveengineering.api.client.IVertexBufferHolder;
+import blusunrize.immersiveengineering.api.utils.ResettableLazy;
 import blusunrize.immersiveengineering.common.IEConfig;
 import com.google.common.collect.ImmutableList;
 import com.mojang.blaze3d.matrix.MatrixStack;
@@ -20,7 +31,7 @@ import java.util.Map.Entry;
 
 import static net.minecraft.client.renderer.vertex.DefaultVertexFormats.*;
 
-public class VertexBufferHolder
+public class VertexBufferHolder implements IVertexBufferHolder
 {
 	public static final VertexFormat BUFFER_FORMAT = new VertexFormat(ImmutableList.of(
 			POSITION_3F, COLOR_4UB, TEX_2F, NORMAL_3B, PADDING_1B
@@ -30,7 +41,7 @@ public class VertexBufferHolder
 	private final ResettableLazy<VertexBuffer> buffer;
 	private final ResettableLazy<List<BakedQuad>> quads;
 
-	public VertexBufferHolder(NonNullSupplier<List<BakedQuad>> quads)
+	private VertexBufferHolder(NonNullSupplier<List<BakedQuad>> quads)
 	{
 		this.quads = new ResettableLazy<>(quads);
 		this.buffer = new ResettableLazy<>(
@@ -48,6 +59,12 @@ public class VertexBufferHolder
 		);
 	}
 
+	public static void addToAPI()
+	{
+		IVertexBufferHolder.CREATE.setValue(VertexBufferHolder::new);
+	}
+
+	@Override
 	public void render(RenderType type, int light, int overlay, IRenderTypeBuffer directOut, MatrixStack transform)
 	{
 		if(IEConfig.GENERAL.enableVBOs.get())
@@ -57,6 +74,7 @@ public class VertexBufferHolder
 			renderToBuilder(directOut.getBuffer(type), transform, light, overlay);
 	}
 
+	@Override
 	public void reset()
 	{
 		buffer.reset();

--- a/src/main/java/blusunrize/immersiveengineering/common/IEConfig.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IEConfig.java
@@ -175,6 +175,9 @@ public class IEConfig
 			enableDebug = builder
 					.comment("A config setting to enable debug features. These features may vary between releases, may cause crashes, and are unsupported. Do not enable unless asked to by a developer of IE.")
 					.define("enableDebug", false);
+			enableVBOs = builder
+					//TODO comment
+					.define("enableVBO", true);
 			builder.pop();
 		}
 
@@ -194,6 +197,7 @@ public class IEConfig
 		public final BooleanValue stencilBufferEnabled;
 		public final Map<String, BooleanValue> compat = new HashMap<>();
 		public final BooleanValue enableDebug;
+		public final BooleanValue enableVBOs;
 	}
 
 	public static class Machines

--- a/src/main/java/blusunrize/immersiveengineering/common/IEConfig.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IEConfig.java
@@ -176,7 +176,8 @@ public class IEConfig
 					.comment("A config setting to enable debug features. These features may vary between releases, may cause crashes, and are unsupported. Do not enable unless asked to by a developer of IE.")
 					.define("enableDebug", false);
 			enableVBOs = builder
-					//TODO comment
+					.comment("Use VBOs to render certain blocks. This is significantly faster than the usual rendering,",
+							"but may not work correctly with visual effects from other mods")
 					.define("enableVBO", true);
 			builder.pop();
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BucketWheelTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BucketWheelTileEntity.java
@@ -9,25 +9,19 @@
 package blusunrize.immersiveengineering.common.blocks.metal;
 
 import blusunrize.immersiveengineering.ImmersiveEngineering;
-import blusunrize.immersiveengineering.client.ClientUtils;
-import blusunrize.immersiveengineering.client.models.IOBJModelCallback;
 import blusunrize.immersiveengineering.common.IEConfig;
 import blusunrize.immersiveengineering.common.IETileTypes;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IBlockBounds;
 import blusunrize.immersiveengineering.common.blocks.generic.MultiblockPartTileEntity;
 import blusunrize.immersiveengineering.common.blocks.multiblocks.IEMultiblocks;
 import blusunrize.immersiveengineering.common.network.MessageTileSync;
-import blusunrize.immersiveengineering.common.util.Utils;
 import com.google.common.collect.ImmutableSet;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.inventory.ItemStackHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Direction.Axis;
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -42,8 +36,7 @@ import net.minecraftforge.fml.network.PacketDistributor;
 
 import javax.annotation.Nullable;
 
-public class BucketWheelTileEntity extends MultiblockPartTileEntity<BucketWheelTileEntity> implements
-		IOBJModelCallback<BlockState>, IBlockBounds
+public class BucketWheelTileEntity extends MultiblockPartTileEntity<BucketWheelTileEntity> implements IBlockBounds
 {
 	public float rotation = 0;
 	public final NonNullList<ItemStack> digStacks = NonNullList.withSize(8, ItemStack.EMPTY);
@@ -124,28 +117,6 @@ public class BucketWheelTileEntity extends MultiblockPartTileEntity<BucketWheelT
 			MessageTileSync sync = new MessageTileSync(this, nbt);
 			ImmersiveEngineering.packetHandler.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(pos)), sync);
 		}
-	}
-
-	@Override
-	@OnlyIn(Dist.CLIENT)
-	public TextureAtlasSprite getTextureReplacement(BlockState object, String group, String material)
-	{
-		if(group.startsWith("dig"))
-		{
-			int index = Integer.parseInt(group.substring(3));
-			if(!this.digStacks.get(index).isEmpty())
-			{
-				ResourceLocation rl = null;
-				BlockState state = Utils.getStateFromItemStack(this.digStacks.get(index));
-				if(state!=null)
-					rl = ClientUtils.getSideTexture(state, Direction.UP);
-				else
-					rl = ClientUtils.getSideTexture(this.digStacks.get(index), Direction.UP);
-				if(rl!=null)
-					return ClientUtils.getSprite(rl);
-			}
-		}
-		return null;
 	}
 
 	@Override

--- a/src/main/resources/META-INF/coremods.json
+++ b/src/main/resources/META-INF/coremods.json
@@ -1,5 +1,6 @@
 {
   "IE wire damage": "asm/wiredamage.js",
   "IE arm angle adjustment": "asm/arm_angles.js",
-  "IE block update callback": "asm/blockwirecollisions.js"
+  "IE block update callback": "asm/blockwirecollisions.js",
+  "IE after TESR callback": "asm/aftertesr.js"
 }

--- a/src/main/resources/asm/aftertesr.js
+++ b/src/main/resources/asm/aftertesr.js
@@ -1,0 +1,40 @@
+function initializeCoreMod() {
+    return {
+        'IE render hook after tile rendering': {
+            'target': {
+                'type': 'METHOD',
+                'class': 'net.minecraft.client.renderer.WorldRenderer',
+                'methodName': 'func_228426_a_',
+                'methodDesc': '(Lcom/mojang/blaze3d/matrix/MatrixStack;FJZLnet/minecraft/client/renderer/ActiveRenderInfo;Lnet/minecraft/client/renderer/GameRenderer;Lnet/minecraft/client/renderer/LightTexture;Lnet/minecraft/client/renderer/Matrix4f;)V'
+            },
+            'transformer': function (method) {
+                var ASMAPI = Java.type('net.minecraftforge.coremod.api.ASMAPI');
+                var opcodes = Java.type('org.objectweb.asm.Opcodes');
+                var callback = ASMAPI.listOf(
+                    ASMAPI.buildMethodCall(
+                        "blusunrize/immersiveengineering/client/utils/VertexBufferHolder",
+                        "afterTERRendering",
+                        "()V",
+                        ASMAPI.MethodType.STATIC
+                    ));
+                var targetString = "destroyProgress";
+                var inserted = false;
+                for (var i = 0; i < method.instructions.size(); ++i) {
+                    var node = method.instructions.get(i);
+                    if (node.getOpcode() === opcodes.LDC && node.cst.equals(targetString)) {
+                        var targetIndex = i - 2;
+                        method.instructions.insert(method.instructions.get(targetIndex), callback);
+                        inserted = true;
+                        break;
+                    }
+                }
+                if (inserted) {
+                    ASMAPI.log("INFO", "Inserted after-TER callback", {});
+                } else {
+                    ASMAPI.log("WARN", "Failed to insert after-TER callback", {});
+                }
+                return method;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Also changes some other TERs to use `ClientUtils#renderModelTESRFast` as it's faster than the block model render and looks very similar in those cases. The crusher actually looks better now IMO: Before one side of the barrels was usually darker than the other, but as the rotation wasn't included in the lighting the darker side rotated with the barrels. Now all sides have the same, roughly correct brightness.