### PR TITLE
Fix Transformers Being Worse Than Accumulators

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
@@ -167,7 +167,7 @@ public class EnergyTransferHandler extends LocalNetworkHandler implements IWorld
 					sources.put(cp, energyIIC);
 				if(energyIIC instanceof LimitingEnergyConnector limiting)
 					for(Connection c : localNet.getConnections(cp))
-						limits.put(c, Arrays.asList((double)limiting.getPowerLimit(), (double)limiting.getPowerLimit()));
+						limits.put(c, Arrays.asList(limiting.getPowerLimit(), limiting.getPowerLimit()));
 			}
 		}
 		for(Entry<ConnectionPoint, EnergyConnector> source : sources.entrySet())
@@ -432,7 +432,7 @@ public class EnergyTransferHandler extends LocalNetworkHandler implements IWorld
 
 	public interface LimitingEnergyConnector extends EnergyConnector
 	{
-		int getPowerLimit();
+		double getPowerLimit();
 	}
 
 	private record SinkPath(ConnectionPoint sinkCP, EnergyConnector sinkConnector, Path pathTo)

--- a/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
@@ -267,19 +267,19 @@ public class EnergyTransferHandler extends LocalNetworkHandler implements IWorld
 				double atSource = allowedFactor*entry.amount();
 				double availableFactor = 1;
 				ConnectionPoint currentPoint = sourceCp;
-				double availableRecent = atSource;
 				for(Connection c : path.conns)
 				{
 					currentPoint = c.getOtherEnd(currentPoint);
 					// We use exponential loss here so there is still some power at arbitrarily far distances
-					availableRecent*=(1-getBasicLoss(c));
+					availableFactor *= (1-getBasicLoss(c));
+					double availableAtPoint = atSource*availableFactor;
+					transferredNextTick.addTo(c, availableAtPoint);
 					if(!currentPoint.equals(path.end))
 					{
 						IImmersiveConnectable iic = localNet.getConnector(currentPoint);
 						if(iic instanceof EnergyConnector)
-							((EnergyConnector)iic).onEnergyPassedThrough(availableRecent);
+							((EnergyConnector)iic).onEnergyPassedThrough(availableAtPoint);
 					}
-					transferredNextTick.addTo(c, availableRecent);
 				}
 				entry.output.insertEnergy(ceilIfClose(atSource*availableFactor));
 			}

--- a/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
@@ -268,9 +268,8 @@ public class EnergyTransferHandler extends LocalNetworkHandler implements IWorld
 				double availableFactor = 1;
 				ConnectionPoint currentPoint = sourceCp;
 				double availableRecent = atSource;
-				for(int conn=0;conn<path.conns.length;conn++)
+				for(Connection c : path.conns)
 				{
-					Connection c = path.conns[conn];
 					currentPoint = c.getOtherEnd(currentPoint);
 					// We use exponential loss here so there is still some power at arbitrarily far distances
 					availableRecent*=(1-getBasicLoss(c));

--- a/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/wires/localhandlers/EnergyTransferHandler.java
@@ -273,9 +273,12 @@ public class EnergyTransferHandler extends LocalNetworkHandler implements IWorld
 					currentPoint = c.getOtherEnd(currentPoint);
 					// We use exponential loss here so there is still some power at arbitrarily far distances
 					availableRecent*=(1-getBasicLoss(c));
-					IImmersiveConnectable iic = localNet.getConnector(currentPoint);
-					if(!currentPoint.equals(path.end) && iic instanceof EnergyConnector connector)
-						connector.onEnergyPassedThrough(availableRecent);
+					if(!currentPoint.equals(path.end))
+					{
+						IImmersiveConnectable iic = localNet.getConnector(currentPoint);
+						if(iic instanceof EnergyConnector)
+							((EnergyConnector)iic).onEnergyPassedThrough(availableRecent);
+					}
 					transferredNextTick.addTo(c, availableRecent);
 				}
 				entry.output.insertEnergy(ceilIfClose(atSource*availableFactor));

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/AbstractTransformerBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/AbstractTransformerBlockEntity.java
@@ -9,10 +9,9 @@
 package blusunrize.immersiveengineering.common.blocks.metal;
 
 import blusunrize.immersiveengineering.api.IEProperties;
-import blusunrize.immersiveengineering.api.wires.Connection;
-import blusunrize.immersiveengineering.api.wires.ConnectionPoint;
-import blusunrize.immersiveengineering.api.wires.IImmersiveConnectable;
-import blusunrize.immersiveengineering.api.wires.WireType;
+import blusunrize.immersiveengineering.api.wires.*;
+import blusunrize.immersiveengineering.api.wires.localhandlers.EnergyTransferHandler.IEnergyWire;
+import blusunrize.immersiveengineering.api.wires.localhandlers.EnergyTransferHandler.LimitingEnergyConnector;
 import blusunrize.immersiveengineering.api.wires.utils.WireUtils;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces.IStateBasedDirectional;
 import blusunrize.immersiveengineering.common.blocks.generic.ImmersiveConnectableBlockEntity;
@@ -36,7 +35,7 @@ import java.util.Set;
 import static blusunrize.immersiveengineering.api.wires.WireType.MV_CATEGORY;
 
 public abstract class AbstractTransformerBlockEntity extends ImmersiveConnectableBlockEntity
-		implements IStateBasedDirectional
+		implements IStateBasedDirectional, LimitingEnergyConnector
 {
 	protected static final int RIGHT_INDEX = 0;
 	protected static final int LEFT_INDEX = 1;
@@ -73,6 +72,11 @@ public abstract class AbstractTransformerBlockEntity extends ImmersiveConnectabl
 	public String getHigherWiretype()
 	{
 		return MV_CATEGORY;
+	}
+
+	@Override
+	public int getPowerLimit() {
+		return Math.min(((IEnergyWire)leftType).getTransferRate(), ((IEnergyWire)rightType).getTransferRate());
 	}
 
 	@Override
@@ -176,5 +180,17 @@ public abstract class AbstractTransformerBlockEntity extends ImmersiveConnectabl
 
 	protected void updateMirrorState()
 	{
+	}
+
+	@Override
+	public boolean isSource(ConnectionPoint cp)
+	{
+		return false;
+	}
+
+	@Override
+	public boolean isSink(ConnectionPoint cp)
+	{
+		return false;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/AbstractTransformerBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/AbstractTransformerBlockEntity.java
@@ -75,7 +75,7 @@ public abstract class AbstractTransformerBlockEntity extends ImmersiveConnectabl
 	}
 
 	@Override
-	public int getPowerLimit() {
+	public double getPowerLimit() {
 		if (leftType==null||rightType==null) return 0;
 		return Math.min(((IEnergyWire)leftType).getTransferRate(), ((IEnergyWire)rightType).getTransferRate());
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/AbstractTransformerBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/AbstractTransformerBlockEntity.java
@@ -9,7 +9,10 @@
 package blusunrize.immersiveengineering.common.blocks.metal;
 
 import blusunrize.immersiveengineering.api.IEProperties;
-import blusunrize.immersiveengineering.api.wires.*;
+import blusunrize.immersiveengineering.api.wires.Connection;
+import blusunrize.immersiveengineering.api.wires.ConnectionPoint;
+import blusunrize.immersiveengineering.api.wires.IImmersiveConnectable;
+import blusunrize.immersiveengineering.api.wires.WireType;
 import blusunrize.immersiveengineering.api.wires.localhandlers.EnergyTransferHandler.IEnergyWire;
 import blusunrize.immersiveengineering.api.wires.localhandlers.EnergyTransferHandler.LimitingEnergyConnector;
 import blusunrize.immersiveengineering.api.wires.utils.WireUtils;

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/AbstractTransformerBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/AbstractTransformerBlockEntity.java
@@ -76,6 +76,7 @@ public abstract class AbstractTransformerBlockEntity extends ImmersiveConnectabl
 
 	@Override
 	public int getPowerLimit() {
+		if (leftType==null||rightType==null) return 0;
 		return Math.min(((IEnergyWire)leftType).getTransferRate(), ((IEnergyWire)rightType).getTransferRate());
 	}
 


### PR DESCRIPTION
Currently, transformers do not limit energy flowing through them at all. This makes them strictly worse than accumulators as the player has no way of preventing overflow through transformers and thus is likely to burn wires.

This PR aims to fix that, registering transformers as limiting connections within the wire network, limited to the throughput of their lowest wire. This makes transformers _better_ than accumulators as they can handle ~8 times the throughput in a block that costs roughly the same to set up, and in minimal excess space.

Their limiting may be a little messy in some edge cases because the more performant setup I developed does not factor loss into the limit, assuming the limit is at the source and not nebulously some way past the source, but it _will_ make transformers more useful for stepping down.

Chaining transformers works, as well, the lowest transformer on a path will be used as the limit.

Fixes #5894, Fixes #5574