### PR TITLE
Add missing lang entry for potted industrial hemp

### DIFF
--- a/src/main/resources/assets/immersiveengineering/lang/en_ud.json
+++ b/src/main/resources/assets/immersiveengineering/lang/en_ud.json
@@ -1239,6 +1239,7 @@
  "block.immersiveengineering.metal_multiblock.mixer": "ɹǝxᴉW",
  "block.immersiveengineering.metal_decoration.structural_arm": "ɯɹⱯ ꞁɐɹnʇɔnɹʇS",
  "block.immersiveengineering.hemp": "dɯǝH ꞁɐᴉɹʇsnpuI",
+ "block.immersiveengineering.potted_hemp": "dɯǝH ꞁɐᴉɹʇsnpuI pǝʇʇoԀ",
  "block.immersiveengineering.cloth_device.cushion": "uoᴉɥsnƆ dɯnՐ",
  "block.immersiveengineering.cloth_device.balloon": "uooꞁꞁɐᗺ",
  "block.immersiveengineering.cloth_device.stripcurtain": "uᴉɐʇɹnƆ dᴉɹʇS",

--- a/src/main/resources/assets/immersiveengineering/lang/en_us.json
+++ b/src/main/resources/assets/immersiveengineering/lang/en_us.json
@@ -994,6 +994,7 @@
   "block.immersiveengineering.mixer": "Mixer",
   "block.immersiveengineering.structural_arm": "Structural Arm",
   "block.immersiveengineering.hemp": "Industrial Hemp",
+  "block.immersiveengineering.potted_hemp": "Potted Industrial Hemp",
   "block.immersiveengineering.sawdust": "Sawdust Flooring",
   "block.immersiveengineering.fiberboard": "Fiberboard",
   "block.immersiveengineering.cushion": "Jump Cushion",


### PR DESCRIPTION
This PR add the localized name for potted industrial hemp. The translated names of blocks without block items are pretty much never used in vanilla, but mods can still get them using Block::getName (All vanilla blocks are translated even if they don't have a corresponding item)