### PR TITLE
Fix problems with CC: Tweaked compatibility and diesel generators and…

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/impl/MultiblockCallbacks.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/impl/MultiblockCallbacks.java
@@ -20,7 +20,7 @@ public class MultiblockCallbacks extends Callback<MultiblockPartBlockEntity<?>>
 	@ComputerCallable
 	public boolean getEnabled(CallbackEnvironment<MultiblockPartBlockEntity<?>> env)
 	{
-		return env.object().computerControl.isEnabled();
+		return env.beforePreprocess().computerControl.isEnabled();
 	}
 
 	@ComputerCallable

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/impl/MultiblockCallbacks.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/impl/MultiblockCallbacks.java
@@ -9,7 +9,6 @@
 package blusunrize.immersiveengineering.common.util.compat.computers.generic.impl;
 
 import blusunrize.immersiveengineering.common.blocks.generic.MultiblockPartBlockEntity;
-import blusunrize.immersiveengineering.common.blocks.generic.PoweredMultiblockBlockEntity;
 import blusunrize.immersiveengineering.common.util.compat.computers.generic.Callback;
 import blusunrize.immersiveengineering.common.util.compat.computers.generic.CallbackEnvironment;
 import blusunrize.immersiveengineering.common.util.compat.computers.generic.ComputerCallable;
@@ -19,13 +18,13 @@ public class MultiblockCallbacks extends Callback<MultiblockPartBlockEntity<?>>
 	public static final MultiblockCallbacks INSTANCE = new MultiblockCallbacks();
 
 	@ComputerCallable
-	public boolean isRunning(CallbackEnvironment<PoweredMultiblockBlockEntity<?, ?>> env)
+	public boolean getEnabled(CallbackEnvironment<MultiblockPartBlockEntity<?>> env)
 	{
-		return env.object().shouldRenderAsActive();
+		return env.object().computerControl.isEnabled();
 	}
 
 	@ComputerCallable
-	public void setEnabled(CallbackEnvironment<PoweredMultiblockBlockEntity<?, ?>> env, boolean enable)
+	public void setEnabled(CallbackEnvironment<MultiblockPartBlockEntity<?>> env, boolean enable)
 	{
 		env.object().computerControl.setEnabled(enable);
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/impl/PoweredMBCallbacks.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/impl/PoweredMBCallbacks.java
@@ -10,10 +10,20 @@ package blusunrize.immersiveengineering.common.util.compat.computers.generic.imp
 
 import blusunrize.immersiveengineering.common.blocks.generic.PoweredMultiblockBlockEntity;
 import blusunrize.immersiveengineering.common.util.compat.computers.generic.Callback;
+import blusunrize.immersiveengineering.common.util.compat.computers.generic.CallbackEnvironment;
+import blusunrize.immersiveengineering.common.util.compat.computers.generic.ComputerCallable;
 
 public class PoweredMBCallbacks extends Callback<PoweredMultiblockBlockEntity<?, ?>>
 {
 	public static final PoweredMBCallbacks INSTANCE = new PoweredMBCallbacks();
+
+	@ComputerCallable
+	public boolean isRunning(CallbackEnvironment<PoweredMultiblockBlockEntity<?, ?>> env)
+	{
+		PoweredMultiblockBlockEntity<?, ?> master = env.object().master();
+		if(master==null) return false;
+		return master.shouldRenderAsActive();
+	}
 
 	public PoweredMBCallbacks()
 	{

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/impl/PoweredMBCallbacks.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/impl/PoweredMBCallbacks.java
@@ -20,9 +20,7 @@ public class PoweredMBCallbacks extends Callback<PoweredMultiblockBlockEntity<?,
 	@ComputerCallable
 	public boolean isRunning(CallbackEnvironment<PoweredMultiblockBlockEntity<?, ?>> env)
 	{
-		PoweredMultiblockBlockEntity<?, ?> master = env.object().master();
-		if(master==null) return false;
-		return master.shouldRenderAsActive();
+		return env.object().shouldRenderAsActive();
 	}
 
 	public PoweredMBCallbacks()

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/owners/DieselGenCallbacks.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/owners/DieselGenCallbacks.java
@@ -8,7 +8,6 @@
 
 package blusunrize.immersiveengineering.common.util.compat.computers.generic.owners;
 
-import blusunrize.immersiveengineering.common.blocks.generic.PoweredMultiblockBlockEntity;
 import blusunrize.immersiveengineering.common.blocks.metal.DieselGeneratorBlockEntity;
 import blusunrize.immersiveengineering.common.util.compat.computers.generic.CallbackEnvironment;
 import blusunrize.immersiveengineering.common.util.compat.computers.generic.ComputerCallable;
@@ -20,9 +19,7 @@ public class DieselGenCallbacks extends MultiblockCallbackOwner<DieselGeneratorB
 	@ComputerCallable
 	public boolean isRunning(CallbackEnvironment<DieselGeneratorBlockEntity> env)
 	{
-		DieselGeneratorBlockEntity master = env.object().master();
-		if(master==null) return false;
-		return master.active;
+		return env.object().active;
 	}
 
 	public DieselGenCallbacks()

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/owners/DieselGenCallbacks.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/owners/DieselGenCallbacks.java
@@ -8,12 +8,23 @@
 
 package blusunrize.immersiveengineering.common.util.compat.computers.generic.owners;
 
+import blusunrize.immersiveengineering.common.blocks.generic.PoweredMultiblockBlockEntity;
 import blusunrize.immersiveengineering.common.blocks.metal.DieselGeneratorBlockEntity;
+import blusunrize.immersiveengineering.common.util.compat.computers.generic.CallbackEnvironment;
+import blusunrize.immersiveengineering.common.util.compat.computers.generic.ComputerCallable;
 import blusunrize.immersiveengineering.common.util.compat.computers.generic.impl.MultiblockCallbacks;
 import blusunrize.immersiveengineering.common.util.compat.computers.generic.impl.TankCallbacks;
 
 public class DieselGenCallbacks extends MultiblockCallbackOwner<DieselGeneratorBlockEntity>
 {
+	@ComputerCallable
+	public boolean isRunning(CallbackEnvironment<DieselGeneratorBlockEntity> env)
+	{
+		DieselGeneratorBlockEntity master = env.object().master();
+		if(master==null) return false;
+		return master.active;
+	}
+
 	public DieselGenCallbacks()
 	{
 		super(DieselGeneratorBlockEntity.class, "diesel_generator");

--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/owners/MultiblockCallbackOwner.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/computers/generic/owners/MultiblockCallbackOwner.java
@@ -27,10 +27,6 @@ public abstract class MultiblockCallbackOwner<T extends MultiblockPartBlockEntit
 	@Override
 	public T preprocess(T arg)
 	{
-		T master = (T)arg.master();
-		if(master!=null)
-			return master;
-		else
-			return arg;
+		return arg;
 	}
 }


### PR DESCRIPTION
Fix problems with CC: Tweaked compatibility and diesel generators and add the new computer callable method getEnabled()

Fixed a problem causing Lua exceptions when methods isRunning() and setEnabled() were called for a diesel generator by:
- Correcting the parameter type for setEnabled() in MultiblockCallbacks.java.
- Moving isRunning() to PoweredMBCallbacks.java.
- Adding a specific version of isRunning() for diesel generators in DieselGenCallbacks.java.

Added a method getEnabled() to MultiblockCallbacks.java so that the enabled status can be also queried.

Made some changes for setting the RS block as CallbackEnvironment for Computer Calls of MultiblockCallbackOwners:
- changed preprocess() accordingly, so that it returns the RS block entity.
- changed the isRunning() method, so that it first retrieves the master block before querying.

Fixes #5402