### PR TITLE
Excavator mirrored bucketwheel flicker fix

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BucketWheelTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BucketWheelTileEntity.java
@@ -198,9 +198,9 @@ public class BucketWheelTileEntity extends MultiblockPartTileEntity<BucketWheelT
 	}
 
 	public void adjustStructureFacingAndMirrored(Direction targetFacing, boolean targetMirrored) {
-		if (world.isRemote || this != this.master() || targetFacing.getAxis() == Direction.Axis.Y || (this.getFacing()==targetFacing && this.getIsMirrored()==targetMirrored))
-			return;
-		boolean changePos = (this.getFacing()!=targetFacing)^targetMirrored;
+		if (this != this.master() || targetFacing.getAxis() == Direction.Axis.Y || (this.getFacing()==targetFacing && this.getIsMirrored()==targetMirrored))
+			return;//world.isRemote ||
+		boolean changePos = (this.getFacing()!=targetFacing)^(this.getIsMirrored()^targetMirrored);
 		BlockPos centerPos = this.getPos();
 		for(int h = -3; h <= 3; h++)
 			for(int w = -3; w <= 3; w++)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BucketWheelTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BucketWheelTileEntity.java
@@ -199,16 +199,15 @@ public class BucketWheelTileEntity extends MultiblockPartTileEntity<BucketWheelT
 
 	public void adjustStructureFacingAndMirrored(Direction targetFacing, boolean targetMirrored)
 	{
-		if(this==this.master()&&targetFacing.getAxis()!=Direction.Axis.Y&&(this.getFacing()!=targetFacing||this.getIsMirrored()!=targetMirrored))
+		if(this==master()&&targetFacing.getAxis()!=Direction.Axis.Y&&(getFacing()!=targetFacing||getIsMirrored()!=targetMirrored))
 		{
-			boolean changePos = (this.getFacing()!=targetFacing)^(this.getIsMirrored()^targetMirrored);
-			BlockPos centerPos = this.getPos();
+			boolean changePos = (getFacing()!=targetFacing)^(getIsMirrored()^targetMirrored);
 			for(int h = -3; h <= 3; h++)
 				for(int w = -3; w <= 3; w++)
 				{
 					if((Math.abs(h)==3&&w!=0)||(Math.abs(w)==3&&h!=0))
 						continue;
-					TileEntity te = world.getTileEntity(centerPos.add(0, h, 0).offset(getFacing(), w));
+					TileEntity te = world.getTileEntity(getPos().add(0, h, 0).offset(getFacing(), w));
 					if(te instanceof BucketWheelTileEntity)
 					{
 						BucketWheelTileEntity bucketTE = (BucketWheelTileEntity)te;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BucketWheelTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/BucketWheelTileEntity.java
@@ -197,28 +197,30 @@ public class BucketWheelTileEntity extends MultiblockPartTileEntity<BucketWheelT
 		return VoxelShapes.create(0, 0, 0, 1, 1, 1);
 	}
 
-	public void adjustStructureFacingAndMirrored(Direction targetFacing, boolean targetMirrored) {
-		if (this != this.master() || targetFacing.getAxis() == Direction.Axis.Y || (this.getFacing()==targetFacing && this.getIsMirrored()==targetMirrored))
-			return;//world.isRemote ||
-		boolean changePos = (this.getFacing()!=targetFacing)^(this.getIsMirrored()^targetMirrored);
-		BlockPos centerPos = this.getPos();
-		for(int h = -3; h <= 3; h++)
-			for(int w = -3; w <= 3; w++)
-			{
-				if((Math.abs(h)==3&&w!=0)||(Math.abs(w)==3&&h!=0))
-					continue;
-				TileEntity te = world.getTileEntity(centerPos.add(0, h, 0).offset(getFacing(), w));
-				if(te instanceof BucketWheelTileEntity)
+	public void adjustStructureFacingAndMirrored(Direction targetFacing, boolean targetMirrored)
+	{
+		if(this==this.master()&&targetFacing.getAxis()!=Direction.Axis.Y&&(this.getFacing()!=targetFacing||this.getIsMirrored()!=targetMirrored))
+		{
+			boolean changePos = (this.getFacing()!=targetFacing)^(this.getIsMirrored()^targetMirrored);
+			BlockPos centerPos = this.getPos();
+			for(int h = -3; h <= 3; h++)
+				for(int w = -3; w <= 3; w++)
 				{
-					BucketWheelTileEntity bucketTE = (BucketWheelTileEntity)te;
-					bucketTE.setFacing(targetFacing);
-					bucketTE.setMirrored(targetMirrored);
-					if(changePos)
-						bucketTE.posInMultiblock = new BlockPos(6-bucketTE.posInMultiblock.getX(), bucketTE.posInMultiblock.getY(), bucketTE.posInMultiblock.getZ());
-					te.markDirty();
-					bucketTE.markContainingBlockForUpdate(null);
-					world.addBlockEvent(te.getPos(), te.getBlockState().getBlock(), 255, 0);
+					if((Math.abs(h)==3&&w!=0)||(Math.abs(w)==3&&h!=0))
+						continue;
+					TileEntity te = world.getTileEntity(centerPos.add(0, h, 0).offset(getFacing(), w));
+					if(te instanceof BucketWheelTileEntity)
+					{
+						BucketWheelTileEntity bucketTE = (BucketWheelTileEntity)te;
+						bucketTE.setFacing(targetFacing);
+						bucketTE.setMirrored(targetMirrored);
+						if(changePos)
+							bucketTE.posInMultiblock = new BlockPos(6-bucketTE.posInMultiblock.getX(), bucketTE.posInMultiblock.getY(), bucketTE.posInMultiblock.getZ());
+						te.markDirty();
+						bucketTE.markContainingBlockForUpdate(null);
+						world.addBlockEvent(te.getPos(), te.getBlockState().getBlock(), 255, 0);
+					}
 				}
-			}
+		}
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/ExcavatorTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/ExcavatorTileEntity.java
@@ -144,27 +144,7 @@ public class ExcavatorTileEntity extends PoweredMultiblockTileEntity<ExcavatorTi
 						target = Math.round(rot/360f*8)%8;
 				}
 				else
-				{
-					boolean changePos = (wheel.getFacing()!=fRot)^mirrored;
-					for(int h = -3; h <= 3; h++)
-						for(int w = -3; w <= 3; w++)
-						{
-							if((Math.abs(h)==3&&w!=0)||(Math.abs(w)==3&&h!=0))
-								continue;
-							TileEntity te = world.getTileEntity(wheelPos.add(0, h, 0).offset(getFacing(), w));
-							if(te instanceof BucketWheelTileEntity)
-							{
-								BucketWheelTileEntity bucketTE = (BucketWheelTileEntity)te;
-								bucketTE.setFacing(fRot);
-								bucketTE.setMirrored(mirrored);
-								if(changePos)
-									bucketTE.posInMultiblock = new BlockPos(6-bucketTE.posInMultiblock.getX(), bucketTE.posInMultiblock.getY(), bucketTE.posInMultiblock.getZ());
-								te.markDirty();
-								bucketTE.markContainingBlockForUpdate(null);
-								world.addBlockEvent(te.getPos(), te.getBlockState().getBlock(), 255, 0);
-							}
-						}
-				}
+					wheel.adjustStructureFacingAndMirrored(fRot,mirrored);
 
 				if(!isRSDisabled())
 				{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/ExcavatorMultiblock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/ExcavatorMultiblock.java
@@ -49,12 +49,9 @@ public class ExcavatorMultiblock extends IETemplateMultiblock
 				ExcavatorTileEntity excavator = (ExcavatorTileEntity)clickedTE;
 				BlockPos wheelCenter = excavator.getWheelCenterPos();
 				IEMultiblocks.BUCKET_WHEEL.createStructure(world, wheelCenter, side.rotateYCCW(), player);
-				if(excavator.getIsMirrored())
-				{
-					TileEntity wheel = world.getTileEntity(wheelCenter);
-					if(wheel!=null&&wheel instanceof BucketWheelTileEntity)
-						((BucketWheelTileEntity)wheel).adjustStructureFacingAndMirrored(side.rotateY(), excavator.getIsMirrored());
-				}
+				TileEntity wheel = world.getTileEntity(wheelCenter);
+				if(wheel instanceof BucketWheelTileEntity)
+					((BucketWheelTileEntity)wheel).adjustStructureFacingAndMirrored(side.rotateY(), excavator.getIsMirrored());
 			}
 		}
 		return excavatorFormed;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/ExcavatorMultiblock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/ExcavatorMultiblock.java
@@ -49,9 +49,12 @@ public class ExcavatorMultiblock extends IETemplateMultiblock
 				ExcavatorTileEntity excavator = (ExcavatorTileEntity)clickedTE;
 				BlockPos wheelCenter = excavator.getWheelCenterPos();
 				IEMultiblocks.BUCKET_WHEEL.createStructure(world, wheelCenter, side.rotateYCCW(), player);
-				TileEntity wheel = world.getTileEntity(wheelCenter);
-				if (wheel != null && wheel instanceof BucketWheelTileEntity)
-					((BucketWheelTileEntity)wheel).adjustStructureFacingAndMirrored(side.rotateYCCW(), excavator.getIsMirrored());
+				if(excavator.getIsMirrored())
+				{
+					TileEntity wheel = world.getTileEntity(wheelCenter);
+					if(wheel!=null&&wheel instanceof BucketWheelTileEntity)
+						((BucketWheelTileEntity)wheel).adjustStructureFacingAndMirrored(side.rotateY(), excavator.getIsMirrored());
+				}
 			}
 		}
 		return excavatorFormed;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/ExcavatorMultiblock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/ExcavatorMultiblock.java
@@ -11,6 +11,7 @@ package blusunrize.immersiveengineering.common.blocks.multiblocks;
 import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.common.blocks.IEBlocks.Multiblocks;
+import blusunrize.immersiveengineering.common.blocks.metal.BucketWheelTileEntity;
 import blusunrize.immersiveengineering.common.blocks.metal.ExcavatorTileEntity;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import net.minecraft.client.renderer.IRenderTypeBuffer;
@@ -45,8 +46,12 @@ public class ExcavatorMultiblock extends IETemplateMultiblock
 			TileEntity clickedTE = world.getTileEntity(pos);
 			if(clickedTE instanceof ExcavatorTileEntity)
 			{
-				BlockPos wheelCenter = ((ExcavatorTileEntity)clickedTE).getWheelCenterPos();
+				ExcavatorTileEntity excavator = (ExcavatorTileEntity)clickedTE;
+				BlockPos wheelCenter = excavator.getWheelCenterPos();
 				IEMultiblocks.BUCKET_WHEEL.createStructure(world, wheelCenter, side.rotateYCCW(), player);
+				TileEntity wheel = world.getTileEntity(wheelCenter);
+				if (wheel != null && wheel instanceof BucketWheelTileEntity)
+					((BucketWheelTileEntity)wheel).adjustStructureFacingAndMirrored(side.rotateYCCW(), excavator.getIsMirrored());
 			}
 		}
 		return excavatorFormed;


### PR DESCRIPTION
mirrors bucketwheel upon mirrored excavator creation, removing the flicker of it jumping from non-mirrored to mirrored
this also might make reorienting and mirroring during the excavators tick unnecessary (didn't get called anymore in debugging for the cases I worked through, even stuff like building a mirrored excavator around a non-mirrored bucketwheel and the other way around), but I'll let you make that call