### PR TITLE
Add option to disable registration of default diesel generator fuels (1.12)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
+##### Version 0.12-99
+- Added option to disable default diesel generator fuels to fix a longstanding issue. (Lycide)
+
 ##### Version 0.12-98 - BUILT
-- Added combat for XLFood to the cloche (LeoBeliik)
-- Added Albedo combat for the flueorescent tube (Pabilo8)
+- Added compat for XLFood to the cloche (LeoBeliik)
+- Added Albedo compat for the flueorescent tube (Pabilo8)
 - Added steel hoe (BluSunrize)
 - Fixed chutes crashing on dedicated servers (Malte)
 - Fixed the Skyhook crashing due to Optifine (Malte)

--- a/src/main/java/blusunrize/immersiveengineering/common/Config.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/Config.java
@@ -175,6 +175,9 @@ public class Config
 			@Mapped(mapClass = Config.class, mapName = "manual_int")
 			@RangeInt(min = 0)
 			public static int dieselGen_output = 4096;
+			@Comment({"Should IE register fuels for the Diesel Generator? if this is set true, IE will overwrite custom values set by crafttweaker. The default fuels are <fluid:fuel>, <fluid:diesel> and <fluid:biodiesel>"})
+			public static boolean diesel_registerFuels = true;
+
 
 			//Simple Machines
 			@Comment({"The Flux per tick consumed to add one heat to a furnace. Creates up to 4 heat in the startup time and then 1 heat per tick to keep it running"})

--- a/src/main/java/blusunrize/immersiveengineering/common/IEContent.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/IEContent.java
@@ -787,9 +787,13 @@ public class IEContent
 			}
 		});
 
-		DieselHandler.registerFuel(fluidBiodiesel, 125);
-		DieselHandler.registerFuel(FluidRegistry.getFluid("fuel"), 375);
-		DieselHandler.registerFuel(FluidRegistry.getFluid("diesel"), 175);
+		if(IEConfig.Machines.diesel_registerFuels == true)
+		{
+			DieselHandler.registerFuel(fluidBiodiesel, 125);
+			DieselHandler.registerFuel(FluidRegistry.getFluid("fuel"), 375);
+			DieselHandler.registerFuel(FluidRegistry.getFluid("diesel"), 175);
+		}
+
 		DieselHandler.registerDrillFuel(fluidBiodiesel);
 		DieselHandler.registerDrillFuel(FluidRegistry.getFluid("fuel"));
 		DieselHandler.registerDrillFuel(FluidRegistry.getFluid("diesel"));


### PR DESCRIPTION
Fixes a longstanding issue in 1.12 where IE registers its fuels after crafttweaker scripts run, rendering any adjustments to the default fuels pointless.