### PR TITLE
[1.6.3] Fixed: crashes when using Wolfpack/Firework Cartridges in a Gun Turret

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/entities/WolfpackShotEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/WolfpackShotEntity.java
@@ -62,7 +62,7 @@ public class WolfpackShotEntity extends RevolvershotHomingEntity
 			Entity hit = ((EntityRayTraceResult)mop).getEntity();
 			if(hit.hurtResistantTime > 0)
 				hit.hurtResistantTime = 0;
-			Entity shooter = field_234609_b_ != null ? world.getPlayerByUuid(field_234609_b_) : null;
+			Entity shooter = field_234609_b_!=null?world.getPlayerByUuid(field_234609_b_): null;
 			hit.attackEntityFrom(IEDamageSources.causeWolfpackDamage(this, shooter),
 					IEServerConfig.TOOLS.bulletDamage_WolfpackPart.get().floatValue());
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/WolfpackShotEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/WolfpackShotEntity.java
@@ -62,7 +62,8 @@ public class WolfpackShotEntity extends RevolvershotHomingEntity
 			Entity hit = ((EntityRayTraceResult)mop).getEntity();
 			if(hit.hurtResistantTime > 0)
 				hit.hurtResistantTime = 0;
-			hit.attackEntityFrom(IEDamageSources.causeWolfpackDamage(this, world.getPlayerByUuid(field_234609_b_)),
+			Entity shooter = field_234609_b_ != null ? world.getPlayerByUuid(field_234609_b_) : null;
+			hit.attackEntityFrom(IEDamageSources.causeWolfpackDamage(this, shooter),
 					IEServerConfig.TOOLS.bulletDamage_WolfpackPart.get().floatValue());
 		}
 		this.remove();

--- a/src/main/java/blusunrize/immersiveengineering/common/items/BulletItem.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/BulletItem.java
@@ -437,7 +437,9 @@ public class BulletItem extends IEBaseItem implements ITextureOverride
 		{
 			ItemStack fireworkStack = new ItemStack(Items.FIREWORK_ROCKET);
 			fireworkStack.setTag(cartridge.hasTag()?cartridge.getTag().copy(): null);
-			FireworkRocketEntity firework = new FireworkRocketEntity(projectile.world, fireworkStack, shooter.getPosX(), shooter.getPosY()+(double)shooter.getEyeHeight()-(double)0.15F, shooter.getPosZ(), true);
+			FireworkRocketEntity firework = shooter != null ?
+					new FireworkRocketEntity(projectile.world, fireworkStack, shooter.getPosX(), shooter.getPosY()+(double)shooter.getEyeHeight()-(double)0.15F, shooter.getPosZ(), true)
+					: new FireworkRocketEntity(projectile.world, fireworkStack, projectile.getPosX(), projectile.getPosY(), projectile.getPosZ(), true);
 			Vector3d vector = projectile.getMotion();
 			firework.shoot(vector.getX(), vector.getY(), vector.getZ(), 1.6f, 1.0f);
 			return firework;

--- a/src/main/java/blusunrize/immersiveengineering/common/items/BulletItem.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/items/BulletItem.java
@@ -437,7 +437,7 @@ public class BulletItem extends IEBaseItem implements ITextureOverride
 		{
 			ItemStack fireworkStack = new ItemStack(Items.FIREWORK_ROCKET);
 			fireworkStack.setTag(cartridge.hasTag()?cartridge.getTag().copy(): null);
-			FireworkRocketEntity firework = shooter != null ?
+			FireworkRocketEntity firework = shooter!=null?
 					new FireworkRocketEntity(projectile.world, fireworkStack, shooter.getPosX(), shooter.getPosY()+(double)shooter.getEyeHeight()-(double)0.15F, shooter.getPosZ(), true)
 					: new FireworkRocketEntity(projectile.world, fireworkStack, projectile.getPosX(), projectile.getPosY(), projectile.getPosZ(), true);
 			Vector3d vector = projectile.getMotion();


### PR DESCRIPTION
I filed #4389 but figured that if I can find the root cause (shooter==null) I should be able to fix it, too.
When testing I found another bug with a similar cause that I also fixed.
I tested the revolver and the gun turret with all kinds of cartridges and there were no crashes after this fix.
Other things I found: Fireworks are OP against flocks of slimes; slow moving/gravity affected projectiles are not aimed properly.

PS: I didn't have the testing/development capacity + git-knowledge to easily adjust the code for lower Minecraft versions. So one can consider this a bit incomplete.