### PR TITLE
Change the Cloche CraftTweaker Recipe Manager to use the right annota…

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ClocheRecipeManager.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/compat/crafttweaker/managers/ClocheRecipeManager.java
@@ -102,7 +102,7 @@ public class ClocheRecipeManager implements IRecipeManager<ClocheRecipe>
 	 * @docParam renderType "generic"
 	 */
 	@ZenCodeType.Method
-	public void addRecipe(String recipePath, IIngredient seed, IIngredient soil, int time, IItemStack[] outputs, Block renderBlock, @ZenCodeType.Optional("\"generic\"") String renderType)
+	public void addRecipe(String recipePath, IIngredient seed, IIngredient soil, int time, IItemStack[] outputs, Block renderBlock, @ZenCodeType.OptionalString("\"generic\"") String renderType)
 	{
 		final ResourceLocation resourceLocation = new ResourceLocation("crafttweaker", recipePath);
 		final List<Lazy<ItemStack>> outputList = CrTIngredientUtil.getNonNullList(outputs);


### PR DESCRIPTION
…tion

Changes the original `Optional` to be an `OptionalString`, as thats what CraftTweaker expects and requires for docs generation.

After this PR is merged i'll PR the 1.18 IE docs to the CraftTweaker site