### PR TITLE
[1.16.3] Simple CraftTweaker integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ logs
 src/generated/resources/.cache/cache
 # Local gradle customizations (e.g. added mods)
 custom.gradle
+docsOut/

--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,11 @@ dependencies {
     //Apparently JEI 1.16.3 can't be applied here without...
     compile fg.deobf('com.feed_the_beast.mods:ftb-gui-library:1.0.0.18')
     testImplementation('junit:junit:4.13')
+
+    compile fg.deobf(group: "com.blamejared.crafttweaker", name: "CraftTweaker-1.16.3", version: "7.0.0.45")
+    compile group: "com.blamejared.crafttweaker", name: "Crafttweaker_Annotation_Processors-1.16.3", version: "1.0.0.45"
+    annotationProcessor group: "com.blamejared.crafttweaker", name: "Crafttweaker_Annotation_Processors-1.16.3", version: "1.0.0.45"
+    annotationProcessor group: "org.reflections", name: 'reflections', version: '0.9.12'
 }
 
 def customGradle = rootProject.file('custom.gradle');

--- a/build.gradle
+++ b/build.gradle
@@ -143,16 +143,22 @@ repositories {
         //gigaherz maven for 1.16.2 mappings
         url 'https://www.dogforce-games.com/maven/'
     }
+    maven {
+        //JEI 1.16.3 tries to load 'mods:ftb-gui-library'
+        url 'https://maven.latmod.com/'
+    }
 }
 
 dependencies {
 //    minecraft "net.minecraftforge:forge:${version_minecraft}-${version_forge}"
     minecraft "net.minecraftforge:forge:1.16.3-34.0.7"
 
-    //runtimeOnly fg.deobf("mezz.jei:jei-1.16.2:7.1.0.11")
+    runtimeOnly fg.deobf("mezz.jei:jei-1.16.3:7.3.2.29")
     //runtimeOnly fg.deobf("nbtedit:NBTEdit:0.9.0")
-    compileOnly fg.deobf("mezz.jei:jei-1.16.2:7.3.2.25:api")
+    compileOnly fg.deobf("mezz.jei:jei-1.16.3:7.3.2.29:api")
     compile "malte0811:BlockModelSplitter:1.2.0"
+    //Apparently JEI 1.16.3 can't be applied here without...
+    compile fg.deobf('com.feed_the_beast.mods:ftb-gui-library:1.0.0.18')
     testImplementation('junit:junit:4.13')
 }
 

--- a/src/main/java/blusunrize/immersiveengineering/ImmersiveEngineering.java
+++ b/src/main/java/blusunrize/immersiveengineering/ImmersiveEngineering.java
@@ -51,6 +51,7 @@ import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.*;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -96,7 +97,7 @@ public class ImmersiveEngineering
 		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::wrongSignature);
 		MinecraftForge.EVENT_BUS.addListener(this::serverStarting);
 		MinecraftForge.EVENT_BUS.addListener(this::registerCommands);
-		MinecraftForge.EVENT_BUS.addListener(this::addReloadListeners);
+		MinecraftForge.EVENT_BUS.addListener(EventPriority.LOWEST, this::addReloadListeners);
 		MinecraftForge.EVENT_BUS.addListener(this::serverStarted);
 		RecipeSerializers.RECIPE_SERIALIZERS.register(FMLJavaModLoadingContext.get().getModEventBus());
 		Villages.Registers.POINTS_OF_INTEREST.register(FMLJavaModLoadingContext.get().getModEventBus());

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/CrTIngredientUtil.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/CrTIngredientUtil.java
@@ -1,0 +1,82 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker;
+
+import blusunrize.immersiveengineering.api.crafting.*;
+import com.blamejared.crafttweaker.api.fluid.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.impl.item.*;
+import net.minecraft.fluid.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import net.minecraft.util.math.*;
+import net.minecraftforge.fluids.*;
+
+public class CrTIngredientUtil {
+    
+    private CrTIngredientUtil() {
+    }
+    
+    /**
+     * So far, only IItemStack supports setting an amount.
+     * So we can at least check for that, I guess?
+     *
+     * @param crafttweakerIngredient The CrT ingredient
+     * @return The IE ingredient
+     */
+    public static IngredientWithSize getIngredientWithSize(IIngredient crafttweakerIngredient) {
+        final Ingredient basePredicate = crafttweakerIngredient.asVanillaIngredient();
+        if(crafttweakerIngredient instanceof IItemStack) {
+            return IngredientWithSize.of(((IItemStack) crafttweakerIngredient).getInternal());
+        }
+        return new IngredientWithSize(basePredicate);
+    }
+    
+    /**
+     * Same as {@link #getIngredientWithSize(IIngredient)} but for an array
+     */
+    public static IngredientWithSize[] getIngredientsWithSize(IIngredient[] crafttweakerIngredients) {
+        final IngredientWithSize[] result = new IngredientWithSize[crafttweakerIngredients.length];
+        for(int i = 0; i < crafttweakerIngredients.length; i++) {
+            result[i] = getIngredientWithSize(crafttweakerIngredients[i]);
+        }
+        return result;
+    }
+    
+    /**
+     * {@link com.blamejared.crafttweaker.impl.helper.CraftTweakerHelper} only allows to get a List, not a NonNullList
+     */
+    public static NonNullList<ItemStack> getNonNullList(IItemStack[] itemStacks) {
+        final NonNullList<ItemStack> result = NonNullList.create();
+        for(IItemStack itemStack : itemStacks) {
+            result.add(itemStack.getInternal());
+        }
+        return result;
+    }
+    
+    /**
+     * Creates a StackWithChance, and clamps the chance to [0..1]
+     */
+    public static StackWithChance getStackWithChance(MCWeightedItemStack weightedStack) {
+        final ItemStack stack = weightedStack.getItemStack().getInternal();
+        final float weight = MathHelper.clamp((float) weightedStack.getWeight(), 0, 1);
+        return new StackWithChance(stack, weight);
+    }
+    
+    /**
+     * Just a simple input sanitation, since I don't know how machines would handle a FluidStack with Fluid.EMPTY and stackSize == 1
+     */
+    public static FluidStack getFluidStack(IFluidStack stack) {
+        final FluidStack internal = stack.getInternal();
+        if(internal.getFluid() == Fluids.EMPTY) {
+            return FluidStack.EMPTY;
+        }
+        return internal;
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/CrafttweakerIntegration.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/CrafttweakerIntegration.java
@@ -1,0 +1,33 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.impl.commands.*;
+import net.minecraft.util.text.*;
+import net.minecraftforge.eventbus.api.*;
+import net.minecraftforge.fml.common.*;
+
+@Mod.EventBusSubscriber(modid = Lib.MODID)
+public class CrafttweakerIntegration {
+    
+    @SubscribeEvent
+    public static void onCommandCollection(CTCommandCollectionEvent event) {
+        event.registerDump("ieBlueprintCategories", "Lists the different blueprint categories for the IE workbench", commandContext -> {
+            
+            for(String recipeCategory : BlueprintCraftingRecipe.recipeCategories) {
+                CraftTweakerAPI.logDump(recipeCategory);
+            }
+            final StringTextComponent message = new StringTextComponent(TextFormatting.GREEN + "Categories written to the log" + TextFormatting.RESET);
+            commandContext.getSource().sendFeedback(message, true);
+            return 0;
+        });
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/actions/AbstractActionGenericRemoveRecipe.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/actions/AbstractActionGenericRemoveRecipe.java
@@ -1,0 +1,66 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions;
+
+import blusunrize.immersiveengineering.common.crafting.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.actions.*;
+import com.blamejared.crafttweaker.api.brackets.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+
+import java.util.*;
+
+public abstract class AbstractActionGenericRemoveRecipe<T extends IRecipe<?>> implements IRuntimeAction {
+    
+    private final IRecipeManager manager;
+    private final CommandStringDisplayable output;
+    
+    public AbstractActionGenericRemoveRecipe(IRecipeManager manager, CommandStringDisplayable output) {
+        this.manager = manager;
+        this.output = output;
+    }
+    
+    @Override
+    public void apply() {
+        int count = 0;
+        final Iterator<Map.Entry<ResourceLocation, IRecipe<?>>> iterator = manager.getRecipes()
+                .entrySet()
+                .iterator();
+        
+        try {
+            while(iterator.hasNext()) {
+                final IRecipe<?> recipe = iterator.next().getValue();
+                if(recipe instanceof GeneratedListRecipe) {
+                    CraftTweakerAPI.logDebug("Skipping GeneratedListRecipe '%s'", recipe.getId());
+                    continue;
+                }
+                
+                //noinspection unchecked
+                if(shouldRemove((T) recipe)) {
+                    iterator.remove();
+                    count++;
+                }
+            }
+        } catch(ClassCastException exception) {
+            CraftTweakerAPI.logThrowing("There is an illegal entry in %s that caused an exception: ", exception, manager
+                    .getCommandString());
+        }
+        
+        CraftTweakerAPI.logInfo("Removed %s \"%s\" recipes", count, manager.getCommandString());
+    }
+    
+    public abstract boolean shouldRemove(T recipe);
+    
+    @Override
+    public String describe() {
+        return "Removing all \"" + manager.getCommandString() + "\" recipes, that output: " + output
+                .getCommandString();
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/actions/AbstractActionRemoveMultipleOutputs.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/actions/AbstractActionRemoveMultipleOutputs.java
@@ -1,0 +1,33 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions;
+
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.item.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+
+import java.util.*;
+
+public abstract class AbstractActionRemoveMultipleOutputs<T extends IRecipe<?>> extends AbstractActionGenericRemoveRecipe<T> {
+    
+    private final IIngredient output;
+    
+    public AbstractActionRemoveMultipleOutputs(IRecipeManager manager, IIngredient output) {
+        super(manager, output);
+        this.output = output;
+    }
+    
+    @Override
+    public boolean shouldRemove(T recipe) {
+        return getAllOutputs(recipe).stream().map(MCItemStackMutable::new).anyMatch(output::matches);
+    }
+    
+    public abstract List<ItemStack> getAllOutputs(T recipe);
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/actions/ActionAddBlueprintCategory.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/actions/ActionAddBlueprintCategory.java
@@ -1,0 +1,51 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions;
+
+import blusunrize.immersiveengineering.api.crafting.*;
+import com.blamejared.crafttweaker.api.actions.*;
+import com.blamejared.crafttweaker.api.logger.*;
+
+public class ActionAddBlueprintCategory implements IUndoableAction {
+    
+    private final String blueprintCategory;
+    
+    public ActionAddBlueprintCategory(String blueprintCategory) {
+        this.blueprintCategory = blueprintCategory;
+    }
+    
+    @Override
+    public void undo() {
+        BlueprintCraftingRecipe.recipeCategories.remove(blueprintCategory);
+    }
+    
+    @Override
+    public String describeUndo() {
+        return "Removing previously added Blueprint Category '" + blueprintCategory + "'";
+    }
+    
+    @Override
+    public void apply() {
+        BlueprintCraftingRecipe.recipeCategories.add(blueprintCategory);
+    }
+    
+    @Override
+    public String describe() {
+        return "Adding Blueprint Category '" + blueprintCategory + "'";
+    }
+    
+    @Override
+    public boolean validate(ILogger logger) {
+        if(BlueprintCraftingRecipe.recipeCategories.contains(blueprintCategory)) {
+            logger.error("Blueprint Category '" + blueprintCategory + "' already exists!");
+            return false;
+        }
+        
+        return true;
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/actions/ActionRemoveFertilizer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/actions/ActionRemoveFertilizer.java
@@ -1,0 +1,54 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions;
+
+import blusunrize.immersiveengineering.api.crafting.*;
+import com.blamejared.crafttweaker.api.actions.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+
+import java.util.*;
+
+public class ActionRemoveFertilizer implements IRuntimeAction {
+    
+    private final IRecipeManager recipeManager;
+    private final IItemStack toBeRemoved;
+    
+    public ActionRemoveFertilizer(IRecipeManager recipeManager, IItemStack toBeRemoved) {
+        this.recipeManager = recipeManager;
+        this.toBeRemoved = toBeRemoved;
+    }
+    
+    @Override
+    public void apply() {
+        final Iterator<Map.Entry<ResourceLocation, IRecipe<?>>> iterator = recipeManager.getRecipes()
+                .entrySet()
+                .iterator();
+    
+        final ItemStack internal = toBeRemoved.getInternal();
+    
+        while(iterator.hasNext()) {
+            final IRecipe<?> recipe = iterator.next().getValue();
+            if(!(recipe instanceof ClocheFertilizer)) {
+                continue;
+            }
+            ClocheFertilizer clocheFertilizer = (ClocheFertilizer) recipe;
+            if(clocheFertilizer.input.test(internal)) {
+                iterator.remove();
+            }
+        }
+    }
+    
+    @Override
+    public String describe() {
+        return "Removing all Fertilizers that match " + toBeRemoved.getCommandString();
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/AlloyRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/AlloyRecipeManager.java
@@ -1,0 +1,63 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove alloy smelter recipes.
+ * <p>
+ * Alloy smelter recipes consist of two input ingredients (size dependent) and one output ItemStack
+ *
+ * @docParam this <recipetype:immersiveengineering:alloy>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/AlloySmelter")
+@ZenCodeType.Name("mods.immersiveengineering.AlloySmelter")
+public class AlloyRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<AlloyRecipe> getRecipeType() {
+        return AlloyRecipe.TYPE;
+    }
+    
+    /**
+     * Adds a recipe to the alloy smelter
+     *
+     * @param recipePath The recipe name, without the resource location
+     * @param inputA     The first item input
+     * @param inputB     The second item input
+     * @param output     The recipe output
+     * @param time       The time this recipe needs, in ticks
+     * @docParam recipePath "spin_iron_to_gold"
+     * @docParam inputA <item:minecraft:iron_ingot> * 10
+     * @docParam inputB <tag:minecraft:wool>
+     * @docParam output <item:minecraft:gold_ingot> * 2
+     * @docParam time 200
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient inputA, IIngredient inputB, int time, IItemStack output) {
+        final ResourceLocation id = new ResourceLocation(Lib.MODID, recipePath);
+        final IngredientWithSize input0 = CrTIngredientUtil.getIngredientWithSize(inputA);
+        final IngredientWithSize input1 = CrTIngredientUtil.getIngredientWithSize(inputB);
+        final AlloyRecipe alloyRecipe = new AlloyRecipe(id, output.getInternal(), input0, input1, time);
+        
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, alloyRecipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ArcFurnaceRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ArcFurnaceRecipeManager.java
@@ -1,0 +1,109 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+import java.util.*;
+
+/**
+ * Allows you to add or remove arc furnace smelter recipes.
+ * <p>
+ * Arc Furnace recipes consist of one base ingredident, a list of additives, and a list of outputs.
+ * Optionally, they can also have an item as slag output.
+ *
+ * @docParam this <recipetype:immersiveengineering:arc_furnace>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/ArcFurnace")
+@ZenCodeType.Name("mods.immersiveengineering.ArcFurnace")
+public class ArcFurnaceRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<ArcFurnaceRecipe> getRecipeType() {
+        return ArcFurnaceRecipe.TYPE;
+    }
+    
+    /**
+     * Adds a recipe to the Arc Furnace
+     *
+     * @param recipePath     The recipe name, without the resource location
+     * @param mainIngredient The main ingredient
+     * @param additives      The additives
+     * @param time           The time the recipe takes, in ticks
+     * @param energy         The total energy the recipe requires
+     * @param outputs        The recipe result(s)
+     * @param slag           The item that should appear as slag
+     * @docParam recipePath "coal_to_bedrock"
+     * @docParam mainIngredient <item:minecraft:coal_block> * 2
+     * @docParam additives [<item:minecraft:diamond> * 1, <tag:minecraft:wool>]
+     * @docParam time 2000
+     * @docParam energy 100000
+     * @docParam outputs [<item:minecraft:bedrock>]
+     * @docParam slag <item:minecraft:gold_nugget>
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient mainIngredient, IIngredient[] additives, int time, int energy, IItemStack[] outputs, @ZenCodeType.Optional("<item:minecraft:air>") IItemStack slag) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final NonNullList<ItemStack> outputList = CrTIngredientUtil.getNonNullList(outputs);
+        final IngredientWithSize main = CrTIngredientUtil.getIngredientWithSize(mainIngredient);
+        final IngredientWithSize[] additivesWithSize = CrTIngredientUtil.getIngredientsWithSize(additives);
+        
+        final ArcFurnaceRecipe recipe = new ArcFurnaceRecipe(resourceLocation, outputList, main, slag
+                .getInternal(), time, energy, additivesWithSize);
+        
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        removeRecipe(output, false);
+    }
+    
+    /**
+     * Removes a recipe based on its outputs.
+     * Removes the recipe as long as one of the recipe's outputs matches the ingredient given.
+     * TODO: Allow for removal of Recycling recipes
+     *
+     * @param output    The recipe result
+     * @param checkSlag If the slag output should be included in the check or not
+     * @docParam output <item:minecraft:iron_ore>
+     * @docParam checkSlag true
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(IIngredient output, boolean checkSlag) {
+        CraftTweakerAPI.apply(new AbstractActionRemoveMultipleOutputs<ArcFurnaceRecipe>(this, output) {
+            @Override
+            public List<ItemStack> getAllOutputs(ArcFurnaceRecipe recipe) {
+                final List<ItemStack> itemStacks = new ArrayList<>(recipe.output);
+                if(checkSlag) {
+                    itemStacks.add(recipe.slag);
+                }
+                return itemStacks;
+            }
+            
+            @Override
+            public String describe() {
+                return super.describe() + ", " + (checkSlag ? "including" : "excluding") + " slag outputs";
+            }
+        });
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/BlastFurnaceFuelManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/BlastFurnaceFuelManager.java
@@ -1,0 +1,53 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Blast Furnace fuel items.
+ * <p>
+ *
+ * @docParam this <recipetype:immersiveengineering:blast_furnace_fuel>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/BlastFurnaceFuel")
+@ZenCodeType.Name("mods.immersiveengineering.BlastFurnaceFuel")
+public class BlastFurnaceFuelManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<BlastFurnaceFuel> getRecipeType() {
+        return BlastFurnaceFuel.TYPE;
+    }
+    
+    /**
+     * Adds a fuel to the Blast Furnace
+     * @param recipePath The recipe name, without the resource location
+     * @param fuel The fuel to be added
+     * @param burnTime The fuel's burntime
+     * @docParam recipePath "the_sungods_sword_can_burn"
+     * @docParam fuel <item:minecraft:golden_sword>.withTag({RepairCost: 0 as int, Damage: 0 as int, display: {Name: "{\"text\":\"Sword of the Sungod\"}" as string}})
+     * @docParam burnTime 100000
+     */
+    @ZenCodeType.Method
+    public void addFuel(String recipePath, IIngredient fuel, int burnTime) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final BlastFurnaceFuel recipe = new BlastFurnaceFuel(resourceLocation, fuel.asVanillaIngredient(), burnTime);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/BlastFurnaceRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/BlastFurnaceRecipeManager.java
@@ -1,0 +1,64 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Blast Furnace recipes.
+ * <p>
+ * Blast furnace recipes consist of an ingredient, an output and an optional slag result.
+ *
+ * @docParam this <recipetype:immersiveengineering:blast_furnace>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/BlastFurnace")
+@ZenCodeType.Name("mods.immersiveengineering.BlastFurnace")
+public class BlastFurnaceRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<BlastFurnaceRecipe> getRecipeType() {
+        return BlastFurnaceRecipe.TYPE;
+    }
+    
+    /**
+     * Adds a Blast furnace recipe
+     *
+     * @param recipePath The recipe name, without the resource location
+     * @param ingredient The item input
+     * @param time       The time this recipe needs, in ticks
+     * @param output     The recipe output
+     * @param slag       The item that should appear in the slag slot, optional
+     * @docParam recipePath "wool_to_charcoal"
+     * @docParam ingredient <tag:minecraft:wool>
+     * @docParam time 1000
+     * @docParam output <item:minecraft:charcoal>
+     * @docParam slag <item:minecraft:string>
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient ingredient, int time, IItemStack output, @ZenCodeType.Optional("<item:minecraft:air>") IItemStack slag) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final IngredientWithSize ingredientWithSize = CrTIngredientUtil.getIngredientWithSize(ingredient);
+        final ItemStack outputItem = output.getInternal();
+        final ItemStack slagItem = slag.getInternal();
+        final BlastFurnaceRecipe blastFurnaceRecipe = new BlastFurnaceRecipe(resourceLocation, outputItem, ingredientWithSize, time, slagItem);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, blastFurnaceRecipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/BlueprintCraftingRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/BlueprintCraftingRecipeManager.java
@@ -1,0 +1,99 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.logger.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove blueprint recipes.
+ * <p>
+ * Blueprint recipes consist of a variable number of inputs and one output.
+ * They are grouped by categories, where each category is one blueprint item ingame.
+ * <p>
+ * You can find all existing categories using `/ct ieBlueprintCategories`
+ *
+ * @docParam this <recipetype:immersiveengineering:blueprint>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Blueprint")
+@ZenCodeType.Name("mods.immersiveengineering.Blueprint")
+public class BlueprintCraftingRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<BlueprintCraftingRecipe> getRecipeType() {
+        return BlueprintCraftingRecipe.TYPE;
+    }
+    
+    /**
+     * Adds a blueprint category. You need to call this method before adding any recipes that use a blueprint category that is not added by IE.
+     * May only be called for a nonexistent category, otherwise it will error.
+     *
+     * Adding a blueprint category will also create a new blueprint item in JEI.
+     * For technical reasons it is not possible to also add one to the creative menu, so stick to JEI for getting the item.
+     *
+     * To localize the generated blueprint's name, you should add a lang file entry "desc.immersiveengineering.info.blueprint.<blueprintCategory>"
+     *
+     * In the example below it would be "desc.immersiveengineering.info.blueprint.badabim"
+     * @param blueprintCategory The category name to be added
+     * @docParam blueprintCategory "badabim"
+     */
+    @ZenCodeType.Method
+    public void addBlueprintCategory(String blueprintCategory) {
+        CraftTweakerAPI.apply(new ActionAddBlueprintCategory(blueprintCategory));
+    }
+    
+    
+    /**
+     * Adds a new recipe.
+     * Make sure that the category exists before calling this method!
+     *
+     *
+     * @param recipePath The recipe name, without the resource location
+     * @param blueprintCategory The category name. The category must exist!
+     * @param inputs The recipe's ingredients
+     * @param output The recipe's output item
+     *
+     * @docParam recipePath "some_test"
+     * @docParam blueprintCategory "bullet"
+     * @docParam inputs [<item:minecraft:bedrock>]
+     * @docParam output <item:minecraft:bedrock> * 2
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, String blueprintCategory, IIngredient[] inputs, IItemStack output) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final IngredientWithSize[] ingredients = CrTIngredientUtil.getIngredientsWithSize(inputs);
+        final ItemStack results = output.getInternal();
+        final BlueprintCraftingRecipe recipe = new BlueprintCraftingRecipe(resourceLocation, blueprintCategory, results, ingredients);
+        
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null) {
+            @Override
+            public boolean validate(ILogger logger) {
+                if(!BlueprintCraftingRecipe.recipeCategories.contains(blueprintCategory)) {
+                    final String format = "Blueprint Category '%s' does not exist yet. You can add it with '<recipetype:immersiveengineering:blueprint>.addBlueprintCategory(\"%s\");'";
+                    logger.error(String.format(format, blueprintCategory, blueprintCategory));
+                    return false;
+                }
+                return true;
+            }
+        });
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/BottlingMachineRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/BottlingMachineRecipeManager.java
@@ -1,0 +1,73 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker.impl.tag.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Bottling Machine recipes.
+ * <p>
+ * Bottling Machine recipes consist of an item ingredient, a fluid input and an item output.
+ *
+ * @docParam this <recipetype:immersiveengineering:bottling_machine>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/BottlingMachine")
+@ZenCodeType.Name("mods.immersiveengineering.BottlingMachine")
+public class BottlingMachineRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<BottlingMachineRecipe> getRecipeType() {
+        return BottlingMachineRecipe.TYPE;
+    }
+    
+    /**
+     * Adds a recipe to the Bottling Machine.
+     * The bottling Machine only goes via Fluid tag!
+     *
+     * @param recipePath The recipe name, without the resource location
+     * @param itemInput  The item input (the item to be filled)
+     * @param fluidTag   The fluid tag of the fluid
+     * @param amount     The amount of the liquid that is required for the recipe (in mB)
+     * @param output     The resulting "filled" item.
+     * @docParam recipePath "grow_a_pick"
+     * @docParam itemInput <item:minecraft:stick>
+     * @docParam fluidTag <tag:minecraft:water>
+     * @docParam amount 250
+     * @docParam output <item:minecraft:wooden_pickaxe>
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient itemInput, MCTag fluidTag, int amount, IItemStack output) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        
+        if(!fluidTag.isFluidTag()) {
+            throw new IllegalArgumentException("The provided Tag needs to be a Fluid Tag!");
+        }
+        
+        final FluidTagInput fluidTagInput = new FluidTagInput(fluidTag.getId().getInternal(), amount);
+        
+        final ItemStack itemOutput = output.getInternal();
+        final Ingredient input = itemInput.asVanillaIngredient();
+        
+        final BottlingMachineRecipe recipe = new BottlingMachineRecipe(resourceLocation, itemOutput, input, fluidTagInput);
+        
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ClocheFertilizerManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ClocheFertilizerManager.java
@@ -1,0 +1,75 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Fertilizers from the Garden Cloche
+ * <p>
+ * A Fertilizer consists of an ingredient and a fertilizer value
+ *
+ * @docParam this <recipetype:immersiveengineering:fertilizer>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Fertilizer")
+@ZenCodeType.Name("mods.immersiveengineering.Fertilizer")
+public class ClocheFertilizerManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<ClocheFertilizer> getRecipeType() {
+        return ClocheFertilizer.TYPE;
+    }
+    
+    /**
+     * Adds the fertilizer as possible fertilizer
+     *
+     * @param recipePath      The recipe name, without the resource location
+     * @param fertilizer      The fertilizer to be added
+     * @param fertilizerValue The value this fertilizer gives in the garden cloche
+     * @docParam recipePath "sulfur_grow"
+     * @docParam fertilizer <tag:forge:dusts/sulfur>
+     * @docParam fertilizerValue 6.0F
+     */
+    @ZenCodeType.Method
+    public void addFertilizer(String recipePath, IIngredient fertilizer, float fertilizerValue) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final ClocheFertilizer recipe = new ClocheFertilizer(resourceLocation, fertilizer.asVanillaIngredient(), fertilizerValue);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+    
+    /**
+     * Removes a given fertilizer.
+     * Will remove all fertilizers for which this IItemStack matches
+     * <p>
+     * In other words, if a fertilizer uses a Tag ingredient, you can remove it by providing any item with that tag.
+     *
+     * @param fertilizer The fertilizer to be removed
+     * @docParam fertilizer <item:minecraft:bone_meal>
+     */
+    @ZenCodeType.Method
+    public void removeFertilizer(IItemStack fertilizer) {
+        CraftTweakerAPI.apply(new ActionRemoveFertilizer(this, fertilizer));
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack fertilizer) {
+        removeFertilizer(fertilizer);
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ClocheRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ClocheRecipeManager.java
@@ -1,0 +1,115 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker.impl.blocks.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.block.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+import java.util.*;
+
+/**
+ * Allows you to add or remove Crops from the Garden Cloche.
+ * <p>
+ * Cloche Recipes consist of a soil, an input item and output items.
+ *
+ * @docParam this <recipetype:immersiveengineering:cloche>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Cloche")
+@ZenCodeType.Name("mods.immersiveengineering.Cloche")
+public class ClocheRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<ClocheRecipe> getRecipeType() {
+        return ClocheRecipe.TYPE;
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        removeRecipe((IIngredient) output);
+    }
+    
+    /**
+     * Removes the recipe based on its outputs.
+     * Removes the recipe as soon as one of its outputs matches the ingredient given.
+     *
+     * @param output The output to match for
+     * @docParam output <item:minecraft:melon>
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(IIngredient output) {
+        CraftTweakerAPI.apply(new AbstractActionRemoveMultipleOutputs<ClocheRecipe>(this, output) {
+            @Override
+            public List<ItemStack> getAllOutputs(ClocheRecipe recipe) {
+                return recipe.outputs;
+            }
+        });
+    }
+    
+    /**
+     * Adds a recipe to the garden Cloche.
+     * <p>
+     * Requires an additional {@link MCBlock} object that should be rendered in the game.<br/>
+     * Also requires a render type that states how the block should "grow" inside the cloche.<br/>
+     * These two parameters are solely for Rendering purposes and don't change what the recipe returns.
+     * <p>
+     * By default these 4 renderers are present:
+     * "crop", can be used for any 1-block crops with an age property
+     * "stacking", can be used for stacking plants like sugarcane or cactus
+     * "stem", can be used for stem-grown plants like melon or pumpkin
+     * "generic", can be used for any block, making it grow in size, like mushrooms
+     *
+     * @param recipePath  recipePath The recipe name, without the resource location
+     * @param seed        The seed that needs to be inserted in the Cloche's gui
+     * @param soil        The soil that this seeds need to grow on
+     * @param time        The time it takes for the crop to mature (without modifiers), in ticks
+     * @param outputs     The outputs this crop produces when it matures
+     * @param renderBlock The block that should be rendered in world
+     * @param renderType  The render type that should be used
+     * @docParam recipePath "bonsai_oak"
+     * @docParam seed <item:minecraft:oak_sapling>
+     * @docParam soil <item:minecraft:dirt>
+     * @docParam time 100
+     * @docParam outputs [<item:minecraft:apple>, <item:minecraft:oak_sapling>, <item:minecraft:oak_wood> * 5]
+     * @docParam renderBlock <blockstate:minecraft:oak_sapling>.block
+     * @docParam renderType "generic"
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient seed, IIngredient soil, int time, IItemStack[] outputs, MCBlock renderBlock, @ZenCodeType.Optional("\"generic\"") String renderType) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final List<ItemStack> outputList = CrTIngredientUtil.getNonNullList(outputs);
+        final Ingredient seedIngredient = seed.asVanillaIngredient();
+        final Ingredient soilIngredient = soil.asVanillaIngredient();
+        if(!ClocheRenderFunction.RENDER_FUNCTION_FACTORIES.containsKey(renderType)) {
+            throw new IllegalArgumentException("Unknown Render Type: " + renderType);
+        }
+        
+        final Block block = renderBlock.getInternal();
+        final ClocheRenderFunction.ClocheRenderReference renderReference = new ClocheRenderFunction.ClocheRenderReference(renderType, block);
+        try {
+            final ClocheRecipe recipe = new ClocheRecipe(resourceLocation, outputList, seedIngredient, soilIngredient, time, renderReference);
+            CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+        } catch(Exception ex) {
+            CraftTweakerAPI.logThrowing("Could not create Cloche recipe '%s' with renderType '%s': ", ex, recipePath, renderType);
+        }
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/CokeOvenRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/CokeOvenRecipeManager.java
@@ -1,0 +1,59 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Coke Oven recipes.
+ * <p>
+ * Coke Oven recipes consist of an input, an output and the amount of creosote produced
+ *
+ * @docParam this <recipetype:immersiveengineering:coke_oven>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/CokeOven")
+@ZenCodeType.Name("mods.immersiveengineering.CokeOven")
+public class CokeOvenRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<CokeOvenRecipe> getRecipeType() {
+        return CokeOvenRecipe.TYPE;
+    }
+    
+    /**
+     * Adds a coke oven recipe
+     *
+     * @param recipePath       RecipePath The recipe name, without the resource location
+     * @param ingredient       The recipe's input
+     * @param time             The time the recipe requires, in ticks
+     * @param output           The produced item
+     * @param creosoteProduced The amount of creosote produced
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient ingredient, int time, IItemStack output, @ZenCodeType.OptionalInt int creosoteProduced) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final IngredientWithSize ingredientWithSize = CrTIngredientUtil.getIngredientWithSize(ingredient);
+        final ItemStack result = output.getInternal();
+        
+        final CokeOvenRecipe recipe = new CokeOvenRecipe(resourceLocation, result, ingredientWithSize, time, creosoteProduced);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/CrusherRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/CrusherRecipeManager.java
@@ -1,0 +1,100 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker.impl.item.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+import java.util.*;
+
+/**
+ * Allows you to add or remove Crusher recipes.
+ * <p>
+ * Crusher Recipes consist of an input, an output and a list of possible secondary outputs.
+ *
+ * @docParam this <recipetype:immersiveengineering:crusher>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Crusher")
+@ZenCodeType.Name("mods.immersiveengineering.Crusher")
+public class CrusherRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<CrusherRecipe> getRecipeType() {
+        return CrusherRecipe.TYPE;
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        removeRecipe((IIngredient) output);
+    }
+    
+    /**
+     * Removes all recipes that output the given IIngredient.
+     * Removes the recipe as soon as any of the recipe's possible outputs matches the given IIngredient.
+     * Includes secondary outputs and chance-based outputs.
+     *
+     * @param output The output whose recipes should be removed
+     * @docParam output <item:immersiveengineering:dust_iron>
+     * @docParam output <tag:forge:dusts>
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(IIngredient output) {
+        CraftTweakerAPI.apply(new AbstractActionRemoveMultipleOutputs<CrusherRecipe>(this, output) {
+            
+            @Override
+            public List<ItemStack> getAllOutputs(CrusherRecipe recipe) {
+                final ArrayList<ItemStack> itemStacks = new ArrayList<>();
+                itemStacks.add(recipe.output);
+                for(StackWithChance secondaryOutput : recipe.secondaryOutputs) {
+                    itemStacks.add(secondaryOutput.getStack());
+                }
+                return itemStacks;
+            }
+        });
+    }
+    
+    /**
+     * Adds a Crusher recipe.
+     *
+     * @param recipePath        The recipe name, without the resource location
+     * @param input             The input ingredient
+     * @param energy            The total energy required
+     * @param mainOutput        The main item that this recipe will return
+     * @param additionalOutputs All secondary items that can be returned
+     * @docParam recipePath "tnt_discharge"
+     * @docParam input <item:minecraft:tnt>
+     * @docParam energy 500
+     * @docParam mainOutput <item:minecraft:gunpowder> * 4
+     * @docParam additionalOutputs <item:minecraft:coal> % 50, <item:minecraft:diamond> % 1
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, int energy, IItemStack mainOutput, MCWeightedItemStack... additionalOutputs) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        
+        final CrusherRecipe recipe = new CrusherRecipe(resourceLocation, mainOutput.getInternal(), input
+                .asVanillaIngredient(), energy);
+        for(MCWeightedItemStack additionalOutput : additionalOutputs) {
+            recipe.addToSecondaryOutput(CrTIngredientUtil.getStackWithChance(additionalOutput));
+        }
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/FermenterRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/FermenterRecipeManager.java
@@ -1,0 +1,147 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.fluid.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker.impl.fluid.*;
+import com.blamejared.crafttweaker.impl.item.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import net.minecraftforge.fluids.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Fermenter recipes.
+ * <p>
+ * Fermenter Recipes consist of an input, a fluid output and an item output either fluid or item output can be empty.
+ *
+ * @docParam this <recipetype:immersiveengineering:fermenter>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Fermenter")
+@ZenCodeType.Name("mods.immersiveengineering.Fermenter")
+public class FermenterRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<FermenterRecipe> getRecipeType() {
+        return FermenterRecipe.TYPE;
+    }
+    
+    /**
+     * Adds a Fermenter recipe.
+     * You need to provide an item output, a fluid output, or both
+     *
+     * @param recipePath  The recipe name, without the resource location
+     * @param input       The recipe's input
+     * @param energy      The total energy required for this recipe
+     * @param itemOutput  The item output (can be empty)
+     * @param fluidOutput The fluid output (can be empty)
+     * @docParam recipePath "fermenter_upgrade_sword"
+     * @docParam input <item:minecraft:wooden_sword>
+     * @docParam energy 1000
+     * @docParam itemOutput <item:minecraft:stone_sword>
+     * @docParam fluidOutput <fluid:minecraft:water> * 100
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, int energy, IItemStack itemOutput, IFluidStack fluidOutput) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final IngredientWithSize ingredient = CrTIngredientUtil.getIngredientWithSize(input);
+        final FluidStack fluidStack = CrTIngredientUtil.getFluidStack(fluidOutput);
+        final ItemStack outputItem = itemOutput.getInternal();
+        
+        final FermenterRecipe recipe = new FermenterRecipe(resourceLocation, fluidStack, outputItem, ingredient, energy);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null) {
+            @Override
+            public String describe() {
+                return super.describe() + " and " + fluidOutput.getCommandString();
+            }
+        });
+    }
+    
+    /**
+     * Adds a Fermenter recipe.
+     * The overload for only the fluid Output
+     *
+     * @param recipePath  The recipe name, without the resource location
+     * @param input       The recipe's input
+     * @param energy      The total energy required for this recipe
+     * @param fluidOutput The fluid output (can be empty)
+     * @docParam recipePath "fermenter_extract_water"
+     * @docParam input <item:minecraft:wooden_hoe>
+     * @docParam energy 1000
+     * @docParam fluidOutput <fluid:minecraft:water> * 100
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, int energy, IFluidStack fluidOutput) {
+        addRecipe(recipePath, input, energy, MCItemStack.EMPTY.get(), fluidOutput);
+    }
+    
+    /**
+     * Adds a Fermenter recipe.
+     * The overload for only the item output
+     *
+     * @param recipePath The recipe name, without the resource location
+     * @param input      The recipe's input
+     * @param energy     The total energy required for this recipe
+     * @param itemOutput The item output (can be empty)
+     * @docParam recipePath "fermenter_upgrade_hoe"
+     * @docParam input <item:minecraft:wooden_shovel>
+     * @docParam energy 1000
+     * @docParam itemOutput <item:minecraft:stone_shovel>
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, int energy, IItemStack itemOutput) {
+        addRecipe(recipePath, input, energy, itemOutput, new MCFluidStackMutable(FluidStack.EMPTY));
+    }
+    
+    /**
+     * Removes all recipes that return the given output fluid.
+     * Since it uses a fluid and not a fluidStack it does not compare stack sizes
+     *
+     * @param outputFluid The fluid to remove
+     * @docParam outputFluid <fluid:immersiveengineering:ethanol>.fluid
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(MCFluid outputFluid) {
+        CraftTweakerAPI.apply(new AbstractActionGenericRemoveRecipe<FermenterRecipe>(this, outputFluid) {
+            @Override
+            public boolean shouldRemove(FermenterRecipe recipe) {
+                return recipe.fluidOutput.getFluid() == outputFluid.getInternal();
+            }
+        });
+    }
+    
+    /**
+     * Removes all recipes that return the given fluidStack.
+     * Takes stack sizes into account!
+     *
+     * @param output The fluid to remove
+     * @docParam output <fluid:immersiveengineering:ethanol> * 80
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(IFluidStack output) {
+        
+        CraftTweakerAPI.apply(new AbstractActionGenericRemoveRecipe<FermenterRecipe>(this, output) {
+            @Override
+            public boolean shouldRemove(FermenterRecipe recipe) {
+                return output.getInternal().isFluidStackIdentical(recipe.fluidOutput);
+            }
+        });
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/MetalPressRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/MetalPressRecipeManager.java
@@ -1,0 +1,65 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Metal Press recipes.
+ * <p>
+ * Metal Press recipes consist of an input, a mold item and an output.
+ *
+ * @docParam this <recipetype:immersiveengineering:metal_press>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/MetalPress")
+@ZenCodeType.Name("mods.immersiveengineering.MetalPress")
+public class MetalPressRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<MetalPressRecipe> getRecipeType() {
+        return MetalPressRecipe.TYPE;
+    }
+    
+    /**
+     * Adds a new metal press recipe
+     *
+     * @param recipePath The recipe name, without the resource location
+     * @param input      The recipe's input
+     * @param mold       The mold to be used
+     * @param energy     The total energy required for this recipe
+     * @param output     The recipe result
+     * @docParam recipePath "book_press"
+     * @docParam input <item:minecraft:paper> * 2
+     * @docParam mold <item:immersiveengineering:manual>
+     * @docParam energy 1000
+     * @docParam output <item:immersiveengineering:manual>
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, IItemStack mold, int energy, IItemStack output) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final IngredientWithSize ingredient = CrTIngredientUtil.getIngredientWithSize(input);
+        final ComparableItemStack moldStack = new ComparableItemStack(mold.getInternal(), mold.hasTag());
+        final ItemStack outputStack = output.getInternal();
+        
+        final MetalPressRecipe recipe = new MetalPressRecipe(resourceLocation, outputStack, ingredient, moldStack, energy);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/MixerRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/MixerRecipeManager.java
@@ -1,0 +1,125 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.fluid.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker.impl.fluid.*;
+import com.blamejared.crafttweaker.impl.tag.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import net.minecraftforge.fluids.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Mixer recipes.
+ * <p>
+ * Mixer Recipes consist of a fluid input, multiple item inputs and a fluid output.
+ *
+ * @docParam this <recipetype:immersiveengineering:mixer>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Mixer")
+@ZenCodeType.Name("mods.immersiveengineering.Mixer")
+public class MixerRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<MixerRecipe> getRecipeType() {
+        return MixerRecipe.TYPE;
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        throw new UnsupportedOperationException("Cannot remove a Mixer recipe by Item output because Mixer Recipes have no Item output!");
+    }
+    
+    /**
+     * Removes all recipes that return this given fluid Stack.
+     * Only removes if the fluid and the fluid amount match.
+     * Does not remove potion recipes!
+     *
+     * @param fluidStack The output to remove
+     * @docParam fluidStack <fluid:immersiveengineering:concrete> * 500
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(IFluidStack fluidStack) {
+        final AbstractActionGenericRemoveRecipe<MixerRecipe> action = new AbstractActionGenericRemoveRecipe<MixerRecipe>(this, fluidStack) {
+            @Override
+            public boolean shouldRemove(MixerRecipe recipe) {
+                return recipe.fluidOutput.isFluidStackIdentical(fluidStack.getInternal());
+            }
+        };
+        
+        CraftTweakerAPI.apply(action);
+    }
+    
+    /**
+     * Removes all recipes that return this given fluid.
+     * Since it's only the fluid, it does not check amounts.
+     * Does not remove potion recipes!
+     *
+     * @param fluid The fluid output to remove
+     * @docParam fluid <fluid:immersiveengineering:concrete>.fluid
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(MCFluid fluid) {
+        final AbstractActionGenericRemoveRecipe<MixerRecipe> action = new AbstractActionGenericRemoveRecipe<MixerRecipe>(this, fluid) {
+            @Override
+            public boolean shouldRemove(MixerRecipe recipe) {
+                return recipe.fluidOutput.getFluid() == fluid.getInternal();
+            }
+        };
+        
+        CraftTweakerAPI.apply(action);
+    }
+    
+    /**
+     * Adds a recipe to the Mixer.
+     * Make sure that the provided Tag is a valid fluid tag.
+     *
+     * Mixer recipes will always convert 1mB of the input fluid to 1mB of the output fluid.
+     * The `amount` parameter specifies for how many mB the given ingredients last
+     *
+     * @param recipePath The recipe name, without the resource location
+     * @param fluidInput The fluid input as Tag
+     * @param inputItems The required input items
+     * @param energy     The total energy required
+     * @param output     The produced output fluidStack
+     * @param amount     The amount of fluid that can be converted per set of input items (in mB)
+     * @docParam recipePath "grow_creosote_oil"
+     * @docParam fluidInput <tag:minecraft:water>
+     * @docParam inputItems [<item:minecraft:oak_sapling>, <item:minecraft:bone_meal> * 4, <item:immersiveengineering:creosote_bucket>]
+     * @docParam energy 5000
+     * @docParam output <fluid:immersiveengineering:creosote>.fluid
+     * @docParam amount 8000
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, MCTag fluidInput, IIngredient[] inputItems, int energy, MCFluid output, int amount) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        if(!fluidInput.isFluidTag()) {
+            throw new IllegalArgumentException("Provided tag is not a fluid tag: " + fluidInput.getCommandString());
+        }
+        
+        final ResourceLocation fluidTagId = fluidInput.getId().getInternal();
+        final FluidTagInput fluidTagInput = new FluidTagInput(fluidTagId, amount);
+        final IngredientWithSize[] ingredientsWithSize = CrTIngredientUtil.getIngredientsWithSize(inputItems);
+        final FluidStack outputFluidStack = new FluidStack(output.getInternal(), amount);
+        
+        final MixerRecipe recipe = new MixerRecipe(resourceLocation, outputFluidStack, fluidTagInput, ingredientsWithSize, energy);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/RefineryRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/RefineryRecipeManager.java
@@ -1,0 +1,128 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.fluid.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker.impl.fluid.*;
+import com.blamejared.crafttweaker.impl.tag.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import net.minecraftforge.fluids.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Refinery recipes.
+ * <p>
+ * Refinery Recipes consist of two fluid inputs and a fluid output.
+ *
+ * @docParam this <recipetype:immersiveengineering:refinery>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Refinery")
+@ZenCodeType.Name("mods.immersiveengineering.Refinery")
+public class RefineryRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<RefineryRecipe> getRecipeType() {
+        return RefineryRecipe.TYPE;
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        throw new UnsupportedOperationException("Cannot remove a refinery recipe by item output, since it only has a fluid output");
+    }
+    
+    /**
+     * Removes all recipes that return this given fluid Stack.
+     * Only removes if the fluid and the fluid amount match.
+     *
+     * @param fluidStack The output to remove
+     * @docParam fluidStack <fluid:immersiveengineering:biodiesel> * 16
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(IFluidStack fluidStack) {
+        final AbstractActionGenericRemoveRecipe<RefineryRecipe> action = new AbstractActionGenericRemoveRecipe<RefineryRecipe>(this, fluidStack) {
+            @Override
+            public boolean shouldRemove(RefineryRecipe recipe) {
+                return recipe.output.isFluidStackIdentical(fluidStack.getInternal());
+            }
+        };
+        
+        CraftTweakerAPI.apply(action);
+    }
+    
+    /**
+     * Removes all recipes that return this given fluid.
+     * Since it's only the fluid, it does not check amounts.
+     *
+     * @param fluid The fluid output to remove
+     * @docParam fluid <fluid:immersiveengineering:biodiesel>.fluid
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(MCFluid fluid) {
+        final AbstractActionGenericRemoveRecipe<RefineryRecipe> action = new AbstractActionGenericRemoveRecipe<RefineryRecipe>(this, fluid) {
+            @Override
+            public boolean shouldRemove(RefineryRecipe recipe) {
+                return recipe.output.getFluid() == fluid.getInternal();
+            }
+        };
+        
+        CraftTweakerAPI.apply(action);
+    }
+    
+    /**
+     * Adds a recipe to the Refinery.
+     * Make sure that the provided Tags are valid fluid tags.
+     *
+     * @param recipePath  The recipe name, without the resource location
+     * @param fluidInput1 The first fluid input, as Tag
+     * @param amount1     The amount of fluid that should be consumed
+     * @param fluidInput2 The second fluid input, as Tag
+     * @param amount2     The amount of fluid that should be consumed
+     * @param energy      The total energy required
+     * @param output      The output fluid
+     * @docParam recipePath "refine_herbicide"
+     * @docParam fluidInput1 <tag:minecraft:water>
+     * @docParam amount1 10
+     * @docParam fluidInput2 <tag:forge:ethanol>
+     * @docParam amount2 1
+     * @docParam energy 1000
+     * @docParam output <fluid:immersiveengineering:herbicide> * 10
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, MCTag fluidInput1, int amount1, MCTag fluidInput2, int amount2, int energy, IFluidStack output) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final FluidStack outputStack = CrTIngredientUtil.getFluidStack(output);
+        
+        if(!fluidInput1.isFluidTag()) {
+            throw new IllegalArgumentException("Provided tag is not a fluid tag: " + fluidInput1.getCommandString());
+        }
+        
+        if(!fluidInput2.isFluidTag()) {
+            throw new IllegalArgumentException("Provided tag is not a fluid tag: " + fluidInput2.getCommandString());
+        }
+        
+        final ResourceLocation tag1Location = fluidInput1.getId().getInternal();
+        final ResourceLocation tag2Location = fluidInput2.getId().getInternal();
+        final FluidTagInput tagInput1 = new FluidTagInput(tag1Location, amount1);
+        final FluidTagInput tagInput2 = new FluidTagInput(tag2Location, amount2);
+        
+        final RefineryRecipe recipe = new RefineryRecipe(resourceLocation, outputStack, tagInput1, tagInput2, energy);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/SawmillRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/SawmillRecipeManager.java
@@ -1,0 +1,133 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker.impl.helper.*;
+import com.blamejared.crafttweaker.impl.item.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
+
+import java.util.*;
+
+/**
+ * Allows you to add or remove Sawmill recipes.
+ * <p>
+ * Sawmill Recipes consist of an input, an optional, intermediate "stripped" output and a "cut" output.
+ * <p>
+ * Each step (stripping and sawing) have possible secondary outputs.
+ * These won't be returned through the conveyor belt, but through the item output to the front, right next to the sawblade.
+ *
+ * @docParam this <recipetype:immersiveengineering:sawmill>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Sawmill")
+@ZenCodeType.Name("mods.immersiveengineering.Sawmill")
+public class SawmillRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<SawmillRecipe> getRecipeType() {
+        return SawmillRecipe.TYPE;
+    }
+    
+    @Override
+    public void removeRecipe(IItemStack output) {
+        final AbstractActionRemoveMultipleOutputs<SawmillRecipe> action = new AbstractActionRemoveMultipleOutputs<SawmillRecipe>(this, output) {
+            @Override
+            public List<ItemStack> getAllOutputs(SawmillRecipe recipe) {
+                final List<ItemStack> itemStacks = new ArrayList<>();
+                itemStacks.add(recipe.output);
+                itemStacks.add(recipe.stripped);
+                itemStacks.addAll(recipe.secondaryOutputs);
+                itemStacks.addAll(recipe.secondaryStripping);
+                return itemStacks;
+            }
+        };
+        CraftTweakerAPI.apply(action);
+    }
+    
+    /**
+     * Adds a sawmill recipe.
+     *
+     * Note that the recipe only works from start to final output.<br/>
+     * So if you remove the sawblade to get the intermediate item, you need a 2nd recipe starting from the intermediate item if you later want to process that item.
+     *
+     * @param recipePath                The recipe name, without the resource location
+     * @param input                     The item input
+     * @param energy                    The total energy required
+     * @param strippedOutput            The intermediate Stripped output. Will be returned if no sawblade is present
+     * @param strippedOutputSecondaries The secondary outputs that are created while stripping. Must be empty if no intermediate output was provided.
+     * @param output                    The output that is returned when a sawblade is present
+     * @param outputSecondaries         The secondary outputs that are created alongside the `output` item
+     * @docParam recipePath "shredding_seeds"
+     * @docParam input <tag:minecraft:saplings>
+     * @docParam energy 1200
+     * @docParam strippedOutput <item:minecraft:dead_bush>
+     * @docParam strippedOutputSecondaries [<item:minecraft:grass>]
+     * @docParam output <item:minecraft:stick> * 2
+     * @docParam outputSecondaries [<item:immersiveengineering:dust_wood>]
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, int energy, IItemStack strippedOutput, IItemStack[] strippedOutputSecondaries, IItemStack output, IItemStack[] outputSecondaries) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final Ingredient ingredient = input.asVanillaIngredient();
+        
+        final ItemStack stripped = strippedOutput.getInternal();
+        final ItemStack[] secondaryStripping = CraftTweakerHelper.getItemStacks(strippedOutputSecondaries);
+        
+        if(stripped.isEmpty() && strippedOutputSecondaries.length != 0) {
+            throw new IllegalArgumentException("Cannot have secondary stripped outputs when the main stripped output is empty!");
+        }
+        
+        final ItemStack mainOutput = output.getInternal();
+        final ItemStack[] secondaryOutputs = CraftTweakerHelper.getItemStacks(outputSecondaries);
+        
+        final SawmillRecipe recipe = new SawmillRecipe(resourceLocation, mainOutput, stripped, ingredient, energy);
+        for(ItemStack stack : secondaryStripping) {
+            recipe.addToSecondaryStripping(stack);
+        }
+        
+        for(ItemStack stack : secondaryOutputs) {
+            recipe.addToSecondaryOutput(stack);
+        }
+        
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+    
+    /**
+     * Adds a sawmill recipe.
+     * This method is a shorter version for recipes that do not require stripping.
+     * Note that recipes without an intermediate item will do nothing if the sawmill has no sawblade.
+     *
+     * @param recipePath        The recipe name, without the resource location
+     * @param input             The item input
+     * @param energy            The total energy required
+     * @param output            The item that is returned
+     * @param outputSecondaries The secondary outputs that are created alongside the `output` item
+     *
+     * @docParam recipePath "splitting_bones"
+     * @docParam input <item:minecraft:bone_block>
+     * @docParam energy 1000
+     * @docParam output <item:minecraft:bone> * 5
+     * @docParam outputSecondaries [<item:minecraft:bone_meal> * 2]
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, int energy, IItemStack output, IItemStack[] outputSecondaries) {
+        addRecipe(recipePath, input, energy, MCItemStack.EMPTY.get(), new IItemStack[0], output, outputSecondaries);
+    }
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/SqueezerRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/SqueezerRecipeManager.java
@@ -1,0 +1,127 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.*;
+import blusunrize.immersiveengineering.api.crafting.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.*;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.actions.*;
+import com.blamejared.crafttweaker.api.*;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.fluid.*;
+import com.blamejared.crafttweaker.api.item.*;
+import com.blamejared.crafttweaker.api.managers.*;
+import com.blamejared.crafttweaker.impl.actions.recipes.*;
+import com.blamejared.crafttweaker.impl.fluid.*;
+import com.blamejared.crafttweaker_annotations.annotations.*;
+import net.minecraft.item.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import net.minecraftforge.fluids.*;
+import org.openzen.zencode.java.*;
+
+/**
+ * Allows you to add or remove Squeezer recipes.
+ * <p>
+ * Squeezer Recipes consist of an input, a fluid output and an item output.
+ *
+ * @docParam this <recipetype:immersiveengineering:squeezer>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/Squeezer")
+@ZenCodeType.Name("mods.immersiveengineering.Squeezer")
+public class SqueezerRecipeManager implements IRecipeManager {
+    
+    @Override
+    public IRecipeType<SqueezerRecipe> getRecipeType() {
+        return SqueezerRecipe.TYPE;
+    }
+    
+    /**
+     * Removes all recipes that return this given fluid Stack.
+     * Only removes if the fluid and the fluid amount match.
+     *
+     * @param fluidStack The output to remove
+     * @docParam fluidStack <fluid:immersiveengineering:plantoil> * 60
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(IFluidStack fluidStack) {
+        final AbstractActionGenericRemoveRecipe<SqueezerRecipe> action = new AbstractActionGenericRemoveRecipe<SqueezerRecipe>(this, fluidStack) {
+            @Override
+            public boolean shouldRemove(SqueezerRecipe recipe) {
+                return recipe.fluidOutput.isFluidStackIdentical(fluidStack.getInternal());
+            }
+        };
+        
+        CraftTweakerAPI.apply(action);
+    }
+    
+    /**
+     * Removes all recipes that return this given fluid.
+     * Since it's only the fluid, it does not check amounts.
+     *
+     * @param fluid The fluid output to remove
+     * @docParam fluid <fluid:immersiveengineering:plantoil>.fluid
+     */
+    @ZenCodeType.Method
+    public void removeRecipe(MCFluid fluid) {
+        final AbstractActionGenericRemoveRecipe<SqueezerRecipe> action = new AbstractActionGenericRemoveRecipe<SqueezerRecipe>(this, fluid) {
+            @Override
+            public boolean shouldRemove(SqueezerRecipe recipe) {
+                return recipe.fluidOutput.getFluid() == fluid.getInternal();
+            }
+        };
+        
+        CraftTweakerAPI.apply(action);
+    }
+    
+    /**
+     * Adds a recipe to the Squeezer.
+     * The item output is optional.
+     *
+     * @param recipePath  The recipe name, without the resource location
+     * @param input       The input item
+     * @param energy      The total energy required for this recipe
+     * @param fluidOutput The fluid output
+     * @param itemOutput  The item output
+     * @docParam recipePath "pressure_creates_diamonds"
+     * @docParam input <item:minecraft:coal_block> * 8
+     * @docParam energy 6000
+     * @docParam fluidOutput <fluid:immersiveengineering:creosote> * 2500
+     * @docParam itemOutput <item:minecraft:diamond>
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, int energy, IFluidStack fluidOutput, @ZenCodeType.Optional("<item:minecraft:air>") IItemStack itemOutput) {
+        final ResourceLocation resourceLocation = new ResourceLocation(Lib.MODID, recipePath);
+        final IngredientWithSize inputWithSize = CrTIngredientUtil.getIngredientWithSize(input);
+        final FluidStack fluidOut = CrTIngredientUtil.getFluidStack(fluidOutput);
+        final ItemStack itemOut = itemOutput.getInternal();
+        
+        final SqueezerRecipe recipe = new SqueezerRecipe(resourceLocation, fluidOut, itemOut, inputWithSize, energy);
+        CraftTweakerAPI.apply(new ActionAddRecipe(this, recipe, null));
+    }
+    
+    /**
+     * Adds a recipe to the Squeezer.
+     * Short form if you don't want a fluid output.
+     * Does the same as if you provided `<fluid:minecraft:empty> * 0` to the other addRecipe Method.
+     *
+     * @param recipePath  The recipe name, without the resource location
+     * @param input       The input item
+     * @param energy      The total energy required for this recipe
+     * @param itemOutput  The item output
+     * @docParam recipePath "slag_off"
+     * @docParam input <item:immersiveengineering:slag> * 9
+     * @docParam energy 5000
+     * @docParam itemOutput <item:minecraft:dirt>
+     */
+    @ZenCodeType.Method
+    public void addRecipe(String recipePath, IIngredient input, int energy, IItemStack itemOutput) {
+        addRecipe(recipePath, input, energy, new MCFluidStackMutable(FluidStack.EMPTY), itemOutput);
+    }
+}


### PR DESCRIPTION
Hello people,

a simple CrT implementation for all Recipetypes added by IE so far, except the MineralMix one, since for latter I didn't know how to properly handle the conditions and properties (though a CrT impl probably wouldn't need them).

It includes the CrT Annotation processors to create documentation entries in `./docsOut` at compilation time.
Please, when you have time to go over the changes, try to check it out into a local branch and run it, to make sure that the APs work properly in your dev environment as well. I haven't heard of anyone having issues with them so far, but then again, few know that they even exist atm...

My glorious test script can be found here:
<https://gist.github.com/kindlich/0ce8964c58c6116df328f281d3aea6da>

They are more or less the same as the examples that are in the generated docs (btw, should I put these generated files in a separate gist?).


This PR is created as draft for now since I'm going to do some more testing, and there are probably still some typos to be found in the javadocs (which will be the generated docs) and in messages...
Still, I wanted to give you the chance to go over the changes if you like ^^.


Questions:

As for the generated CrT documentation: 
I _could_ add a new step to the Jenkinsfile that will take the generated docs and uploads them to the CrT docs repository.
The again, this would increase your build pipeline time by about 15~20 seconds, and I don't think the implementation will change often enough for this to be reasonable. But your call 😛 


Do you want the MineralMix to be in there as well?