### PR TITLE
Workbench stackable upgrades fix

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/gui/IESlot.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/IESlot.java
@@ -237,7 +237,7 @@ public abstract class IESlot extends Slot
 		{
 			if(preventDoubles)
 				for(Slot slot : container.inventorySlots)
-					if(this != slot&&slot instanceof Upgrades&&((Upgrades)slot).preventDoubles&&ItemStack.areItemsEqual(slot.getStack(), itemStack))
+					if(this!=slot&&slot instanceof Upgrades&&ItemStack.areItemsEqual(slot.getStack(), itemStack))
 						return false;
 			return !itemStack.isEmpty()&&itemStack.getItem() instanceof IUpgrade&&((IUpgrade)itemStack.getItem()).getUpgradeTypes(itemStack).contains(type)&&((IUpgrade)itemStack.getItem()).canApplyUpgrades(upgradeableTool, itemStack);
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/IESlot.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/IESlot.java
@@ -237,7 +237,7 @@ public abstract class IESlot extends Slot
 		{
 			if(preventDoubles)
 				for(Slot slot : container.inventorySlots)
-					if(slot instanceof Upgrades&&((Upgrades)slot).preventDoubles&&ItemStack.areItemsEqual(slot.getStack(), itemStack))
+					if(this != slot&&slot instanceof Upgrades&&((Upgrades)slot).preventDoubles&&ItemStack.areItemsEqual(slot.getStack(), itemStack))
 						return false;
 			return !itemStack.isEmpty()&&itemStack.getItem() instanceof IUpgrade&&((IUpgrade)itemStack.getItem()).getUpgradeTypes(itemStack).contains(type)&&((IUpgrade)itemStack.getItem()).canApplyUpgrades(upgradeableTool, itemStack);
 		}

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/ModWorkbenchContainer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/ModWorkbenchContainer.java
@@ -162,8 +162,6 @@ public class ModWorkbenchContainer extends IEBaseContainer<ModWorkbenchTileEntit
 								b = false;
 								break;
 							}
-							else
-								continue;
 					}
 					if(b)
 						return ItemStack.EMPTY;


### PR DESCRIPTION
made slots with a stackable upgrade valid for the same upgrade


effectively allows you to add to a stack of Augers without having to pull it out of the drill's inventory
doesn't currently apply to any other upgrades, so eh

