### PR TITLE
Modifications to the Cloche for more dynamic recipes

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/crafting/ClocheRecipe.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/crafting/ClocheRecipe.java
@@ -56,6 +56,18 @@ public class ClocheRecipe extends IESerializableRecipe
 		this(id, ImmutableList.of(output), seed, soil, time, renderReference);
 	}
 
+	// Allow for more dynamic recipes in subclasses
+	public List<ItemStack> getOutputs(ItemStack seed, ItemStack soil)
+	{
+		return this.outputs;
+	}
+
+	// Allow for more dynamic recipes in subclasses
+	public int getTime(ItemStack seed, ItemStack soil)
+	{
+		return this.time;
+	}
+
 	@Override
 	protected IERecipeSerializer<ClocheRecipe> getIESerializer()
 	{

--- a/src/api/java/blusunrize/immersiveengineering/api/crafting/ClocheRenderFunction.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/crafting/ClocheRenderFunction.java
@@ -32,10 +32,25 @@ public interface ClocheRenderFunction
 
 	Collection<Pair<BlockState, TransformationMatrix>> getBlocks(ItemStack stack, float growth);
 
-	// hook for dynamic cloche recipes
+	/**
+	 * Method to inject quads into the Cloche's plant rendering.
+	 * Any quads passed to the consumer will be included in the plant rendering.
+	 *
+	 *
+	 * Immersive Engineering will not cache any quads injected by this method,
+	 * therefore it is up to the implementation to make sure quads are properly cached.
+	 *
+	 * Additionally, even though this method is only called client side, the containing class exists on both sides.
+	 * As a result, it is imperative that implementations of this method do not contain direct references to client-only
+	 * code.
+	 *
+	 * @param stack the stack containing the seed for which the plant is being rendered
+	 * @param growth the current growth progress of the plant which is being rendered
+	 * @param quadConsumer the consumer to pass quads to
+	 */
 	default void injectQuads(ItemStack stack, float growth, Consumer<?> quadConsumer)
 	{
-		// default behaviour: do nothing
+
 	}
 
 

--- a/src/api/java/blusunrize/immersiveengineering/api/crafting/ClocheRenderFunction.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/crafting/ClocheRenderFunction.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public interface ClocheRenderFunction
@@ -30,6 +31,12 @@ public interface ClocheRenderFunction
 	float getScale(ItemStack seed, float growth);
 
 	Collection<Pair<BlockState, TransformationMatrix>> getBlocks(ItemStack stack, float growth);
+
+	// hook for dynamic cloche recipes
+	default void injectQuads(ItemStack stack, float growth, Consumer<?> quadConsumer)
+	{
+		// default behaviour: do nothing
+	}
 
 
 	/**

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/ClocheRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/ClocheRenderer.java
@@ -93,7 +93,6 @@ public class ClocheRenderer extends TileEntityRenderer<ClocheTileEntity>
 			matrixStack.translate((1-scale)/2, 0, (1-scale)/2);
 			matrixStack.scale(scale, scale, scale);
 
-			//
 			Collection<Pair<BlockState, TransformationMatrix>> blocks = recipe.renderFunction.getBlocks(seed, growth);
 			for(Pair<BlockState, TransformationMatrix> block : blocks)
 			{

--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/ClocheRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/ClocheRenderer.java
@@ -40,6 +40,7 @@ import net.minecraftforge.client.model.data.EmptyModelData;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 public class ClocheRenderer extends TileEntityRenderer<ClocheTileEntity>
 {
@@ -86,11 +87,13 @@ public class ClocheRenderer extends TileEntityRenderer<ClocheTileEntity>
 
 			NonNullList<ItemStack> inventory = tile.getInventory();
 			ItemStack seed = inventory.get(ClocheTileEntity.SLOT_SEED);
-			float growth = MathHelper.clamp(tile.renderGrowth/recipe.time, 0, 1);
+			ItemStack soil = inventory.get(ClocheTileEntity.SLOT_SOIL);
+			float growth = MathHelper.clamp(tile.renderGrowth/recipe.getTime(seed, soil), 0, 1);
 			float scale = recipe.renderFunction.getScale(seed, growth);
 			matrixStack.translate((1-scale)/2, 0, (1-scale)/2);
 			matrixStack.scale(scale, scale, scale);
 
+			//
 			Collection<Pair<BlockState, TransformationMatrix>> blocks = recipe.renderFunction.getBlocks(seed, growth);
 			for(Pair<BlockState, TransformationMatrix> block : blocks)
 			{
@@ -110,6 +113,17 @@ public class ClocheRenderer extends TileEntityRenderer<ClocheTileEntity>
 						tile.getWorldNonnull(), blockPos, false, col, combinedLightIn);
 				matrixStack.pop();
 			}
+
+			// Injection of quads from dynamic recipes
+			List<BakedQuad> injectedQuadList = new ArrayList<>();
+			Consumer<?> quadInjector = (object) -> {if(object instanceof BakedQuad) injectedQuadList.add((BakedQuad) object);};
+			recipe.renderFunction.injectQuads(seed, growth, quadInjector);
+			if(injectedQuadList.size() > 0)
+			{
+				RenderUtils.renderModelTESRFancy(injectedQuadList, new TransformingVertexBuilder(baseBuilder, matrixStack),
+						tile.getWorldNonnull(), blockPos, false, -1, combinedLightIn);
+			}
+
 			matrixStack.pop();
 		}
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/ClocheTileEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/ClocheTileEntity.java
@@ -133,6 +133,7 @@ public class ClocheTileEntity extends IEBaseTileEntity implements ITickableTileE
 		if(dummy!=0||isRSPowered())
 			return;
 		ItemStack seed = inventory.get(SLOT_SEED);
+		ItemStack soil = inventory.get(SLOT_SOIL);
 		if(world.isRemote)
 		{
 			for(Iterator<Particle> iterator = particles.iterator(); iterator.hasNext(); )
@@ -147,7 +148,7 @@ public class ClocheTileEntity extends IEBaseTileEntity implements ITickableTileE
 				ClocheRecipe recipe = getRecipe();
 				if(recipe!=null&&fertilizerAmount > 0)
 				{
-					if(renderGrowth < recipe.time+IEServerConfig.MACHINES.cloche_growth_mod.get()*fertilizerMod)
+					if(renderGrowth < recipe.getTime(seed, soil) + IEServerConfig.MACHINES.cloche_growth_mod.get()*fertilizerMod)
 					{
 						renderGrowth += IEServerConfig.MACHINES.cloche_growth_mod.get()*fertilizerMod;
 						fertilizerAmount--;
@@ -182,9 +183,9 @@ public class ClocheTileEntity extends IEBaseTileEntity implements ITickableTileE
 				if(recipe!=null&&fertilizerAmount > 0&&energyStorage.extractEnergy(consumption, true)==consumption)
 				{
 					boolean consume = false;
-					if(growth >= recipe.time)
+					if(growth >= recipe.getTime(seed, soil))
 					{
-						List<ItemStack> outputs = recipe.outputs;
+						List<ItemStack> outputs = recipe.getOutputs(seed, soil);
 						int canFit = 0;
 						boolean[] emptySlotsUsed = new boolean[4];
 						for(ItemStack output : outputs)


### PR DESCRIPTION
As discussed on Discord, this PR adds two major modifications to the code related to the Garden Cloche.

The first is with regards to the recipe, where two getters have been added: one for time and one for products, these getters are given both the seed and soil as arguments.

The second is with regards to rendering, where a new default method has been added to the ClocheRenderFunction which allows the injection of custom quads. Note that this is up to the implementer to ensure these quads are cached on their side, and that their implementation does not reference client-side code.

Uses for this, specifically for my case, is to allow different behaviour with seeds containing different traits (such as increased produce, increased growth rate and lenience with regards to soil requirements).