### PR TITLE
HempBlock: Update neighbours when growing top block

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/HempBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/plant/HempBlock.java
@@ -144,7 +144,7 @@ public class HempBlock extends CropBlock implements BonemealableBlock
 					{
 						BlockPos above = pos.above();
 						BlockState aboveState = this.getStateForAge(getMaxAge()).setValue(TOP, true);
-						world.setBlock(above, aboveState, 2);
+						world.setBlockAndUpdate(above, aboveState);
 						net.minecraftforge.common.ForgeHooks.onCropsGrowPost(world, above, aboveState);
 					}
 				}
@@ -172,6 +172,6 @@ public class HempBlock extends CropBlock implements BonemealableBlock
 
 		world.setBlock(pos, this.getStateForAge(newAge), 2);
 		if(growTop)
-			world.setBlock(pos.above(), this.getStateForAge(getMaxAge()).setValue(TOP, true), 2);
+			world.setBlockAndUpdate(pos.above(), this.getStateForAge(getMaxAge()).setValue(TOP, true));
 	}
 }


### PR DESCRIPTION
Vanilla multi-block crops like SugarCaneBlock use setBlockAndUpdate when
placing the new block (equivalent to calling setBlock with update flags
3, i.e. UPDATE_NEIGHBORS | UPDATE_CLIENTS) rather than a direct call to
setBlock with flags 2 (i.e. just UPDATE_CLIENTS). However, HempBlock
currently just does the latter. Whilst vanilla's observer seems able to
pick up this update, AE2's Annihilation Plane cannot, and so will not
harvest the crop unless refreshed for some other reason (e.g. the
network is rebooted). Thus, more closely align the implementation with
blocks like SugarCaneBlock in order to play nicely with whatever trigger
mechanism AE2 is using.
