### PR TITLE
Fix for a crash when Secondaries of a recipe have different item from main recipe result / Resolves #5506

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/crafting/ArcFurnaceRecipe.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/crafting/ArcFurnaceRecipe.java
@@ -91,7 +91,8 @@ public class ArcFurnaceRecipe extends MultiblockRecipe
 	{
 		Random random = new Random(seed);
 		var output = this.output.get();
-		NonNullList<ItemStack> actualOutput = NonNullList.withSize(output.size(), ItemStack.EMPTY);
+		int remainingIndex = output.size();
+		NonNullList<ItemStack> actualOutput = NonNullList.withSize(output.size() + secondaryOutputs.size() , ItemStack.EMPTY);
 		for(int i = 0; i < output.size(); ++i)
 			actualOutput.set(i, output.get(i).copy());
 		for(StackWithChance secondary : secondaryOutputs)
@@ -106,8 +107,10 @@ public class ArcFurnaceRecipe extends MultiblockRecipe
 					remaining = ItemStack.EMPTY;
 					break;
 				}
-			if(!remaining.isEmpty())
-				actualOutput.add(remaining);
+			if(!remaining.isEmpty()) {
+				actualOutput.set(remainingIndex, remaining);
+				remainingIndex++;
+			}
 		}
 		return actualOutput;
 	}


### PR DESCRIPTION
Better explanation of the issue: A NonNullList is not a dynamic list implementation. Its size cannot be changed after creation. If the secondary field could not be merged with the main recipe result, it is supposed to be added to the output, which is not possible due to the nature of NonNullList and caused a crash.
None of the IE recipes trigger this problem, but custom recipes from people who want to use secondary outputs different from the main output do.

In #5506, I misunderstood the actual problem, as using Item instead of Tag should work fine, and the real problem is described above.

The fix increases the size of the initial list from just the output size to the output size plus the size of all secondaries, even if they can be merged.
This results in some empty ItemStacks in the final list but fixes the crash caused by the secondaries being different from the main recipe result. Empty ItemStacks have no effect because the proper treatment of them is already in place, as far as I can tell.