### PR TITLE
quickMoveStack slot.mayPlace guard

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/gui/IEBaseContainer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/IEBaseContainer.java
@@ -113,7 +113,7 @@ public class IEBaseContainer<T extends BlockEntity> extends AbstractContainerMen
 					return ItemStack.EMPTY;
 				}
 			}
-			else if(!this.moveItemStackTo(itemstack1, 0, slotCount, false))
+			else if(!this.moveItemStackToWithMayPlace(itemstack1, 0, slotCount, false))
 			{
 				return ItemStack.EMPTY;
 			}
@@ -129,6 +129,26 @@ public class IEBaseContainer<T extends BlockEntity> extends AbstractContainerMen
 		}
 
 		return itemstack;
+	}
+
+	protected boolean moveItemStackToWithMayPlace(ItemStack pStack, int pStartIndex, int pEndIndex, boolean pReverseDirection)
+	{
+		boolean inAllowedRange = true;
+		int allowedStart = pStartIndex;
+		for(int i = pStartIndex; i < pEndIndex; i++)
+		{
+			boolean mayplace = this.slots.get(i).mayPlace(pStack);
+			if(inAllowedRange && (!mayplace || i == pEndIndex-1)) {
+				if(moveItemStackTo(pStack, allowedStart, i, pReverseDirection))
+					return true;
+				inAllowedRange = false;
+			}
+			else if (!inAllowedRange && mayplace) {
+				allowedStart = i;
+				inAllowedRange = true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/IEBaseContainer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/IEBaseContainer.java
@@ -138,12 +138,14 @@ public class IEBaseContainer<T extends BlockEntity> extends AbstractContainerMen
 		for(int i = pStartIndex; i < pEndIndex; i++)
 		{
 			boolean mayplace = this.slots.get(i).mayPlace(pStack);
-			if(inAllowedRange && (!mayplace || i == pEndIndex-1)) {
+			if(inAllowedRange&&(!mayplace||i==pEndIndex-1))
+			{
 				if(moveItemStackTo(pStack, allowedStart, i, pReverseDirection))
 					return true;
 				inAllowedRange = false;
 			}
-			else if (!inAllowedRange && mayplace) {
+			else if(!inAllowedRange&&mayplace)
+			{
 				allowedStart = i;
 				inAllowedRange = true;
 			}

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/IEBaseContainer.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/IEBaseContainer.java
@@ -113,7 +113,7 @@ public class IEBaseContainer<T extends BlockEntity> extends AbstractContainerMen
 					return ItemStack.EMPTY;
 				}
 			}
-			else if(!this.moveItemStackToWithMayPlace(itemstack1, 0, slotCount, false))
+			else if(!this.moveItemStackToWithMayPlace(itemstack1, 0, slotCount))
 			{
 				return ItemStack.EMPTY;
 			}
@@ -131,7 +131,7 @@ public class IEBaseContainer<T extends BlockEntity> extends AbstractContainerMen
 		return itemstack;
 	}
 
-	protected boolean moveItemStackToWithMayPlace(ItemStack pStack, int pStartIndex, int pEndIndex, boolean pReverseDirection)
+	protected boolean moveItemStackToWithMayPlace(ItemStack pStack, int pStartIndex, int pEndIndex)
 	{
 		boolean inAllowedRange = true;
 		int allowedStart = pStartIndex;
@@ -140,7 +140,7 @@ public class IEBaseContainer<T extends BlockEntity> extends AbstractContainerMen
 			boolean mayplace = this.slots.get(i).mayPlace(pStack);
 			if(inAllowedRange&&(!mayplace||i==pEndIndex-1))
 			{
-				if(moveItemStackTo(pStack, allowedStart, i, pReverseDirection))
+				if(moveItemStackTo(pStack, allowedStart, i, false))
 					return true;
 				inAllowedRange = false;
 			}


### PR DESCRIPTION
Guard slots that may not be placed in from being placed into with quickMoveStack. These slots can be inserted into if a stack of the same item is already present in the slot

notably guards output slots of various machines

fixes https://github.com/BluSunrize/ImmersiveEngineering/issues/4972

I'm only semi happy with the solution, if someone has a better idea, I'm all ears.