### PR TITLE
Fix for crash when rendering pipe/conveyors in minecolonies building tool

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFluidPipe.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityFluidPipe.java
@@ -520,6 +520,9 @@ public class TileEntityFluidPipe extends TileEntityIEBase implements IFluidPipe,
 		if(connections!=3&&connections!=12&&connections!=48)
 			return 1;
 		//		TileEntity con = world.getTileEntity(xCoord+(connection==4?-1: connection==5?1: 0),yCoord+(connection==0?-1: connection==1?1: 0),zCoord+(connection==2?-1: connection==3?1: 0));
+		if (world == null)
+			return 1;
+		
 		TileEntity con = world.getTileEntity(getPos().offset(EnumFacing.byIndex(connection)));
 		if(con instanceof TileEntityFluidPipe)
 		{

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorBasic.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorBasic.java
@@ -13,6 +13,7 @@ import blusunrize.immersiveengineering.api.tool.ConveyorHandler.IConveyorBelt;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
 
 /**
  * @author BluSunrize - 20.08.2016
@@ -45,7 +46,10 @@ public class ConveyorBasic implements IConveyorBelt
 	@Override
 	public boolean isActive(TileEntity tile)
 	{
-		return tile.getWorld().getRedstonePowerFromNeighbors(tile.getPos()) <= 0;
+		World w = tile.getWorld();
+		if (w == null)
+			return true;
+		return w.getRedstonePowerFromNeighbors(tile.getPos()) <= 0;
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorVertical.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/conveyors/ConveyorVertical.java
@@ -32,6 +32,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraft.world.World;
 
 import javax.annotation.Nullable;
 import javax.vecmath.Matrix4f;
@@ -75,7 +76,10 @@ public class ConveyorVertical extends ConveyorBasic
 
 	boolean renderBottomBelt(TileEntity tile, EnumFacing facing)
 	{
-		TileEntity te = tile.getWorld().getTileEntity(tile.getPos().add(0, -1, 0));
+		World w = tile.getWorld();
+		if (w == null)
+			return false;
+		TileEntity te = w.getTileEntity(tile.getPos().add(0, -1, 0));
 		if(te instanceof IConveyorTile&&((IConveyorTile)te).getConveyorSubtype()!=null)
 			for(EnumFacing f : ((IConveyorTile)te).getConveyorSubtype().sigTransportDirections(te, ((IConveyorTile)te).getFacing()))
 				if(f==EnumFacing.UP)


### PR DESCRIPTION
the game always crashed when pipes are in a custom minecolonies structure. 
the check if world is null fixes that

Caused by: java.lang.NullPointerException
	at blusunrize.immersiveengineering.common.blocks.metal.TileEntityFluidPipe.getConnectionStyle(TileEntityFluidPipe.java:523)
	at blusunrize.immersiveengineering.common.blocks.metal.TileEntityFluidPipe.getRenderCacheKey(TileEntityFluidPipe.java:663)