### PR TITLE
Sand Recipe Updates

### DIFF
--- a/src/generated/resources/data/forge/tags/blocks/sandstone/colorless.json
+++ b/src/generated/resources/data/forge/tags/blocks/sandstone/colorless.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sandstone",
+    "minecraft:cut_sandstone",
+    "minecraft:chiseled_sandstone",
+    "minecraft:smooth_sandstone"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/blocks/sandstone/red.json
+++ b/src/generated/resources/data/forge/tags/blocks/sandstone/red.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:red_sandstone",
+    "minecraft:cut_red_sandstone",
+    "minecraft:chiseled_red_sandstone",
+    "minecraft:smooth_red_sandstone"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/sandstone/colorless.json
+++ b/src/generated/resources/data/forge/tags/items/sandstone/colorless.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sandstone",
+    "minecraft:cut_sandstone",
+    "minecraft:chiseled_sandstone",
+    "minecraft:smooth_sandstone"
+  ]
+}

--- a/src/generated/resources/data/forge/tags/items/sandstone/red.json
+++ b/src/generated/resources/data/forge/tags/items/sandstone/red.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:red_sandstone",
+    "minecraft:cut_red_sandstone",
+    "minecraft:chiseled_red_sandstone",
+    "minecraft:smooth_red_sandstone"
+  ]
+}

--- a/src/generated/resources/data/immersiveengineering/recipes/cloche/cactus.json
+++ b/src/generated/resources/data/immersiveengineering/recipes/cloche/cactus.json
@@ -9,7 +9,7 @@
     "item": "minecraft:cactus"
   },
   "soil": {
-    "item": "minecraft:sand"
+    "tag": "forge:sand"
   },
   "time": 560,
   "render": {

--- a/src/generated/resources/data/immersiveengineering/recipes/cloche/sugar_cane.json
+++ b/src/generated/resources/data/immersiveengineering/recipes/cloche/sugar_cane.json
@@ -9,7 +9,7 @@
     "item": "minecraft:sugar_cane"
   },
   "soil": {
-    "item": "minecraft:sand"
+    "tag": "forge:sand"
   },
   "time": 560,
   "render": {

--- a/src/generated/resources/data/immersiveengineering/recipes/crusher/red_sandstone.json
+++ b/src/generated/resources/data/immersiveengineering/recipes/crusher/red_sandstone.json
@@ -9,11 +9,11 @@
     }
   ],
   "result": {
-    "item": "minecraft:sand",
+    "item": "minecraft:red_sand",
     "count": 2
   },
   "input": {
-    "tag": "forge:sandstone/colorless"
+    "tag": "forge:sandstone/red"
   },
   "energy": 3200
 }

--- a/src/main/java/blusunrize/immersiveengineering/api/IETags.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/IETags.java
@@ -40,6 +40,8 @@ public class IETags
 	public static final Tag<Block> clayBlock = createBlockTag(getStorageBlock("clay"));
 	public static final Tag<Item> charCoal = new ItemTags.Wrapper(forgeLoc("charcoal"));
 	public static final Tag<Block> glowstoneBlock = createBlockTag(getStorageBlock("glowstone"));
+	public static final Tag<Block> colorlessSandstoneBlocks = createBlockTag(forgeLoc("sandstone/colorless"));
+	public static final Tag<Block> redSandstoneBlocks = createBlockTag(forgeLoc("sandstone/red"));
 	//Other mods
 	public static final Tag<Block> charCoalBlocks = createBlockTag(getStorageBlock("charcoal"));
 	//IE Blocks

--- a/src/main/java/blusunrize/immersiveengineering/api/crafting/builders/ClocheRecipeBuilder.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/crafting/builders/ClocheRecipeBuilder.java
@@ -54,6 +54,11 @@ public class ClocheRecipeBuilder extends IEFinishedRecipe<ClocheRecipeBuilder>
 		return addItem("soil", itemStack);
 	}
 
+	public ClocheRecipeBuilder addSoil(Tag<Item> tag)
+	{
+		return addSoil(Ingredient.fromTag(tag));
+	}
+
 	public ClocheRecipeBuilder addSoil(Ingredient ingredient)
 	{
 		return addWriter(jsonObject -> jsonObject.add("soil", ingredient.serialize()));

--- a/src/main/java/blusunrize/immersiveengineering/api/crafting/builders/ClocheRecipeBuilder.java
+++ b/src/main/java/blusunrize/immersiveengineering/api/crafting/builders/ClocheRecipeBuilder.java
@@ -74,6 +74,6 @@ public class ClocheRecipeBuilder extends IEFinishedRecipe<ClocheRecipeBuilder>
 	@Override
 	protected boolean isComplete()
 	{
-		return super.isComplete() && hasRender;
+		return super.isComplete()&&hasRender;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/data/IEBlockTags.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/data/IEBlockTags.java
@@ -47,6 +47,16 @@ class IEBlockTags extends BlockTagsProvider
 				.add(Blocks.CLAY);
 		getBuilder(IETags.glowstoneBlock)
 				.add(Blocks.GLOWSTONE);
+		getBuilder(IETags.colorlessSandstoneBlocks)
+				.add(Blocks.SANDSTONE)
+				.add(Blocks.CUT_SANDSTONE)
+				.add(Blocks.CHISELED_SANDSTONE)
+				.add(Blocks.SMOOTH_SANDSTONE);
+		getBuilder(IETags.redSandstoneBlocks)
+				.add(Blocks.RED_SANDSTONE)
+				.add(Blocks.CUT_RED_SANDSTONE)
+				.add(Blocks.CHISELED_RED_SANDSTONE)
+				.add(Blocks.SMOOTH_RED_SANDSTONE);
 		for(EnumMetals metal : EnumMetals.values())
 		{
 			MetalTags tags = IETags.getTagsFor(metal);

--- a/src/main/java/blusunrize/immersiveengineering/common/data/Recipes.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/data/Recipes.java
@@ -315,13 +315,13 @@ public class Recipes extends RecipeProvider
 
 		ClocheRecipeBuilder.builder(Items.SUGAR_CANE)
 				.addInput(Items.SUGAR_CANE)
-				.addSoil(Blocks.SAND)
+				.addSoil(Tags.Items.SAND)
 				.setTime(560)
 				.setRender(new ClocheRenderReference("stacking", Blocks.SUGAR_CANE))
 				.build(out, toRL("cloche/sugar_cane"));
 		ClocheRecipeBuilder.builder(Items.CACTUS)
 				.addInput(Items.CACTUS)
-				.addSoil(Blocks.SAND)
+				.addSoil(Tags.Items.SAND)
 				.setTime(560)
 				.setRender(new ClocheRenderReference("stacking", Blocks.CACTUS))
 				.build(out, toRL("cloche/cactus"));
@@ -667,9 +667,14 @@ public class Recipes extends RecipeProvider
 				.build(out, toRL("crusher/glass"));
 		CrusherRecipeBuilder.builder(new ItemStack(Items.SAND, 2))
 				.addSecondary(IETags.saltpeterDust, .5f)
-				.addInput(Tags.Items.SANDSTONE)
+				.addInput(IETags.getItemTag(IETags.colorlessSandstoneBlocks))
 				.setEnergy(3200)
 				.build(out, toRL("crusher/sandstone"));
+		CrusherRecipeBuilder.builder(new ItemStack(Items.RED_SAND, 2))
+				.addSecondary(IETags.saltpeterDust, .5f)
+				.addInput(IETags.getItemTag(IETags.redSandstoneBlocks))
+				.setEnergy(3200)
+				.build(out, toRL("crusher/red_sandstone"));
 		CrusherRecipeBuilder.builder(new ItemStack(Items.CLAY_BALL, 4))
 				.addInput(IETags.getItemTag(IETags.clayBlock))
 				.setEnergy(1600)


### PR DESCRIPTION
- allow Cactus and Sugar Cane to use Red Sand as soil in the Cloche
- make Red Sandstones in the Crusher return Red Sand instead of regular one
- changed ClocheRecipeBuilder in the API to also allow Tags as parameter for addSoil