### PR TITLE
fixes metal press not playing sounds, potential for looping sound

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/MetalPressBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/MetalPressBlockEntity.java
@@ -12,6 +12,7 @@ import blusunrize.immersiveengineering.api.crafting.MetalPressRecipe;
 import blusunrize.immersiveengineering.api.tool.conveyor.ConveyorHandler.IConveyorAttachable;
 import blusunrize.immersiveengineering.api.utils.CapabilityReference;
 import blusunrize.immersiveengineering.api.utils.DirectionalBlockPos;
+import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IBlockBounds;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IPlayerInteraction;
 import blusunrize.immersiveengineering.common.blocks.generic.PoweredMultiblockBlockEntity;
@@ -21,6 +22,7 @@ import blusunrize.immersiveengineering.common.util.IESounds;
 import blusunrize.immersiveengineering.common.util.ListUtils;
 import blusunrize.immersiveengineering.common.util.Utils;
 import com.google.common.collect.ImmutableSet;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
@@ -70,19 +72,22 @@ public class MetalPressBlockEntity extends PoweredMultiblockBlockEntity<MetalPre
 	public void tickClient()
 	{
 		super.tickClient();
+		if(isRSDisabled())
+			return;
 		for(MultiblockProcess<?> process : processQueue)
 		{
 			float maxTicks = process.maxTicks;
 			float transportTime = getTransportTime(maxTicks);
 			float pressTime = getPressTime(maxTicks);
 			float fProcess = process.processTick;
+			LocalPlayer localPlayer = ClientUtils.mc().player;
 			//Note: the >= and < check instead of a single == is because fProcess is an int and transportTime and pressTime are floats. Because of that it has to be windowed
 			if(fProcess >= transportTime&&fProcess < transportTime+1f)
-				level.playSound(null, getBlockPos(), IESounds.metalpress_piston, SoundSource.BLOCKS, .3F, 1);
+				level.playSound(localPlayer, getBlockPos(), IESounds.metalpress_piston, SoundSource.BLOCKS, .3F, 1);
 			if(fProcess >= (transportTime+pressTime)&&fProcess < (transportTime+pressTime+1f))
-				level.playSound(null, getBlockPos(), IESounds.metalpress_smash, SoundSource.BLOCKS, .3F, 1);
+				level.playSound(localPlayer, getBlockPos(), IESounds.metalpress_smash, SoundSource.BLOCKS, .3F, 1);
 			if(fProcess >= (maxTicks-transportTime)&&fProcess < (maxTicks-transportTime+1f))
-				level.playSound(null, getBlockPos(), IESounds.metalpress_piston, SoundSource.BLOCKS, .3F, 1);
+				level.playSound(localPlayer, getBlockPos(), IESounds.metalpress_piston, SoundSource.BLOCKS, .3F, 1);
 		}
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/MetalPressBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/MetalPressBlockEntity.java
@@ -8,11 +8,11 @@
 
 package blusunrize.immersiveengineering.common.blocks.metal;
 
+import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.crafting.MetalPressRecipe;
 import blusunrize.immersiveengineering.api.tool.conveyor.ConveyorHandler.IConveyorAttachable;
 import blusunrize.immersiveengineering.api.utils.CapabilityReference;
 import blusunrize.immersiveengineering.api.utils.DirectionalBlockPos;
-import blusunrize.immersiveengineering.client.ClientUtils;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IBlockBounds;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IPlayerInteraction;
 import blusunrize.immersiveengineering.common.blocks.generic.PoweredMultiblockBlockEntity;
@@ -22,7 +22,6 @@ import blusunrize.immersiveengineering.common.util.IESounds;
 import blusunrize.immersiveengineering.common.util.ListUtils;
 import blusunrize.immersiveengineering.common.util.Utils;
 import com.google.common.collect.ImmutableSet;
-import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
@@ -80,7 +79,7 @@ public class MetalPressBlockEntity extends PoweredMultiblockBlockEntity<MetalPre
 			float transportTime = getTransportTime(maxTicks);
 			float pressTime = getPressTime(maxTicks);
 			float fProcess = process.processTick;
-			LocalPlayer localPlayer = ClientUtils.mc().player;
+			Player localPlayer = ImmersiveEngineering.proxy.getClientPlayer();
 			//Note: the >= and < check instead of a single == is because fProcess is an int and transportTime and pressTime are floats. Because of that it has to be windowed
 			if(fProcess >= transportTime&&fProcess < transportTime+1f)
 				level.playSound(localPlayer, getBlockPos(), IESounds.metalpress_piston, SoundSource.BLOCKS, .3F, 1);


### PR DESCRIPTION
fixes metal press not playing sounds
re-added redstone check to prevent possibility of sound looping 20 times a second by toggling on redstone on a tick a sound is played
fixes https://github.com/BluSunrize/ImmersiveEngineering/issues/5027

(client side `playSound` needs to pass the client's `Player` entity instead of `null`. Interestingly sound only played before, because the code also ran on the server and broadcasted the sound, making the client play it. I learned something, I suppose, and maybe someone reading this, does, too \^\^)

side notes:

Sound is not broadcasted by the server side `playSound` anymore, which I suppose is the whole reason of putting it into the client side tick in the first place. Nothing I learned in the last 2 hours says, this should be bad in some way, but I'm eyeing it a bit critically.

Also, I was not sure if I should have added `@OnlyIn(Dist.CLIENT)` here, because the function uses LocalPlayer now but it didn't burn without it, so..

My point is, look it over if you have the time