### PR TITLE
Fix Revolver Perk Bug (1.19.2)

### DIFF
--- a/src/generated/resources/data/immersiveengineering/recipes/crafting/revolver.json
+++ b/src/generated/resources/data/immersiveengineering/recipes/crafting/revolver.json
@@ -1,9 +1,9 @@
 {
   "type": "immersiveengineering:revolver_assembly",
   "copy_nbt": [
-    3,
+    1,
     4,
-    5
+    6
   ],
   "key": {
     "b": {


### PR DESCRIPTION
What this PR does:
- Updates the indexes of items to check in the crafting matrix when applying perks to the revolver

Address https://github.com/BluSunrize/ImmersiveEngineering/issues/5452


## Evidence
### Items with Perks
![barrel](https://user-images.githubusercontent.com/115904577/196047503-867063c1-13c7-41bc-8e8b-9f194fac5659.PNG)
![drum](https://user-images.githubusercontent.com/115904577/196047506-81c1df97-3038-4afb-b901-073a402ffb59.PNG)
![hammer](https://user-images.githubusercontent.com/115904577/196047508-e2d2141a-f33c-45ef-8b90-d2d8e903cc51.PNG)
### Before (only the drum perks are applied)
![before](https://user-images.githubusercontent.com/115904577/196047517-8a174f86-5cc6-47f1-a0e3-5d9006341a41.PNG)
### After (all perks are applied)
![after](https://user-images.githubusercontent.com/115904577/196047520-54cebfd9-f179-4ae1-b0b8-ea0f8b0bb19d.PNG)