### PR TITLE
Add IMultiblock:getBlock

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/multiblocks/MultiblockHandler.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/multiblocks/MultiblockHandler.java
@@ -17,6 +17,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate.StructureBlockInfo;
 import net.minecraftforge.common.MinecraftForge;
@@ -99,6 +101,11 @@ public class MultiblockHandler
 		void initializeClient(Consumer<MultiblockManualData> consumer);
 
 		Component getDisplayName();
+
+		default Block getBlock()
+		{
+			return Blocks.AIR;
+		}
 	}
 
 	public static MultiblockFormEvent postMultiblockFormationEvent(Player player, IMultiblock multiblock, BlockPos clickedBlock, ItemStack hammer)

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/IETemplateMultiblock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/IETemplateMultiblock.java
@@ -130,6 +130,7 @@ public abstract class IETemplateMultiblock extends TemplateMultiblock
 		return baseState.get().getName();
 	}
 
+	@Override
 	public Block getBlock()
 	{
 		return baseState.get();


### PR DESCRIPTION
Allow addons to get a multiblock's block-item.

Adding to `IMultiblock` as the API looks like it encourages use of that interface. Other idea would be add it to `TemplateMultiblock` since currently those are the only ones that will have a non-air block.