### PR TITLE
Fix VertexBufferHolder breaking with cached PoseStack entries

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/utils/VertexBufferHolder.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/utils/VertexBufferHolder.java
@@ -180,7 +180,7 @@ public class VertexBufferHolder implements IVertexBufferHolder
 			this.buffer = buffer;
 			this.light = light;
 			this.overlay = overlay;
-			this.transform = transform.last().pose();
+			this.transform = new Matrix4f(transform.last().pose());
 			this.inverted = inverted;
 		}
 	}


### PR DESCRIPTION
When creating buffered jobs, `VertexBufferHolder` stores the position matrix contained in the last entry of the `PoseStack` in order to use it later. However, the block entity renderer pops that entry off the PoseStack shortly after. In vanilla, this does not cause a problem, as PoseStacks allocate fresh entries each time. However, some performance mods (e.g. Sodium) might cache PoseStack entries to curb the allocation rate in scenes with lots of block entities. This causes issues with IE as the same `Matrix4f` instance ends up being reused many times, causing all block entities using `VertexBufferHolder` to [render at the same location](https://youtu.be/ztxgwUI74CI) (video provided by the user who experienced the problem).

It's debatable whether this is a bug in IE, since the code works correctly if mods provide the same semantics as vanilla. Sodium's input on the issue was that it is undefined behavior in graphics programming to expect a matrix reference to be valid after popping it off the stack. I chose to fix the issue in Embeddium by disabling the problematic optimization, since I personally believe vanilla semantics have to be preserved for compatibility, but I'm providing this PR to also fix the issue on IE's end.