### PR TITLE
Deactivate diesel generator when there is no energy output.

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/DieselGeneratorBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/DieselGeneratorBlockEntity.java
@@ -170,6 +170,11 @@ public class DieselGeneratorBlockEntity extends MultiblockPartBlockEntity<Diesel
 			{
 				consumeTick--;
 			}
+			else if(active)
+			{
+				active = false;
+				animation_fanFadeOut = 80;
+			}
 			if(consumeTick<=0) //Consume 10*tick-amount every 10ticks to allow for 1/10th mB amounts
 			{
 				GeneratorFuel recipe = recipeGetter.apply(level, tanks[0].getFluid().getFluid());


### PR DESCRIPTION
This fix an issue where the diesel generator animation and sound would continue to run even when there was no energy output.

Closes #5440 