### PR TITLE
adds canTakeItemForPickAll overrides to mirror vanilla crafting behavior

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/gui/CraftingTableContainer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/CraftingTableContainer.java
@@ -132,4 +132,9 @@ public class CraftingTableContainer extends IEBaseContainer<CraftingTableBlockEn
 		}
 		return itemstack;
 	}
+
+	@Override
+	public boolean canTakeItemForPickAll(ItemStack pStack, Slot pSlot) {
+		return pSlot.container != this.craftResultInventory && super.canTakeItemForPickAll(pStack, pSlot);
+	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/CraftingTableContainer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/CraftingTableContainer.java
@@ -134,7 +134,8 @@ public class CraftingTableContainer extends IEBaseContainer<CraftingTableBlockEn
 	}
 
 	@Override
-	public boolean canTakeItemForPickAll(ItemStack pStack, Slot pSlot) {
-		return pSlot.container != this.craftResultInventory && super.canTakeItemForPickAll(pStack, pSlot);
+	public boolean canTakeItemForPickAll(ItemStack pStack, Slot pSlot)
+	{
+		return pSlot.container!=this.craftResultInventory&&super.canTakeItemForPickAll(pStack, pSlot);
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/ModWorkbenchContainer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/ModWorkbenchContainer.java
@@ -202,4 +202,9 @@ public class ModWorkbenchContainer extends IEBaseContainer<ModWorkbenchBlockEnti
 		if(!world.isClientSide)
 			broadcastChanges();
 	}
+
+	@Override
+	public boolean canTakeItemForPickAll(ItemStack pStack, Slot pSlot) {
+		return pSlot.container != this.inventoryBPoutput && super.canTakeItemForPickAll(pStack, pSlot);
+	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/ModWorkbenchContainer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/ModWorkbenchContainer.java
@@ -204,7 +204,8 @@ public class ModWorkbenchContainer extends IEBaseContainer<ModWorkbenchBlockEnti
 	}
 
 	@Override
-	public boolean canTakeItemForPickAll(ItemStack pStack, Slot pSlot) {
-		return pSlot.container != this.inventoryBPoutput && super.canTakeItemForPickAll(pStack, pSlot);
+	public boolean canTakeItemForPickAll(ItemStack pStack, Slot pSlot)
+	{
+		return pSlot.container!=this.inventoryBPoutput&&super.canTakeItemForPickAll(pStack, pSlot);
 	}
 }


### PR DESCRIPTION
fixes unintended doubleclick behavior
solves https://github.com/BluSunrize/ImmersiveEngineering/issues/5003