### PR TITLE
[1.16.3] Anti IndexOutOfBounds measure

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/gui/TurretScreen.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/TurretScreen.java
@@ -63,7 +63,7 @@ public abstract class TurretScreen extends IEContainerScreen<TurretContainer>
 					CompoundNBT tag = new CompoundNBT();
 					int listOffset = -1;
 					int rem = list.selectedOption;
-					if(rem>=0)
+					if(rem>=0&&tile.targetList.size()>0)
 					{
 						tile.targetList.remove(rem);
 						tag.putInt("remove", rem);


### PR DESCRIPTION
`tile.targetList.remove(rem)` is to blame