### PR TITLE
Fix for Hemp Seeds dropping while using Modded Shears

### DIFF
--- a/src/main/resources/data/immersiveengineering/loot_modifiers/hemp_from_grass.json
+++ b/src/main/resources/data/immersiveengineering/loot_modifiers/hemp_from_grass.json
@@ -10,9 +10,7 @@
       "term": {
         "condition": "minecraft:match_tool",
         "predicate": {
-          "items": [
-            "minecraft:shears"
-          ]
+          "tag": "forge:shears"
         }
       }
     },

--- a/src/main/resources/data/immersiveengineering/loot_modifiers/hemp_from_tall_grass.json
+++ b/src/main/resources/data/immersiveengineering/loot_modifiers/hemp_from_tall_grass.json
@@ -10,9 +10,7 @@
       "term": {
         "condition": "minecraft:match_tool",
         "predicate": {
-          "items": [
-            "minecraft:shears"
-          ]
+          "tag": "forge:shears"
         }
       }
     },


### PR DESCRIPTION
### Issue Description
While using modded shears, Hemp Seeds still drop, because of the way loot modifiers are made 😅

### Fix Description
Change predicate from Items to Tag, to allow modded Shears to work as intended 😄