### PR TITLE
update oc2 version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,7 @@ dependencies {
     compileOnly fg.deobf("curse.maven:the-one-probe-245211:3550084")
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.18-5.0.2.4:api")
     compileOnly fg.deobf("curse.maven:jade-324717:3551337")
-    compileOnly fg.deobf("curse.maven:opencomputers2-437654:3630307")
+    compileOnly fg.deobf("curse.maven:opencomputers2-437654:3739469")
     compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-forge-1.18.1:9.0.0+15")
 
     implementation "malte0811:BlockModelSplitter:2.0.1"

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/oc2/OC2CompatModule.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/oc2/OC2CompatModule.java
@@ -22,7 +22,7 @@ public class OC2CompatModule extends EarlyIECompatModule
 	public OC2CompatModule(BooleanValue enabled)
 	{
 		DeferredRegister<BlockDeviceProvider> register = DeferredRegister.create(
-				new ResourceLocation(API.MOD_ID, "block_device_providers"), Lib.MODID
+				new ResourceLocation(API.MOD_ID, "block_device_provider"), Lib.MODID
 		);
 		register.register("generic", () -> new DeviceProvider(enabled));
 		register.register(FMLJavaModLoadingContext.get().getModEventBus());


### PR DESCRIPTION
oc2 has changed its device registry name from `block_device_providers` to `block_device_provider` and changed some api method signature, thus a update of oc2 version is needed.