### PR TITLE
Fix External Heater breaking when used with an extra-fast cooking recipe.

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/util/VanillaFurnaceHeater.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/VanillaFurnaceHeater.java
@@ -25,24 +25,22 @@ public class VanillaFurnaceHeater implements IExternalHeatable
 		this.furnace = furnace;
 	}
 
-	int getCookTime()
+	boolean canCook()
 	{
 		ItemStack input = furnace.getItem(DATA_LIT_TIME);
 		if(input.isEmpty())
-			return -1;
+			return false;
 		Optional<? extends AbstractCookingRecipe> output = ((FurnaceTEAccess)furnace).getQuickCheck().getRecipeFor(furnace, furnace.getLevel());
 		if(output.isEmpty())
-			return -1;
+			return false;
 		ItemStack existingOutput = furnace.getItem(2);
 		if(existingOutput.isEmpty())
-			return output.get().getCookingTime();
+			return true;
 		ItemStack outStack = output.get().getResultItem();
 		if(!existingOutput.sameItem(outStack))
-			return -1;
+			return false;
 		int stackSize = existingOutput.getCount()+outStack.getCount();
-		if (stackSize <= furnace.getMaxStackSize()&&stackSize <= outStack.getMaxStackSize())
-			return output.get().getCookingTime();
-		return -1;
+		return stackSize <= furnace.getMaxStackSize()&&stackSize <= outStack.getMaxStackSize();
 	}
 
 	@Override
@@ -52,8 +50,8 @@ public class VanillaFurnaceHeater implements IExternalHeatable
 		if(now < blockedUntilGameTime)
 			return 0;
 		int energyConsumed = 0;
-		int cookingTime = getCookTime();
-		if(cookingTime>=0||redstone)
+		boolean canCook = canCook();
+		if(canCook||redstone)
 		{
 			ContainerData furnaceData = ((FurnaceTEAccess)furnace).getDataAccess();
 			int burnTime = furnaceData.get(DATA_LIT_TIME);
@@ -78,7 +76,7 @@ public class VanillaFurnaceHeater implements IExternalHeatable
 				}
 			}
 			// Speed up once fully charged
-			if(cookingTime>=0&&furnaceData.get(DATA_LIT_TIME) >= FULLY_HEATED_LIT_TIME&&furnaceData.get(DATA_COOKING_PROGRESS) < cookingTime-1)
+			if(canCook&&furnaceData.get(DATA_LIT_TIME) >= FULLY_HEATED_LIT_TIME&&furnaceData.get(DATA_COOKING_PROGRESS) < furnaceData.get(DATA_COOKING_TOTAL_TIME)-1)
 			{
 				int energyToUse = ExternalHeaterHandler.defaultFurnaceSpeedupCost;
 				if(energyAvailable-energyConsumed > energyToUse)

--- a/src/main/java/blusunrize/immersiveengineering/common/util/VanillaFurnaceHeater.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/VanillaFurnaceHeater.java
@@ -26,23 +26,25 @@ public class VanillaFurnaceHeater implements IExternalHeatable
 		this.furnace = furnace;
 	}
 
-	boolean canCook()
+	int getCookTime()
 	{
 		ItemStack input = furnace.getItem(DATA_LIT_TIME);
 		if(input.isEmpty())
-			return false;
+			return -1;
 		RecipeType<? extends AbstractCookingRecipe> type = ((FurnaceTEAccess)furnace).getRecipeType();
 		Optional<? extends AbstractCookingRecipe> output = furnace.getLevel().getRecipeManager().getRecipeFor(type, furnace, furnace.getLevel());
 		if(output.isEmpty())
-			return false;
+			return -1;
 		ItemStack existingOutput = furnace.getItem(2);
 		if(existingOutput.isEmpty())
-			return true;
+			return output.get().getCookingTime();
 		ItemStack outStack = output.get().getResultItem();
 		if(!existingOutput.sameItem(outStack))
-			return false;
+			return -1;
 		int stackSize = existingOutput.getCount()+outStack.getCount();
-		return stackSize <= furnace.getMaxStackSize()&&stackSize <= outStack.getMaxStackSize();
+		if (stackSize <= furnace.getMaxStackSize()&&stackSize <= outStack.getMaxStackSize())
+			return output.get().getCookingTime();
+		return -1;
 	}
 
 	@Override
@@ -52,8 +54,8 @@ public class VanillaFurnaceHeater implements IExternalHeatable
 		if(now < blockedUntilGameTime)
 			return 0;
 		int energyConsumed = 0;
-		boolean canCook = canCook();
-		if(canCook||redstone)
+		int cookingTime = getCookTime();
+		if(cookingTime>=0||redstone)
 		{
 			ContainerData furnaceData = ((FurnaceTEAccess)furnace).getDataAccess();
 			int burnTime = furnaceData.get(DATA_LIT_TIME);
@@ -78,7 +80,7 @@ public class VanillaFurnaceHeater implements IExternalHeatable
 				}
 			}
 			// Speed up once fully charged
-			if(canCook&&furnaceData.get(DATA_LIT_TIME) >= FULLY_HEATED_LIT_TIME&&furnaceData.get(DATA_COOKING_PROGRESS) < BURN_TIME_STANDARD-1)
+			if(cookingTime>=0&&furnaceData.get(DATA_LIT_TIME) >= FULLY_HEATED_LIT_TIME&&furnaceData.get(DATA_COOKING_PROGRESS) < cookingTime-1)
 			{
 				int energyToUse = ExternalHeaterHandler.defaultFurnaceSpeedupCost;
 				if(energyAvailable-energyConsumed > energyToUse)

--- a/src/main/java/blusunrize/immersiveengineering/common/util/VanillaFurnaceHeater.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/VanillaFurnaceHeater.java
@@ -6,7 +6,6 @@ import blusunrize.immersiveengineering.mixin.accessors.FurnaceTEAccess;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.AbstractCookingRecipe;
-import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.block.AbstractFurnaceBlock;
 import net.minecraft.world.level.block.entity.FurnaceBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -31,8 +30,7 @@ public class VanillaFurnaceHeater implements IExternalHeatable
 		ItemStack input = furnace.getItem(DATA_LIT_TIME);
 		if(input.isEmpty())
 			return -1;
-		RecipeType<? extends AbstractCookingRecipe> type = ((FurnaceTEAccess)furnace).getRecipeType();
-		Optional<? extends AbstractCookingRecipe> output = furnace.getLevel().getRecipeManager().getRecipeFor(type, furnace, furnace.getLevel());
+		Optional<? extends AbstractCookingRecipe> output = ((FurnaceTEAccess)furnace).getQuickCheck().getRecipeFor(furnace, furnace.getLevel());
 		if(output.isEmpty())
 			return -1;
 		ItemStack existingOutput = furnace.getItem(2);

--- a/src/main/java/blusunrize/immersiveengineering/mixin/accessors/FurnaceTEAccess.java
+++ b/src/main/java/blusunrize/immersiveengineering/mixin/accessors/FurnaceTEAccess.java
@@ -9,9 +9,10 @@
 
 package blusunrize.immersiveengineering.mixin.accessors;
 
+import net.minecraft.world.Container;
 import net.minecraft.world.inventory.ContainerData;
 import net.minecraft.world.item.crafting.AbstractCookingRecipe;
-import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -20,10 +21,9 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 @Mixin(AbstractFurnaceBlockEntity.class)
 public interface FurnaceTEAccess
 {
-	// This is a Forge-added field in 1.19, so it does not need to be remapped
-	@Accessor(remap = false)
+	@Accessor
 	@Final
-	RecipeType<? extends AbstractCookingRecipe> getRecipeType();
+	RecipeManager.CachedCheck<Container, ? extends AbstractCookingRecipe> getQuickCheck();
 
 	@Accessor
 	@Final


### PR DESCRIPTION
Though it's not used in vanilla, it's possible to adjust the `cookingTime` for furnace recipes. The heater's speedup behaviour didn't account for this, allowing it to increment the count beyond the expected maximum, breaking the furnace entirely since it uses `==` to check for completion. I altered the code to get the actual cooking time for the recipe and use that instead. While investigating, I also noticed that the furnace has a `RecipeManager.CachedCheck` instance used to avoid scanning the whole recipe list every tick, so I swapped the heater handler to use that. Haven't done timings, but I assume that might improve perf?

To test, I used the following recipe. Would it be a good idea to include that in the `test` package, maybe make a gametest? 
```json
{
  "type": "minecraft:smelting",
  "ingredient": {
    "item": "minecraft:dirt"
  },
  "result": "minecraft:diamond",
  "cookingtime": 25
}
```