### PR TITLE
Update CraftTweaker examples and add Mineral Mix support

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/CrafttweakerEventHandlers.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/CrafttweakerEventHandlers.java
@@ -47,6 +47,7 @@ public class CrafttweakerEventHandlers
 		addExampleFile(event, "crusher");
 		addExampleFile(event, "fermenter");
 		addExampleFile(event, "metal_press");
+		addExampleFile(event, "mineral_mix");
 		addExampleFile(event, "mixer");
 		addExampleFile(event, "refinery");
 		addExampleFile(event, "sawmill");

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ClocheFertilizerManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ClocheFertilizerManager.java
@@ -44,16 +44,16 @@ public class ClocheFertilizerManager implements IRecipeManager
 	 *
 	 * @param recipePath      The recipe name, without the resource location
 	 * @param fertilizer      The fertilizer to be added
-	 * @param fertilizerValue The value this fertilizer gives in the garden cloche
+	 * @param growthModifier The value this fertilizer gives in the garden cloche
 	 * @docParam recipePath "sulfur_grow"
 	 * @docParam fertilizer <tag:forge:dusts/sulfur>
 	 * @docParam fertilizerValue 6.0F
 	 */
 	@ZenCodeType.Method
-	public void addFertilizer(String recipePath, IIngredient fertilizer, float fertilizerValue)
+	public void addFertilizer(String recipePath, IIngredient fertilizer, float growthModifier)
 	{
 		final ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", recipePath);
-		final ClocheFertilizer recipe = new ClocheFertilizer(resourceLocation, fertilizer.asVanillaIngredient(), fertilizerValue);
+		final ClocheFertilizer recipe = new ClocheFertilizer(resourceLocation, fertilizer.asVanillaIngredient(), growthModifier);
 		CraftTweakerAPI.apply(new ActionAddRecipeCustomOutput(this, recipe, fertilizer));
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/MineralMixManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/MineralMixManager.java
@@ -12,6 +12,7 @@ import blusunrize.immersiveengineering.api.excavator.MineralMix;
 import blusunrize.immersiveengineering.common.util.compat.crafttweaker.CrTIngredientUtil;
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.item.IItemStack;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
 import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
@@ -71,5 +72,11 @@ public class MineralMixManager implements IRecipeManager
 		final List<RegistryKey<World>> dimensionKeys = Arrays.stream(dimensions).map(resourceLocation1 -> RegistryKey.getOrCreateKey(Registry.WORLD_KEY, resourceLocation1)).collect(Collectors.toList());
 		final MineralMix mix = new MineralMix(resourceLocation, stacksWithChances, weight, failChance, dimensionKeys, background);
 		CraftTweakerAPI.apply(new ActionAddRecipe(this, mix, null));
+	}
+
+	@Override
+	public void removeRecipe(IItemStack output)
+	{
+		throw new UnsupportedOperationException("Mineral Mixes can only be removed by name, not by output!");
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/MineralMixManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/MineralMixManager.java
@@ -1,0 +1,75 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2021
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+package blusunrize.immersiveengineering.common.util.compat.crafttweaker.managers;
+
+import blusunrize.immersiveengineering.api.crafting.StackWithChance;
+import blusunrize.immersiveengineering.api.excavator.MineralMix;
+import blusunrize.immersiveengineering.common.util.compat.crafttweaker.CrTIngredientUtil;
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.api.annotations.ZenRegister;
+import com.blamejared.crafttweaker.api.managers.IRecipeManager;
+import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
+import com.blamejared.crafttweaker.impl.item.MCWeightedItemStack;
+import com.blamejared.crafttweaker_annotations.annotations.Document;
+import net.minecraft.block.Block;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.World;
+import org.openzen.zencode.java.ZenCodeType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Allows you to add or remove Mineral Mix recipes.
+ * <p>
+ * Mineral Mixes consist of a list of weighted itemstack outputs, a weight for how often the mix is selected, a change of how often the mix should fail, a list of dimensions that the mix can be excavated in and a background used in the gui.
+ *
+ * @docParam this <recipetype:immersiveengineering:mineral_mix>
+ */
+@ZenRegister
+@Document("mods/immersiveengineering/MineralMix")
+@ZenCodeType.Name("mods.immersiveengineering.MineralMix")
+public class MineralMixManager implements IRecipeManager
+{
+
+	@Override
+	public IRecipeType<MineralMix> getRecipeType()
+	{
+		return MineralMix.TYPE;
+	}
+
+	/**
+	 * Adds a Mineral Mix recipe
+	 *
+	 * @param recipePath The recipe name, without the resource location
+	 * @param outputs    The WeightedItemStack array outputs
+	 * @param weight     How often should the Mix be exavated.
+	 * @param failChance The chance for the Mix to fail excavation.
+	 * @param dimensions The list of dimensions that this Mix can be mined in.
+	 * @param background The background block used in samples
+	 * @docParam recipePath "sheep_mix"
+	 * @docParam outputs [<item:minecraft:white_wool> % 50, <item:minecraft:orange_wool> % 25, <item:minecraft:magenta_wool>]
+	 * @docParam weight 50
+	 * @docParam failChance 0.5
+	 * @docParam dimensions [<resource:minecraft:overworld>]
+	 * @docParam background <block:minecraft:white_wool>
+	 */
+	@ZenCodeType.Method
+	public void addRecipe(String recipePath, MCWeightedItemStack[] outputs, int weight, float failChance, ResourceLocation[] dimensions, Block background)
+	{
+		final ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", recipePath);
+		final StackWithChance[] stacksWithChances = Arrays.stream(outputs).map(CrTIngredientUtil::getStackWithChance).toArray(StackWithChance[]::new);
+		final List<RegistryKey<World>> dimensionKeys = Arrays.stream(dimensions).map(resourceLocation1 -> RegistryKey.getOrCreateKey(Registry.WORLD_KEY, resourceLocation1)).collect(Collectors.toList());
+		final MineralMix mix = new MineralMix(resourceLocation, stacksWithChances, weight, failChance, dimensionKeys, background);
+		CraftTweakerAPI.apply(new ActionAddRecipe(this, mix, null));
+	}
+}

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/alloy.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/alloy.zs
@@ -2,7 +2,7 @@
  * Adds a new recipe to the Alloy Kiln
  */
 
-//<recipetype:immersiveengineering:alloy>.addRecipe(recipePath as string, inputA as IIngredient, inputB as IIngredient, time as int, output as IItemStack)
+//<recipetype:immersiveengineering:alloy>.addRecipe(recipePath as string, inputA as IIngredientWithAmount, inputB as IIngredientWithAmount, time as int, output as IItemStack)
 <recipetype:immersiveengineering:alloy>.addRecipe("spin_iron_to_gold", <item:minecraft:iron_ingot> * 10, <tag:items:minecraft:wool>, 200, <item:minecraft:gold_ingot> * 2);
 
 /*

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/arc_furnace.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/arc_furnace.zs
@@ -2,7 +2,7 @@
  * Adds a new recipe to the Arc furnace
  */
 
-//<recipetype:immersiveengineering:arc_furnace>.addRecipe(recipePath as string, mainIngredient as IIngredient, additives as IIngredient[], time as int, energy as int, outputs as IItemStack[], slag as IItemStack = <item:minecraft:air>) as void
+//<recipetype:immersiveengineering:arc_furnace>.addRecipe(recipePath as string, mainIngredient as IIngredientWithAmount, additives as IIngredientWithAmount[], time as int, energy as int, outputs as IItemStack[], slag as IItemStack = <item:minecraft:air>) as void
 <recipetype:immersiveengineering:arc_furnace>.addRecipe("coal_to_bedrock", <item:minecraft:coal_block> * 2, [<item:minecraft:diamond> * 1, <tag:items:minecraft:wool>], 2000, 100000, [<item:minecraft:bedrock>], <item:minecraft:gold_nugget>);
 
 /*
@@ -13,6 +13,6 @@
  * Cannot remove Recycling Recipes!
  */
 
-//<recipetype:immersiveengineering:arc_furnace>.removeRecipe(output as IItemStack, true as bool = false);
+//<recipetype:immersiveengineering:arc_furnace>.removeRecipe(output as IItemStack, checkSlag as bool = false);
 <recipetype:immersiveengineering:arc_furnace>.removeRecipe(<item:immersiveengineering:slag>, true);
 <recipetype:immersiveengineering:arc_furnace>.removeRecipe(<item:minecraft:iron_ingot> * 3);

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/blast_furnace.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/blast_furnace.zs
@@ -17,5 +17,5 @@
  * Adds a new recipe to the blast furnace.
  * The slag item is optional and will be set to air if not provided
  */
-//<recipetype:immersiveengineering:blast_furnace>.addRecipe(recipePath as string, ingredient as IIngredient, time as int, output as IItemStack, slag as IItemStack = <item:minecraft:air>)
+//<recipetype:immersiveengineering:blast_furnace>.addRecipe(recipePath as string, ingredient as IIngredientWithAmount, time as int, output as IItemStack, slag as IItemStack = <item:minecraft:air>)
 <recipetype:immersiveengineering:blast_furnace>.addRecipe("wool_to_charcoal", <tag:items:minecraft:wool>, 1000, <item:minecraft:charcoal>, <item:minecraft:string>);

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/blueprint.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/blueprint.zs
@@ -2,15 +2,11 @@
  * Adds a new blueprint recipe.
  * The recipe category must already exist. It is currently not possible to add new blueprint categories.
  *
- * TODO: Remove once that issue is fixed: https://github.com/BluSunrize/ImmersiveEngineering/issues/4556 
- * Some recipe outputs may cause the game to get stuck, when putting the blueprint in the workbench.
- * For that reason, try to stick with items (not blocks) for now.
  */
-//<recipetype:immersiveengineering:blueprint>.addRecipe(name as string, blueprintCategory as string, inputs as IIngredient[], output as IItemStack)
+//<recipetype:immersiveengineering:blueprint>.addRecipe(name as string, blueprintCategory as string, inputs as IIngredientWithAmount[], output as IItemStack)
 <recipetype:immersiveengineering:blueprint>.addRecipe("test_gaps", "bullet", [<item:minecraft:redstone>, <tag:items:forge:gems>], <item:minecraft:iron_sword>);
 
-//TODO: Will currently lock the game, since it cannot render the block, remove once fixed
-//<recipetype:immersiveengineering:blueprint>.addRecipe("some_test", "bullet", [<item:minecraft:bedrock>], <item:minecraft:iron_block>);
+<recipetype:immersiveengineering:blueprint>.addRecipe("some_test", "bullet", [<item:minecraft:bedrock>], <item:minecraft:iron_block>);
 
 //Will not work, because the category "unknown_category" does not exist
 //<recipetype:immersiveengineering:blueprint>.addRecipe("unknown_category_test", "unknown_category", [<item:minecraft:iron_nugget> * 10], <item:minecraft:iron_sword>);

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/cloche.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/cloche.zs
@@ -1,7 +1,7 @@
 /*
  * Adds a fertilizer to the garden Cloche
  */
-//<recipetype:immersiveengineering:fertilizer>.addFertilizer(name as string, fertilizer as IIngredient, value as float);
+//<recipetype:immersiveengineering:fertilizer>.addFertilizer(name as string, fertilizer as IIngredient, growthModifier as float);
 <recipetype:immersiveengineering:fertilizer>.addFertilizer("sulfur_grow", <tag:items:forge:dusts/sulfur>, 6.0F);
 
 

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/coke_oven.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/coke_oven.zs
@@ -1,12 +1,12 @@
 /*
- * Adds a new fuel to the coke oven.
+ * Adds a new recipe to the coke oven.
  * The creosoteProduced argument can be left out and will default to 0mB
  */
-//<recipetype:immersiveengineering:coke_oven>.addRecipe(recipePath as string, ingredient as IIngredient, time as int, output as IItemStack, creosoteProduced as int = 0)
+//<recipetype:immersiveengineering:coke_oven>.addRecipe(recipePath as string, ingredient as IIngredientWithAmount, time as int, output as IItemStack, creosoteProduced as int = 0)
 <recipetype:immersiveengineering:coke_oven>.addRecipe("burn_a_stick", <item:minecraft:stick>, 100, <item:immersiveengineering:stick_treated>, 1);
 
 /*
- * Removes a fuel from the coke oven
+ * Removes a recipe from the coke oven
  */
  //<recipetype:immersiveengineering:coke_oven>.removeRecipe(fuel as IItemStack)
 <recipetype:immersiveengineering:coke_oven>.removeRecipe(<item:immersiveengineering:coal_coke>);

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/fermenter.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/fermenter.zs
@@ -2,11 +2,11 @@
  * Adds a recipe to the fermenter.
  * You can provide itemOutput, fluidOutput, or both.
  */
-//<recipetype:immersiveengineering:fermenter>.addRecipe(name as string, input as IIngredient, energy as int, fluidOutput as IFluidStack)
+//<recipetype:immersiveengineering:fermenter>.addRecipe(name as string, input as IIngredientWithAmount, energy as int, fluidOutput as IFluidStack)
 <recipetype:immersiveengineering:fermenter>.addRecipe("fermenter_extract_water", <item:minecraft:wooden_hoe>, 1000, <fluid:minecraft:water> * 100);
-//<recipetype:immersiveengineering:fermenter>.addRecipe(name as string, input as IIngredient, energy as int, itemOutput as IItemStack)
+//<recipetype:immersiveengineering:fermenter>.addRecipe(name as string, input as IIngredientWithAmount, energy as int, itemOutput as IItemStack)
 <recipetype:immersiveengineering:fermenter>.addRecipe("fermenter_upgrade_hoe", <item:minecraft:wooden_shovel>, 1000, <item:minecraft:stone_shovel>);
-//<recipetype:immersiveengineering:fermenter>.addRecipe(name as string, input as IIngredient, energy as int, itemOutput as IItemStack, fluidOutput as IFluidStack)
+//<recipetype:immersiveengineering:fermenter>.addRecipe(name as string, input as IIngredientWithAmount, energy as int, itemOutput as IItemStack, fluidOutput as IFluidStack)
 <recipetype:immersiveengineering:fermenter>.addRecipe("fermenter_upgrade_sword", <item:minecraft:wooden_sword>, 1000, <item:minecraft:stone_sword>, <fluid:minecraft:water> * 100);
 
 /*

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/metal_press.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/metal_press.zs
@@ -1,8 +1,8 @@
 /*
  * Adds a recipe to the metal press
  */
-//<recipetype:immersiveengineering:metal_press>.addRecipe(recipePath as String, input as IIngredient, mold as IItemStack, energy as int, output as IItemStack)
-<recipetype:immersiveengineering:metal_press>.addRecipe("copy_manual", <item:minecraft:white_wool> * 61, <item:immersiveengineering:manual>, 1000, <item:immersiveengineering:manual>);
+//<recipetype:immersiveengineering:metal_press>.addRecipe(recipePath as string, input as IIngredientWithAmount, mold as IItemStack, energy as int, output as IItemStack)
+<recipetype:immersiveengineering:metal_press>.addRecipe("copy_manual", <item:minecraft:paper>, <item:immersiveengineering:manual>, 1000, <item:immersiveengineering:manual>);
 
 /*
  * Removes recipes from the Metal Press based on output

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/mineral_mix.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/mineral_mix.zs
@@ -1,0 +1,13 @@
+/*
+ * Adds a new mix to the Mineral Mixes
+ */
+
+//<recipetype:immersiveengineering:mineral_mix>.addRecipe(String recipePath, MCWeightedItemStack[] outputs, int weight, float failChance, ResourceLocation[] dimensions, Block background)
+<recipetype:immersiveengineering:mineral_mix>.addRecipe("sheep_mix", [<item:minecraft:white_wool> % 50, <item:minecraft:orange_wool> % 25, <item:minecraft:magenta_wool>], 50, 0.5, [<resource:minecraft:overworld>], <block:minecraft:white_wool>);
+
+/*
+ * Removes a mix from the Mineral Mixes based on it's name
+ */
+
+//<recipetype:immersiveengineering:mineral_mix>.removeByName(name as String)
+<recipetype:immersiveengineering:mineral_mix>.removeByName("immersiveengineering:mineral/ancient_debris");

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/mixer.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/mixer.zs
@@ -4,7 +4,7 @@
  * Mixer recipes will always convert 1mB of the input fluid to 1mB of the output fluid.
  * The `amount` parameter specifies for how many mB the given ingredients last
  */
-//<recipetype:immersiveengineering:mixer>.addRecipe(recipePath as String, fluidInput as MCTag<MCFluid>, IIngredientinputItems as [], energy as int, output as MCFluid, amount as int)
+//<recipetype:immersiveengineering:mixer>.addRecipe(recipePath as string, fluidInput as MCTag<MCFluid>, inputItems as IIngredientWithAmount[], energy as int, output as MCFluid, amount as int)
 <recipetype:immersiveengineering:mixer>.addRecipe("grow_creosote_oil", <tag:fluids:minecraft:water>, [<item:minecraft:oak_sapling>, <item:minecraft:bone_meal> * 4, <item:immersiveengineering:creosote_bucket>], 5000, <fluid:immersiveengineering:creosote>, 8000);
 
 

--- a/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/squeezer.zs
+++ b/src/main/resources/data/immersiveengineering/scripts/immersiveengineering/squeezer.zs
@@ -3,13 +3,13 @@
  * Squeezer recipes can return an item output, a fluid output or both
  */
 
-//<recipetype:immersiveengineering:squeezer>.addRecipe(recipePath as string, input as IIngredient, energy as int, itemOutput as IItemStack)
+//<recipetype:immersiveengineering:squeezer>.addRecipe(recipePath as string, input as IIngredientWithAmount, energy as int, itemOutput as IItemStack)
 <recipetype:immersiveengineering:squeezer>.addRecipe("slag_off", <item:immersiveengineering:slag> * 9, 5000, <item:minecraft:dirt>);
 
-//<recipetype:immersiveengineering:squeezer>.addRecipe(recipePath as string, input as IIngredient, energy as int, fluidOutput as IFluidStack)
+//<recipetype:immersiveengineering:squeezer>.addRecipe(recipePath as string, input as IIngredientWithAmount, energy as int, fluidOutput as IFluidStack)
 <recipetype:immersiveengineering:squeezer>.addRecipe("the_last_drops", <item:minecraft:coal> * 8, 6000, <fluid:immersiveengineering:creosote> * 250);
 
-//<recipetype:immersiveengineering:squeezer>.addRecipe(recipePath as string, input as IIngredient, energy as int, fluidOutput as IFluidStack, itemOutput as IItemStack)
+//<recipetype:immersiveengineering:squeezer>.addRecipe(recipePath as string, input as IIngredientWithAmount, energy as int, fluidOutput as IFluidStack, itemOutput as IItemStack)
 <recipetype:immersiveengineering:squeezer>.addRecipe("pressure_creates_diamonds", <item:minecraft:coal_block> * 8, 6000, <fluid:immersiveengineering:creosote> * 2500, <item:minecraft:diamond>);
 
 /*


### PR DESCRIPTION
While I was going through and documenting it on the CraftTweaker docs I noticed that some of the examples were slightly outdated (due to the IIngredientWithAmount changes mainly)