### PR TITLE
Minecarts Interact With Hoppers & Fluid Pumps

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/FluidPumpBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/FluidPumpBlockEntity.java
@@ -139,10 +139,10 @@ public class FluidPumpBlockEntity extends IEBaseBlockEntity implements IEServerT
 						int out = this.outputFluid(drain, FluidAction.EXECUTE);
 						input.drain(out, FluidAction.EXECUTE);
 					}
-					else if (!(entities=level.getEntities(null, new AABB(getBlockPos().offset(f.getNormal())))).isEmpty())
+					else if (!(entities=level.getEntities(null, new AABB(getBlockPos().relative(f)))).isEmpty())
 					{
 						for (Entity toCheck : entities) {
-							input = toCheck.getCapability(FluidHandler.ENTITY, f);
+							input = toCheck.getCapability(FluidHandler.ENTITY, f.getOpposite());
 							if (input!=null)
 							{
 								int drainAmount = IFluidPipe.getTransferableAmount(this.canOutputPressurized(false));
@@ -299,10 +299,10 @@ public class FluidPumpBlockEntity extends IEBaseBlockEntity implements IEServerT
 						sum += temp;
 					}
 				}
-				else if (!(entities=level.getEntities(null, new AABB(getBlockPos().offset(f.getNormal())))).isEmpty())
+				else if (!(entities=level.getEntities(null, new AABB(getBlockPos().relative(f)))).isEmpty())
 				{
 					for (Entity toCheck : entities) {
-						handler = toCheck.getCapability(FluidHandler.ENTITY, f);
+						handler = toCheck.getCapability(FluidHandler.ENTITY, f.getOpposite());
 						if (handler!=null)
 						{
 							FluidStack insertResource = Utils.copyFluidStackWithAmount(fs, fs.getAmount(), true);

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/FluidPumpBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/FluidPumpBlockEntity.java
@@ -38,7 +38,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.block.Blocks;
@@ -53,7 +52,6 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.Capabilities.EnergyStorage;
 import net.neoforged.neoforge.capabilities.Capabilities.FluidHandler;
 import net.neoforged.neoforge.energy.IEnergyStorage;
@@ -129,7 +127,9 @@ public class FluidPumpBlockEntity extends IEBaseBlockEntity implements IEServerT
 				if(sideConfig.get(f)==IOSideConfig.INPUT)
 				{
 					IFluidHandler input = blockFluidHandlers.get(f).getCapability();
-					List<Entity> entities;
+					// attempt to find an adjacent entity fluid handler
+					if(input==null)
+						input = getEntityFluidHandler(f);
 					if(input!=null)
 					{
 						int drainAmount = IFluidPipe.getTransferableAmount(this.canOutputPressurized(false));
@@ -138,21 +138,6 @@ public class FluidPumpBlockEntity extends IEBaseBlockEntity implements IEServerT
 							continue;
 						int out = this.outputFluid(drain, FluidAction.EXECUTE);
 						input.drain(out, FluidAction.EXECUTE);
-					}
-					else if (!(entities=level.getEntities(null, new AABB(getBlockPos().relative(f)))).isEmpty())
-					{
-						for (Entity toCheck : entities) {
-							input = toCheck.getCapability(FluidHandler.ENTITY, f.getOpposite());
-							if (input!=null)
-							{
-								int drainAmount = IFluidPipe.getTransferableAmount(this.canOutputPressurized(false));
-								FluidStack drain = input.drain(drainAmount, FluidAction.SIMULATE);
-								if(drain.isEmpty())
-									continue;
-								int out = this.outputFluid(drain, FluidAction.EXECUTE);
-								input.drain(out, FluidAction.EXECUTE);
-							}
-						}
 					}
 					else
 						gatherInfiniteFluidFromWorld(f);
@@ -284,7 +269,6 @@ public class FluidPumpBlockEntity extends IEBaseBlockEntity implements IEServerT
 			if(sideConfig.get(f)==IOSideConfig.OUTPUT)
 			{
 				IFluidHandler handler = blockFluidHandlers.get(f).getCapability();
-				List<Entity> entities;
 				if(handler!=null)
 				{
 					// TODO check if there are bad BE assumptions here
@@ -299,19 +283,17 @@ public class FluidPumpBlockEntity extends IEBaseBlockEntity implements IEServerT
 						sum += temp;
 					}
 				}
-				else if (!(entities=level.getEntities(null, new AABB(getBlockPos().relative(f)))).isEmpty())
+				else
 				{
-					for (Entity toCheck : entities) {
-						handler = toCheck.getCapability(FluidHandler.ENTITY, f.getOpposite());
-						if (handler!=null)
+					handler = getEntityFluidHandler(f);
+					if(handler!=null)
+					{
+						FluidStack insertResource = Utils.copyFluidStackWithAmount(fs, fs.getAmount(), true);
+						int temp = handler.fill(insertResource, FluidAction.SIMULATE);
+						if(temp > 0)
 						{
-							FluidStack insertResource = Utils.copyFluidStackWithAmount(fs, fs.getAmount(), true);
-							int temp = handler.fill(insertResource, FluidAction.SIMULATE);
-							if(temp > 0)
-							{
-								sorting.put(new DirectionalFluidOutput(handler, f, null, worldPosition.relative(f)), temp);
-								sum += temp;
-							}
+							sorting.put(new DirectionalFluidOutput(handler, f, null, worldPosition.relative(f)), temp);
+							sum += temp;
 						}
 					}
 				}
@@ -341,6 +323,16 @@ public class FluidPumpBlockEntity extends IEBaseBlockEntity implements IEServerT
 			return f;
 		}
 		return 0;
+	}
+
+	@Nullable
+	private IFluidHandler getEntityFluidHandler(Direction direction)
+	{
+		return level.getEntities(null, new AABB(getBlockPos().relative(direction))).stream()
+				.map(entity -> entity.getCapability(FluidHandler.ENTITY, direction.getOpposite()))
+				.filter(Objects::nonNull)
+				.findFirst()
+				.orElse(null);
 	}
 
 

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/BarrelMinecartEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/BarrelMinecartEntity.java
@@ -26,13 +26,17 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.capabilities.Capabilities.FluidHandler;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidUtil;
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 
 import javax.annotation.Nonnull;
 import java.util.function.Supplier;
 
 public class BarrelMinecartEntity extends IEMinecartEntity<WoodenBarrelBlockEntity>
 {
+	public MinecartFluidHandler minecartFluidHandler = new MinecartFluidHandler(this);
+
 	public BarrelMinecartEntity(Level world, double x, double y, double z)
 	{
 		this(IEEntityTypes.BARREL_MINECART.get(), world, x, y, z);
@@ -51,7 +55,7 @@ public class BarrelMinecartEntity extends IEMinecartEntity<WoodenBarrelBlockEnti
 	public static <T extends BarrelMinecartEntity>
 	void registerCapabilities(RegisterCapabilitiesEvent ev, Supplier<EntityType<T>> type)
 	{
-		ev.registerEntity(FluidHandler.ENTITY, type.get(), (e, $) -> e.containedBlockEntity.tank);
+		ev.registerEntity(FluidHandler.ENTITY, type.get(), (e, $) -> e.minecartFluidHandler);
 	}
 
 	@Override
@@ -102,4 +106,67 @@ public class BarrelMinecartEntity extends IEMinecartEntity<WoodenBarrelBlockEnti
 		return IEBlocks.WoodenDevices.WOODEN_BARREL.defaultBlockState();
 	}
 
+
+	static class MinecartFluidHandler implements IFluidHandler
+	{
+		final BarrelMinecartEntity minecart;
+
+		public MinecartFluidHandler(BarrelMinecartEntity minecart)
+		{
+			this.minecart = minecart;
+		}
+
+		@Override
+		public int getTanks()
+		{
+			return 1;
+		}
+
+		@Override
+		public FluidStack getFluidInTank(int tank)
+		{
+			return this.minecart.containedBlockEntity.tank.getFluidInTank(tank);
+		}
+
+		@Override
+		public int getTankCapacity(int tank)
+		{
+			return this.minecart.containedBlockEntity.tank.getTankCapacity(tank);
+		}
+
+		@Override
+		public boolean isFluidValid(int tank, FluidStack stack)
+		{
+			return this.minecart.containedBlockEntity.tank.isFluidValid(tank, stack);
+		}
+
+		@Override
+		public int fill(FluidStack resource, FluidAction action)
+		{
+			int filled = this.minecart.containedBlockEntity.tank.fill(resource, action);
+			updateContainingEntity();
+			return filled;
+		}
+
+		@Override
+		public FluidStack drain(FluidStack resource, FluidAction action)
+		{
+			FluidStack drained = this.minecart.containedBlockEntity.tank.drain(resource, action);
+			updateContainingEntity();
+			return drained;
+		}
+
+		@Override
+		public FluidStack drain(int maxDrain, FluidAction action)
+		{
+			FluidStack drained = this.minecart.containedBlockEntity.tank.drain(maxDrain, action);
+			updateContainingEntity();
+			return drained;
+		}
+
+		private void updateContainingEntity()
+		{
+			this.minecart.updateSynchedData();
+		}
+	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/CrateMinecartEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/CrateMinecartEntity.java
@@ -54,7 +54,7 @@ public class CrateMinecartEntity extends IEMinecartEntity<WoodenCrateBlockEntity
 	public static <T extends CrateMinecartEntity>
 	void registerCapabilities(RegisterCapabilitiesEvent ev, Supplier<EntityType<T>> type)
 	{
-		ev.registerEntity(ItemHandler.ENTITY, type.get(), (e, $) -> e.containedBlockEntity.getInventoryCap());
+		ev.registerEntity(ItemHandler.ENTITY_AUTOMATION, type.get(), (e, $) -> e.containedBlockEntity.getInventoryCap());
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/IEMinecartEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/IEMinecartEntity.java
@@ -12,6 +12,9 @@ package blusunrize.immersiveengineering.common.entities;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IComparatorOverride;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IInteractionObjectIE;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -36,6 +39,7 @@ import java.util.function.Supplier;
 
 public abstract class IEMinecartEntity<T extends BlockEntity> extends AbstractMinecart implements MenuProvider
 {
+	private static final EntityDataAccessor<CompoundTag> DATA_ID_BE_DATA = SynchedEntityData.defineId(IEMinecartEntity.class, EntityDataSerializers.COMPOUND_TAG);
 	protected T containedBlockEntity;
 
 	protected IEMinecartEntity(EntityType<?> type, Level world, double x, double y, double z)
@@ -115,6 +119,14 @@ public abstract class IEMinecartEntity<T extends BlockEntity> extends AbstractMi
 	}
 
 	@Override
+	protected void defineSynchedData()
+	{
+		super.defineSynchedData();
+		this.entityData.define(DATA_ID_BE_DATA, new CompoundTag());
+	}
+
+
+	@Override
 	protected void addAdditionalSaveData(@Nonnull CompoundTag compound)
 	{
 		super.addAdditionalSaveData(compound);
@@ -131,6 +143,20 @@ public abstract class IEMinecartEntity<T extends BlockEntity> extends AbstractMi
 		super.readAdditionalSaveData(compound);
 		this.containedBlockEntity = getTileProvider().get();
 		this.containedBlockEntity.load(compound);
+		this.updateSynchedData();
+	}
+
+	public void updateSynchedData()
+	{
+		this.getEntityData().set(DATA_ID_BE_DATA, this.containedBlockEntity.saveWithoutMetadata());
+	}
+
+	@Override
+	public void onSyncedDataUpdated(EntityDataAccessor<?> p_38527_)
+	{
+		super.onSyncedDataUpdated(p_38527_);
+		if(DATA_ID_BE_DATA.equals(p_38527_))
+			this.containedBlockEntity.load(this.getEntityData().get(DATA_ID_BE_DATA));
 	}
 
 	// This is only used by the super impl of destroy, which does not allow attaching NBT to the drop. So it's actually

--- a/src/main/resources/assets/immersiveengineering/manual/en_us/fluid_pump.txt
+++ b/src/main/resources/assets/immersiveengineering/manual/en_us/fluid_pump.txt
@@ -1,8 +1,9 @@
 Fluid Pump
 The Pressure is On
-<&pump_recipe>Fluid Pumps are used to pressurize and move fluids, both within and without pipe systems.<br>
-Using the Engineer's Hammer on the bottom of the pump will change the face between input, output, and blocked.<br>
-When given a redstone signal, the fluid pump will extract from tanks at low power, moving fluid into the output for distribution.<br>
+<&pump_recipe>Fluid Pumps are used to move and pressurize fluids, both within and without pipe systems.<br>
+Fluids will only be pumped from <link;storage_barrels;fluid barrels> or <link;storage_minecarts;minecarts;fluid_storage> if the tank and pump have connections on that side.<br>
+Using the Engineer's Hammer on the faces of the lower half of the pump will change the connection between input, output, and blocked.<br>
+When given a redstone signal, the fluid pump will extract at low power, moving fluid into the output for distribution.<br>
 Providing a fluid pump with flux will engage the high pressure pump and will output the fluid at a significant boost in transfer rate.<br>
 When placed against pools of fluid in the world, pumps will suck up the fluid into their internal tank from their inputs. Water can be pumped in the same way it can be picked up with a bucket.<br>
 Fluids that are picked up will be replaced with cobblestone to the amount of flowing fluids in the world. This behavior can be toggled off and on by using an Engineer's Hammer on the pump's top while sneaking.


### PR DESCRIPTION
Means IE can do fluid/item IO into its minecarts. Currently no information in the fluid pump entry about this, need to add it. Closes #4377