### PR TITLE
Globally sync Water Wheel rotation

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
@@ -127,8 +127,6 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 
 	private void setPerTickAndAdvance(double newValue)
 	{
-		if(isDummy())
-			return;
 		if(newValue!=perTick)
 		{
 			globalSyncDelayCounter = globalSyncDelay;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
@@ -48,13 +48,14 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 	public boolean multiblock = false;
 	private boolean beingBroken = false;
 	public double perTick;
+	private double catchupSpeed;
 	private final CapabilityReference<IRotationAcceptor> outputCap = CapabilityReference.forNeighbor(
 			this, IRotationAcceptor.CAPABILITY, () -> getFacing().getOpposite()
 	);
 	private final CapabilityReference<IRotationAcceptor> reverseOutputCap = CapabilityReference.forNeighbor(
 			this, IRotationAcceptor.CAPABILITY, this::getFacing
 	);
-	private static final int globalSyncDelay = 20*20;
+	private static final int globalSyncDelay = 10*20;
 	private int globalSyncDelayCounter = 1;
 
 	public WatermillBlockEntity(BlockEntityType<WatermillBlockEntity> type, BlockPos pos, BlockState state)
@@ -65,7 +66,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 	@Override
 	public void tickClient()
 	{
-		rotation += perTick;
+		rotation += perTick+catchupSpeed;
 		rotation %= 1;
 	}
 
@@ -133,21 +134,38 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 			perTick = newValue;
 			markContainingBlockForUpdate(null);
 		}
-		else if(globalSyncDelayCounter >= 0)
+		else if(globalSyncDelayCounter > 0)
 			globalSyncDelayCounter--;
 
 		if(globalSyncDelayCounter==0)
 		{
 			float newrot = (float)(level.getGameTime()*perTick);
-			if(rotation!=newrot)
+			if(Math.abs((newrot%.125)-(rotation%.125)) < perTick)
 			{
-				rotation = newrot;
-				//update so changing perTick client side a second time AFTER globalSyncDelayCounter went to zero once does not jank from the markContainingBlockForUpdate above
+				rotation = (float)(newrot-perTick);
+				catchupSpeed = 0;
+				globalSyncDelayCounter--;
 				markContainingBlockForUpdate(null);
 			}
+			else
+			{
+				double oldCatchupSpeed = catchupSpeed;
+				catchupSpeed = perTick/8 < 0.0002?perTick/8: 0.0002;
+				if(oldCatchupSpeed!=catchupSpeed)
+					markContainingBlockForUpdate(null);
+			}
+
+//				rotation += perTick+(perTick/2 < 0.002?perTick/2: 0.002);
+
+//			if(rotation!=newrot)
+//			{
+//				rotation = newrot;
+//				//update so changing perTick client side a second time AFTER globalSyncDelayCounter went to zero once does not jank from the markContainingBlockForUpdate above
+//				markContainingBlockForUpdate(null);
+//			}
 		}
-		else
-			rotation += perTick;
+//		else
+		rotation += perTick+catchupSpeed;
 		rotation %= 1;
 	}
 
@@ -252,6 +270,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 		offset = nbt.getIntArray("offset");
 		rotation = nbt.getFloat("rotation");
 		perTick = nbt.getDouble("perTick");
+		catchupSpeed = nbt.getDouble("catchupSpeed");
 
 		if(offset==null||offset.length < 2)
 			offset = new int[]{0, 0};
@@ -263,6 +282,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 		nbt.putIntArray("offset", offset);
 		nbt.putFloat("rotation", rotation);
 		nbt.putDouble("perTick", perTick);
+		nbt.putDouble("catchupSpeed", catchupSpeed);
 	}
 
 	private AABB renderAABB;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
@@ -54,7 +54,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 	private final CapabilityReference<IRotationAcceptor> reverseOutputCap = CapabilityReference.forNeighbor(
 			this, IRotationAcceptor.CAPABILITY, this::getFacing
 	);
-	private static final int globalSyncDelay = 10*20;
+	private static final int globalSyncDelay = 20*20;
 	private int globalSyncDelayCounter = 1;
 
 	public WatermillBlockEntity(BlockEntityType<WatermillBlockEntity> type, BlockPos pos, BlockState state)
@@ -127,6 +127,8 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 
 	private void setPerTickAndAdvance(double newValue)
 	{
+		if(isDummy())
+			return;
 		if(newValue!=perTick)
 		{
 			globalSyncDelayCounter = globalSyncDelay;
@@ -138,7 +140,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 
 		if(globalSyncDelayCounter==0)
 		{
-			float newrot = syncedRot();
+			float newrot = (float)(level.getGameTime()*perTick);
 			if(rotation!=newrot)
 			{
 				rotation = newrot;
@@ -147,7 +149,8 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 			}
 		}
 		else
-			rotation = (float)(rotation+perTick)%1;
+			rotation += perTick;
+		rotation %= 1;
 	}
 
 	private boolean canUse(@Nullable BlockEntity tileEntity)
@@ -358,10 +361,5 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 						level.removeBlock(pos2, false);
 					}
 				}
-	}
-
-	private float syncedRot()
-	{
-		return ((float)(level.getGameTime()*perTick))%1;
 	}
 }


### PR DESCRIPTION
synchronizes all waterwheels that are going at the same speed by setting their `rotation` to `level.getGameTime()*perTick % 1`

changing `perTick` by changing the waterflow starts a grace period where the rotation is not synced to the game time so players still perceive smooth transitions in waterwheel speed/rotation instead of janky jumping of the wheel. after the grace period the wheel makes a single jump, hopefully when noone is looking anymore.