### PR TITLE
removes inventory tag from empty crates when broken

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WoodenCrateBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WoodenCrateBlockEntity.java
@@ -201,7 +201,7 @@ public class WoodenCrateBlockEntity extends IEBaseBlockEntity implements IIEInve
 	{
 		ItemStack stack = new ItemStack(getBlockState().getBlock(), 1);
 		CompoundTag tag = new CompoundTag();
-		ContainerHelper.saveAllItems(tag, inventory);
+		ContainerHelper.saveAllItems(tag, inventory, false);
 		if(!tag.isEmpty())
 			stack.setTag(tag);
 		if(this.name!=null)


### PR DESCRIPTION
makes once placed empty crates able to stack with freshly crafted empty crates again

fixes https://github.com/BluSunrize/ImmersiveEngineering/issues/5095