### PR TITLE
Fix duplication of buckets in the Assembler

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/IEContent.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IEContent.java
@@ -208,7 +208,7 @@ public class IEContent
 			if(!(potentialBucket instanceof BucketItem))
 				return null;
 			// bucket was consumed in recipe
-			if(remain.isEmpty())
+			if(remain.getItem()!=Items.BUCKET)
 				return null;
 			//Explicitly check for vanilla-style non-dynamic container items
 			//noinspection deprecation
@@ -225,7 +225,7 @@ public class IEContent
 			if(matching[0].getItem()!=Items.MILK_BUCKET||!ForgeMod.MILK.isPresent())
 				return null;
 			// bucket was consumed in recipe
-			if(remain.isEmpty())
+			if(remain.getItem()!=Items.BUCKET)
 				return null;
 			return new FluidStackRecipeQuery(new FluidStack(ForgeMod.MILK.get(), FluidAttributes.BUCKET_VOLUME));
 		});

--- a/src/main/java/blusunrize/immersiveengineering/common/IEContent.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IEContent.java
@@ -189,7 +189,7 @@ public class IEContent
 
 		/*ASSEMBLER RECIPE ADAPTERS*/
 		//Fluid Ingredients
-		AssemblerHandler.registerSpecialIngredientConverter((o) ->
+		AssemblerHandler.registerSpecialIngredientConverter((o, remain) ->
 		{
 			if(o instanceof IngredientFluidStack)
 				return new FluidTagRecipeQuery(((IngredientFluidStack)o).getFluidTagInput());
@@ -199,13 +199,16 @@ public class IEContent
 		// Buckets
 		// TODO add "duplicates" of the fluid-aware recipes that only use buckets, so that other mods using similar
 		//  code don't need explicit compat?
-		AssemblerHandler.registerSpecialIngredientConverter((o) ->
+		AssemblerHandler.registerSpecialIngredientConverter((o, remain) ->
 		{
 			final ItemStack[] matching = o.getItems();
 			if(!o.isVanilla()||matching.length!=1)
 				return null;
 			final Item potentialBucket = matching[0].getItem();
 			if(!(potentialBucket instanceof BucketItem))
+				return null;
+			// bucket was consumed in recipe
+			if(remain.isEmpty())
 				return null;
 			//Explicitly check for vanilla-style non-dynamic container items
 			//noinspection deprecation
@@ -215,9 +218,14 @@ public class IEContent
 			return new FluidStackRecipeQuery(new FluidStack(contained, FluidAttributes.BUCKET_VOLUME));
 		});
 		// Milk is a weird special case
-		AssemblerHandler.registerSpecialIngredientConverter(o -> {
+		AssemblerHandler.registerSpecialIngredientConverter((o, remain) -> {
 			final ItemStack[] matching = o.getItems();
-			if(!o.isVanilla()||matching.length!=1||matching[0].getItem()!=Items.MILK_BUCKET||!ForgeMod.MILK.isPresent())
+			if(!o.isVanilla()||matching.length!=1)
+				return null;
+			if(matching[0].getItem()!=Items.MILK_BUCKET||!ForgeMod.MILK.isPresent())
+				return null;
+			// bucket was consumed in recipe
+			if(remain.isEmpty())
 				return null;
 			return new FluidStackRecipeQuery(new FluidStack(ForgeMod.MILK.get(), FluidAttributes.BUCKET_VOLUME));
 		});

--- a/src/main/java/blusunrize/immersiveengineering/common/crafting/DefaultAssemblerAdapter.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/crafting/DefaultAssemblerAdapter.java
@@ -4,6 +4,7 @@ import blusunrize.immersiveengineering.api.tool.assembler.AssemblerHandler;
 import blusunrize.immersiveengineering.api.tool.assembler.AssemblerHandler.IRecipeAdapter;
 import blusunrize.immersiveengineering.api.tool.assembler.RecipeQuery;
 import blusunrize.immersiveengineering.common.util.FakePlayerUtil;
+import blusunrize.immersiveengineering.common.util.Utils;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.inventory.CraftingContainer;
 import net.minecraft.world.item.ItemStack;
@@ -37,6 +38,11 @@ public class DefaultAssemblerAdapter implements IRecipeAdapter<Recipe<CraftingCo
 		int[] ingredientAssignment = RecipeMatcher.findMatches(inputList, ingredientsForMatching);
 		ForgeHooks.setCraftingPlayer(null);
 
+		// Collect remaining items
+		NonNullList<ItemStack> remains = recipe.getRemainingItems(
+				Utils.InventoryCraftingFalse.createFilledCraftingInventory(3, 3, input)
+		);
+
 		// - 1: Input list contains the output slot
 		RecipeQuery[] query = new RecipeQuery[input.size()-1];
 		if(ingredientAssignment!=null)
@@ -48,14 +54,15 @@ public class DefaultAssemblerAdapter implements IRecipeAdapter<Recipe<CraftingCo
 				int ingredIndex = ingredientAssignment[stackIndex];
 				if(ingredIndex < numNonEmpty)
 					query[stackIndex] = AssemblerHandler.createQueryFromIngredient(
-							(Ingredient)ingredientsForMatching.get(ingredIndex)
+							(Ingredient)ingredientsForMatching.get(ingredIndex),
+							remains.get(stackIndex)
 					);
 			}
 		else
 			// Otherwise request the exact stacks used in the input
 			for(int i = 0; i < query.length; i++)
 				if(!input.get(i).isEmpty())
-					query[i] = AssemblerHandler.createQueryFromItemStack(input.get(i));
+					query[i] = AssemblerHandler.createQueryFromItemStack(input.get(i), remains.get(i));
 		return query;
 	}
 }


### PR DESCRIPTION
By making it aware of the lack of remaining items.

Closes #5382

@malte0811 I definitely need your feedback on this.

Technically this shouldn't result in a major version increase because it isn't API breaking? `specialQueryConverters` was removed but it was inaccessible anyway and had no method to add to it.