### PR TITLE
Fixed Improved Blast Furnace output capability facing

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/stone/BlastFurnaceAdvancedBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/stone/BlastFurnaceAdvancedBlockEntity.java
@@ -217,9 +217,9 @@ public class BlastFurnaceAdvancedBlockEntity extends BlastFurnaceBlockEntity<Bla
 		{
 			if(inputOffset.equals(posInMultiblock)&&facing==Direction.UP)
 				return inputHandler.getAndCast();
-			if(outputOffset.equals(posInMultiblock)&&facing==getFacing())
+			if(outputOffset.equals(posInMultiblock)&&facing==getFacing().getOpposite())
 				return outputHandler.getAndCast();
-			if(slagOutputOffset.equals(posInMultiblock)&&facing==getFacing().getOpposite())
+			if(slagOutputOffset.equals(posInMultiblock)&&facing==getFacing())
 				return slagHandler.getAndCast();
 		}
 		return super.getCapability(capability, facing);


### PR DESCRIPTION
The inventory handlers of the Improved Blast Furnace were previously pointed inwards, which meant that it was not usable with certain modded item transportation means that did not implement a container, like the Create mod's funnels. This has been fixed.