### PR TITLE
Exponential Wire Loss

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
@@ -254,8 +254,8 @@ public class EnergyTransferHandler extends LocalNetworkHandler implements IWorld
 				for(Connection c : path.conns)
 				{
 					currentPoint = c.getOtherEnd(currentPoint);
-					//TODO use Blu's loss formula
-					availableFactor -= getBasicLoss(c);
+					// We use exponential loss here so there is still some power at arbitrarily far distances
+					availableFactor *= (1-getBasicLoss(c));
 					double availableAtPoint = atSource*availableFactor;
 					transferredNextTick.addTo(c, availableAtPoint);
 					if(!currentPoint.equals(path.end))
@@ -344,7 +344,7 @@ public class EnergyTransferHandler extends LocalNetworkHandler implements IWorld
 		public Path append(Connection next, boolean isPathToSink)
 		{
 			ConnectionPoint newEnd = next.getOtherEnd(end);
-			double newLoss = loss+getBasicLoss(next);
+			double newLoss = loss+(1-loss)*getBasicLoss(next);
 			Connection[] newPath = Arrays.copyOf(conns, conns.length+1);
 			newPath[newPath.length-1] = next;
 			return new Path(newPath, start, newEnd, newLoss, isPathToSink);

--- a/src/main/java/blusunrize/immersiveengineering/common/config/IEServerConfig.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/config/IEServerConfig.java
@@ -53,15 +53,15 @@ public class IEServerConfig
 			// Split: Color in client, all others in server
 			energyWireConfigs.put(
 					IEWireType.COPPER,
-					new EnergyWireConfig(builder, "copper", 16, 2048, 0.05)
+					new EnergyWireConfig(builder, "copper", 16, 2048, 0.0125)
 			);
 			energyWireConfigs.put(
 					IEWireType.ELECTRUM,
-					new EnergyWireConfig(builder, "electrum", 16, 8192, 0.025)
+					new EnergyWireConfig(builder, "electrum", 16, 8192, 0.003)
 			);
 			energyWireConfigs.put(
 					IEWireType.STEEL,
-					new EnergyWireConfig(builder, "hv", 32, 32768, 0.025)
+					new EnergyWireConfig(builder, "hv", 32, 32768, 0.0008)
 			);
 			wireConfigs.put(
 					IEWireType.STRUCTURE_ROPE,
@@ -129,10 +129,10 @@ public class IEServerConfig
 				super(builder, name, defLength, false);
 				this.transferRate = builder.comment("The transfer rate of "+name+" wire in IF/t")
 						.defineInRange("transferRate", defRate, 0, Integer.MAX_VALUE);
-				this.lossRatio = builder.comment("The percentage of power lost every 16 blocks of distance in "+name+" wire")
-						.defineInRange("loss", defLoss, 0, 1);
+				this.lossRatio = builder.comment("The percentage of received power lost every 16 blocks of distance in "+name+" wire. This means exponential loss!")
+						.defineInRange("distanceLoss", defLoss, 0, 1);
 				this.connectorRate = builder
-						.comment("In- and output rates of "+name+" wire connectors. This is independant of the transferrate of the wires.")
+						.comment("In- and output rates of "+name+" wire connectors. This is independent of the transfer rate of the wires.")
 						.defineInRange("wireConnectorInput", defRate/8, 0, Integer.MAX_VALUE);
 				builder.pop();
 			}


### PR DESCRIPTION
Wire loss is now exponential, and wire losses are now~10% loss at: 128 blocks for LV, 512 blocks for MV, 2048 blocks for HV. This fixes #5857.