### PR TITLE
Cap maximum furnace burn time of creosote containing items to one bucket's worth

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
@@ -72,6 +72,7 @@ import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fml.network.PacketDistributor;
 import org.apache.commons.lang3.tuple.Pair;
@@ -385,7 +386,7 @@ public class EventHandler
 		if(Utils.isFluidRelatedItemStack(event.getItemStack()))
 			FluidUtil.getFluidContained(event.getItemStack()).ifPresent(fs -> {
 				if(!fs.isEmpty()&&lazy_creosote_tag.get().contains(fs.getFluid()))
-					event.setBurnTime((int)(0.8*fs.getAmount()));
+					event.setBurnTime((int)(0.8*Math.min(fs.getAmount(), FluidAttributes.BUCKET_VOLUME)));
 			});
 	}
 }


### PR DESCRIPTION
When a FurnaceFuelBurnTimeEvent resolves its item's contained fluid amount is reduced by up to one bucket so the calculation for the creosote burn time needs to reflect that.