### PR TITLE
[1.12.2] Fix clientside crashes

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/TileEntityMultiblockPart.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/TileEntityMultiblockPart.java
@@ -281,7 +281,7 @@ public abstract class TileEntityMultiblockPart<T extends TileEntityMultiblockPar
 
 	public boolean isDummy()
 	{
-		return offset[0]!=0||offset[1]!=0||offset[2]!=0;
+		return offset.length>=3 && (offset[0]!=0||offset[1]!=0||offset[2]!=0);
 	}
 
 	@Override


### PR DESCRIPTION
```
java.lang.ArrayIndexOutOfBoundsException: 0
    at blusunrize.immersiveengineering.common.blocks.TileEntityMultiblockPart.isDummy(TileEntityMultiblockPart.java:284)
    at blusunrize.immersiveengineering.common.blocks.metal.TileEntityArcFurnace.TickCentral_TrueITickableUpdate(TileEntityArcFurnace.java:75)
    at com.github.terminatornl.tickcentral.api.TickHub.trueUpdate(TickHub.java:48)
    at com.github.terminatornl.tickcentral.api.TickInterceptor.redirectUpdate(TickInterceptor.java:24)
    at blusunrize.immersiveengineering.common.blocks.metal.TileEntityArcFurnace.update(TileEntityArcFurnace.java)
    at com.zeitheron.hammercore.asm.McHooks.tickTile(McHooks.java:38)
    at net.minecraft.world.World.updateEntities(World.java:1838)
    at net.minecraft.client.Minecraft.runTick(Minecraft.java:1847)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1098)
    at net.minecraft.client.Minecraft.run(Minecraft.java:3942)
    at net.minecraft.client.main.Main.main(SourceFile:123)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
```