### PR TITLE
Move Recipe Caching to LOWEST priority

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/ImmersiveEngineering.java
+++ b/src/main/java/blusunrize/immersiveengineering/ImmersiveEngineering.java
@@ -24,6 +24,7 @@ import blusunrize.immersiveengineering.common.config.IEClientConfig;
 import blusunrize.immersiveengineering.common.config.IECommonConfig;
 import blusunrize.immersiveengineering.common.config.IEServerConfig;
 import blusunrize.immersiveengineering.common.crafting.IngredientSerializers;
+import blusunrize.immersiveengineering.common.crafting.RecipeCachingReloadListener;
 import blusunrize.immersiveengineering.common.crafting.RecipeReloadListener;
 import blusunrize.immersiveengineering.common.items.*;
 import blusunrize.immersiveengineering.common.items.IEItems.Misc;
@@ -51,6 +52,7 @@ import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -100,6 +102,7 @@ public class ImmersiveEngineering
 		MinecraftForge.EVENT_BUS.addListener(this::serverStarting);
 		MinecraftForge.EVENT_BUS.addListener(this::registerCommands);
 		MinecraftForge.EVENT_BUS.addListener(this::addReloadListeners);
+		MinecraftForge.EVENT_BUS.addListener(EventPriority.LOWEST, this::addReloadListenersLowest);
 		MinecraftForge.EVENT_BUS.addListener(this::serverStarted);
 		RecipeSerializers.RECIPE_SERIALIZERS.register(FMLJavaModLoadingContext.get().getModEventBus());
 		Villages.Registers.POINTS_OF_INTEREST.register(FMLJavaModLoadingContext.get().getModEventBus());
@@ -259,6 +262,11 @@ public class ImmersiveEngineering
 	{
 		DataPackRegistries dataPackRegistries = event.getDataPackRegistries();
 		event.addListener(new RecipeReloadListener(dataPackRegistries));
+	}
+
+	public void addReloadListenersLowest(AddReloadListenerEvent event)
+	{
+		event.addListener(new RecipeCachingReloadListener(event.getDataPackRegistries()));
 	}
 
 	public void serverStarted(FMLServerStartedEvent event)

--- a/src/main/java/blusunrize/immersiveengineering/common/crafting/RecipeCachingReloadListener.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/crafting/RecipeCachingReloadListener.java
@@ -1,0 +1,23 @@
+package blusunrize.immersiveengineering.common.crafting;
+
+import net.minecraft.resources.DataPackRegistries;
+import net.minecraft.resources.IResourceManager;
+import net.minecraft.resources.IResourceManagerReloadListener;
+
+import javax.annotation.Nonnull;
+
+public class RecipeCachingReloadListener implements IResourceManagerReloadListener
+{
+	private final DataPackRegistries dataPackRegistries;
+
+	public RecipeCachingReloadListener(DataPackRegistries dataPackRegistries)
+	{
+		this.dataPackRegistries = dataPackRegistries;
+	}
+
+	@Override
+	public void onResourceManagerReload(@Nonnull IResourceManager resourceManager)
+	{
+		RecipeReloadListener.buildRecipeLists(dataPackRegistries.getRecipeManager());
+	}
+}

--- a/src/main/java/blusunrize/immersiveengineering/common/crafting/RecipeCachingReloadListener.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/crafting/RecipeCachingReloadListener.java
@@ -1,3 +1,12 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2020
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ *
+ */
+
 package blusunrize.immersiveengineering.common.crafting;
 
 import net.minecraft.resources.DataPackRegistries;

--- a/src/main/java/blusunrize/immersiveengineering/common/crafting/RecipeReloadListener.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/crafting/RecipeReloadListener.java
@@ -34,6 +34,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.network.PacketDistributor;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -52,13 +53,12 @@ public class RecipeReloadListener implements IResourceManagerReloadListener
 	}
 
 	@Override
-	public void onResourceManagerReload(IResourceManager resourceManager)
+	public void onResourceManagerReload(@Nonnull IResourceManager resourceManager)
 	{
 		if(dataPackRegistries!=null)
 		{
 			RecipeManager recipeManager = dataPackRegistries.getRecipeManager();
 			startArcRecyclingRecipeGen(recipeManager);
-			buildRecipeLists(recipeManager);
 			MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
 			if(server!=null)
 			{
@@ -93,7 +93,7 @@ public class RecipeReloadListener implements IResourceManagerReloadListener
 			buildRecipeLists(clientRecipeManager);
 	}
 
-	static void buildRecipeLists(RecipeManager recipeManager)
+	public static void buildRecipeLists(RecipeManager recipeManager)
 	{
 		Collection<IRecipe<?>> recipes = recipeManager.getRecipes();
 		// Empty recipe list shouldn't happen, but has been known to be caused by other mods


### PR DESCRIPTION
This allows CraftTweaker's addJSONRecipe to work until CraftTweaker compat is ready.

Fixes: #4233 