### PR TITLE
Water wheel linking fix

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/energy/IRotationAcceptor.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/energy/IRotationAcceptor.java
@@ -15,4 +15,6 @@ import javax.annotation.Nonnull;
 public interface IRotationAcceptor
 {
 	void inputRotation(double rotation, @Nonnull Direction side);
+
+	boolean sideAcceptsRotation(@Nonnull Direction side);
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/DynamoBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/DynamoBlockEntity.java
@@ -42,7 +42,7 @@ public class DynamoBlockEntity extends IEBaseBlockEntity implements IIEInternalF
 	@Override
 	public void inputRotation(double rotation, @Nonnull Direction side)
 	{
-		if(side!=this.getFacing().getOpposite())
+		if(!sideAcceptsRotation(side))
 			return;
 		int output = (int)(IEServerConfig.MACHINES.dynamo_output.get()*rotation);
 		for(Direction fd : DirectionUtils.VALUES)
@@ -51,6 +51,12 @@ public class DynamoBlockEntity extends IEBaseBlockEntity implements IIEInternalF
 			BlockEntity te = Utils.getExistingTileEntity(level, outputPos);
 			output -= EnergyHelper.insertFlux(te, fd.getOpposite(), output, false);
 		}
+	}
+
+	@Override
+	public boolean sideAcceptsRotation(@Nonnull Direction side)
+	{
+		return side==this.getFacing().getOpposite();
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
@@ -68,7 +68,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IETickabl
 		if(isBlocked())//TODO throttle?
 		{
 			setPerTickAndAdvance(0);
-			if(linkElementNumber >0)
+			if(linkElementNumber > 0)
 				dissolveLink();
 			return;
 		}
@@ -82,7 +82,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IETickabl
 		BlockEntity acc = SafeChunkUtils.getSafeBE(level, getBlockPos().relative(getFacing().getOpposite()));
 		boolean hasRotAcceptor = false;
 		Triple<Boolean, List<WatermillBlockEntity>, Double> linkedWheels = null;
-		if(acc instanceof IRotationAcceptor rotAcc && rotAcc.sideAcceptsRotation(getFacing().getOpposite()))
+		if(acc instanceof IRotationAcceptor rotAcc&&rotAcc.sideAcceptsRotation(getFacing().getOpposite()))
 		{
 			linkedWheels = searchAndSetLink((byte)1, getFacing()); //linkedWheels.a is always gonna be true at this point
 			hasRotAcceptor = true;
@@ -90,7 +90,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IETickabl
 		else if(linkElementNumber==0)
 		{
 			acc = SafeChunkUtils.getSafeBE(level, getBlockPos().relative(getFacing()));
-			if(acc instanceof IRotationAcceptor rotAcc && rotAcc.sideAcceptsRotation(getFacing()))
+			if(acc instanceof IRotationAcceptor rotAcc&&rotAcc.sideAcceptsRotation(getFacing()))
 			{
 				linkedWheels = searchAndSetLink((byte)1, getFacing().getOpposite());
 				hasRotAcceptor = linkedWheels.a; //could be indirectly linked to another RotationAcceptor


### PR DESCRIPTION
makes linking of the up to 3 waterwheels "more deterministic"

IRotationAcceptors can now grab wheels independent of them facing the opposite way
Opposing IRotationAcceptors now don't race anymore to grab wheels for linking, but affiliation is depending on the wheels initial facing
"Slave"-wheels don't reset to non-slaves on tick anymore, only potentially when the blocks in the link get updated

contains an api change, be advised:
IRotationAcceptor now has a method that checks if a side actually accept rotation. Previously wheels would link even if the dynamo was not oriented the correct way

fixes https://github.com/BluSunrize/ImmersiveEngineering/issues/5030
