### PR TITLE
Routers' stack amount fix

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/gui/FluidSorterScreen.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/FluidSorterScreen.java
@@ -55,7 +55,7 @@ public class FluidSorterScreen extends IEContainerScreen<FluidSorterContainer>
 			for(int i = 0; i < 8; i++)
 				if(tile.filters[side][i]!=null&&!tile.filters[side][i].isEmpty())
 					if(getSlotArea(side, i).contains(mouseX, mouseY))
-						FluidInfoArea.fillTooltip(tile.filters[side][i], 0, addLine);
+						FluidInfoArea.fillTooltip(tile.filters[side][i], -1, addLine);
 	}
 
 	@Override
@@ -137,12 +137,16 @@ public class FluidSorterScreen extends IEContainerScreen<FluidSorterContainer>
 
 	public void setFluidInSlot(int side, int slot, FluidStack fluid)
 	{
-		tile.filters[side][slot] = fluid;
 		CompoundTag tag = new CompoundTag();
 		tag.putInt("filter_side", side);
 		tag.putInt("filter_slot", slot);
 		if(fluid!=null)
+		{
+			if(!fluid.isEmpty())
+				fluid.setAmount(1);//normalizes amount, neat, maybe saves space idk
 			tag.put("filter", fluid.writeToNBT(new CompoundTag()));
+		}
+		tile.filters[side][slot] = fluid;
 		ImmersiveEngineering.packetHandler.sendToServer(new MessageBlockEntitySync(tile, tag));
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/client/gui/FluidSorterScreen.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/FluidSorterScreen.java
@@ -65,7 +65,7 @@ public class FluidSorterScreen extends IEContainerScreen<FluidSorterContainer>
 		for(int side = 0; side < 6; side++)
 			for(int i = 0; i < 8; i++)
 			{
-				if(getSlotArea(side, i).contains((int) mouseX, (int) mouseY))
+				if(getSlotArea(side, i).contains((int)mouseX, (int)mouseY))
 				{
 					ItemStack stack = menu.getCarried();
 					if(stack.isEmpty())
@@ -150,7 +150,8 @@ public class FluidSorterScreen extends IEContainerScreen<FluidSorterContainer>
 		ImmersiveEngineering.packetHandler.sendToServer(new MessageBlockEntitySync(tile, tag));
 	}
 
-	protected Rect2i getSlotArea(int side, int i) {
+	protected Rect2i getSlotArea(int side, int i)
+	{
 		int x = leftPos+4+(side/2)*58+(i < 3?i*18: i > 4?(i-5)*18: i==3?0: 36);
 		int y = topPos+22+(side%2)*76+(i < 3?0: i > 4?36: 18);
 		return new Rect2i(x, y, 16, 16);

--- a/src/main/java/blusunrize/immersiveengineering/client/gui/FluidSorterScreen.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/FluidSorterScreen.java
@@ -141,11 +141,7 @@ public class FluidSorterScreen extends IEContainerScreen<FluidSorterContainer>
 		tag.putInt("filter_side", side);
 		tag.putInt("filter_slot", slot);
 		if(fluid!=null)
-		{
-			if(!fluid.isEmpty())
-				fluid.setAmount(1);//normalizes amount, neat, maybe saves space idk
 			tag.put("filter", fluid.writeToNBT(new CompoundTag()));
-		}
 		tile.filters[side][slot] = fluid;
 		ImmersiveEngineering.packetHandler.sendToServer(new MessageBlockEntitySync(tile, tag));
 	}

--- a/src/main/java/blusunrize/immersiveengineering/client/gui/info/FluidInfoArea.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/info/FluidInfoArea.java
@@ -95,8 +95,9 @@ public class FluidInfoArea extends InfoArea
 
 		if(tankCapacity > 0)
 			tooltip.accept(applyFormat(new TextComponent(fluid.getAmount()+"/"+tankCapacity+"mB"), ChatFormatting.GRAY));
-		else
+		else if (tankCapacity == 0)
 			tooltip.accept(applyFormat(new TextComponent(fluid.getAmount()+"mB"), ChatFormatting.GRAY));
+		//don't display amount for tankCapacity < 0, i.e. for ghost fluid stacks
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/client/gui/info/FluidInfoArea.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/info/FluidInfoArea.java
@@ -62,7 +62,8 @@ public class FluidInfoArea extends InfoArea
 		fillTooltip(tank.getFluid(), tank.getCapacity(), tooltip::add);
 	}
 
-	public static void fillTooltip(FluidStack fluid, int tankCapacity, Consumer<Component> tooltip) {
+	public static void fillTooltip(FluidStack fluid, int tankCapacity, Consumer<Component> tooltip)
+	{
 
 		if(!fluid.isEmpty())
 			tooltip.accept(applyFormat(
@@ -95,7 +96,7 @@ public class FluidInfoArea extends InfoArea
 
 		if(tankCapacity > 0)
 			tooltip.accept(applyFormat(new TextComponent(fluid.getAmount()+"/"+tankCapacity+"mB"), ChatFormatting.GRAY));
-		else if (tankCapacity == 0)
+		else if(tankCapacity==0)
 			tooltip.accept(applyFormat(new TextComponent(fluid.getAmount()+"mB"), ChatFormatting.GRAY));
 		//don't display amount for tankCapacity < 0, i.e. for ghost fluid stacks
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/FluidSorterBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/FluidSorterBlockEntity.java
@@ -151,7 +151,10 @@ public class FluidSorterBlockEntity extends IEBaseBlockEntity implements IIntera
 		{
 			int side = message.getInt("filter_side");
 			int slot = message.getInt("filter_slot");
-			this.filters[side][slot] = FluidStack.loadFluidStackFromNBT(message.getCompound("filter"));
+			FluidStack newFilter = FluidStack.loadFluidStackFromNBT(message.getCompound("filter"));
+			if (!newFilter.isEmpty())
+				newFilter.setAmount(1); // Not strictly necessary, but also doesn't hurt
+			this.filters[side][slot] = newFilter;
 		}
 		this.setChanged();
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/SorterBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/SorterBlockEntity.java
@@ -74,7 +74,7 @@ public class SorterBlockEntity extends IEBaseBlockEntity implements IInteraction
 			Direction[][] validOutputs = getValidOutputs(inputSide, stack);
 			stack = doInsert(stack, validOutputs[0], simulate);
 			// Only if no filtered outputs were found, use unfiltered
-			if(validOutputs[0].length==0 || !stack.isEmpty())
+			if(validOutputs[0].length==0||!stack.isEmpty())
 				stack = doInsert(stack, validOutputs[1], simulate);
 			if(first)
 				routed = null;
@@ -415,6 +415,12 @@ public class SorterBlockEntity extends IEBaseBlockEntity implements IInteraction
 		public int getSlotId(Direction side, int slotOnSide)
 		{
 			return side.ordinal()*filterSlotsPerSide+slotOnSide;
+		}
+
+		@Override
+		public int getSlotLimit(int slot)
+		{
+			return 1;
 		}
 
 		public Iterable<ItemStack> getFilterStacksOnSide(Direction side)


### PR DESCRIPTION
fixes ItemRouter Inventories being able to have stack sizes > 1
fixes FluidRouter having input dependent amounts and removes amount display

fixes https://github.com/BluSunrize/ImmersiveEngineering/issues/4994

