### PR TITLE
Fix free energy from diesel generators filled with water (#5844)

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/logic/DieselGeneratorLogic.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/logic/DieselGeneratorLogic.java
@@ -78,14 +78,15 @@ public class DieselGeneratorLogic
 					.map(CapabilityReference::getNullable)
 					.filter(Objects::nonNull)
 					.collect(Collectors.toList());
-			if(!presentOutputs.isEmpty()&&EnergyHelper.distributeFlux(presentOutputs, output, false) < output)
-				state.consumeTick--;
-			if(state.consumeTick <= 0) //Consume 10*tick-amount every 10ticks to allow for 1/10th mB amounts
+			GeneratorFuel recipe = state.recipeGetter.apply(
+				context.getLevel().getRawLevel(), state.tank.getFluid().getFluid()
+			);
+			if(recipe != null &&
+			   !presentOutputs.isEmpty() && 
+			   EnergyHelper.distributeFlux(presentOutputs, output, false) < output)
 			{
-				GeneratorFuel recipe = state.recipeGetter.apply(
-						context.getLevel().getRawLevel(), state.tank.getFluid().getFluid()
-				);
-				if(recipe!=null)
+				state.consumeTick--;
+				if(state.consumeTick <= 0) //Consume 10*tick-amount every 10ticks to allow for 1/10th mB amounts
 				{
 					int burnTime = recipe.getBurnTime();
 					int fluidConsumed = (10*FluidType.BUCKET_VOLUME)/burnTime;


### PR DESCRIPTION
Moves the check that the generator's contained fluid is a valid fuel so it occurs before energy is generated. Fixes #5844 