### PR TITLE
Improve Utility of Gunpowder Barrel

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/render/entity/IEExplosiveRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/entity/IEExplosiveRenderer.java
@@ -8,10 +8,9 @@
 
 package blusunrize.immersiveengineering.client.render.entity;
 
-import blusunrize.immersiveengineering.common.entities.IEExplosiveEntity;
+import blusunrize.immersiveengineering.common.entities.GunpowderBarrelEntity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import org.joml.Quaternionf;
-import org.joml.Vector3f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
@@ -22,7 +21,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.inventory.InventoryMenu;
 
-public class IEExplosiveRenderer extends EntityRenderer<IEExplosiveEntity>
+public class IEExplosiveRenderer extends EntityRenderer<GunpowderBarrelEntity>
 {
 	public IEExplosiveRenderer(Context renderManager)
 	{
@@ -31,7 +30,7 @@ public class IEExplosiveRenderer extends EntityRenderer<IEExplosiveEntity>
 	}
 
 	@Override
-	public void render(IEExplosiveEntity entity, float entityYaw, float partialTicks, PoseStack matrixStackIn, MultiBufferSource bufferIn, int packedLightIn)
+	public void render(GunpowderBarrelEntity entity, float entityYaw, float partialTicks, PoseStack matrixStackIn, MultiBufferSource bufferIn, int packedLightIn)
 	{
 		if(entity.block==null)
 			return;
@@ -63,7 +62,7 @@ public class IEExplosiveRenderer extends EntityRenderer<IEExplosiveEntity>
 	}
 
 	@Override
-	public ResourceLocation getTextureLocation(IEExplosiveEntity entity)
+	public ResourceLocation getTextureLocation(GunpowderBarrelEntity entity)
 	{
 		return InventoryMenu.BLOCK_ATLAS;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/EventHandler.java
@@ -96,7 +96,6 @@ import java.util.function.Predicate;
 
 public class EventHandler
 {
-	public static Map<Level, Set<IEExplosion>> currentExplosions = new WeakHashMap<>();
 	public static final Queue<Runnable> SERVER_TASKS = new ArrayDeque<>();
 
 	@SubscribeEvent
@@ -174,19 +173,6 @@ public class EventHandler
 			Runnable next = SERVER_TASKS.poll();
 			if(next!=null)
 				next.run();
-		}
-
-		final Set<IEExplosion> explosionsInLevel = currentExplosions.get(event.level);
-		if(explosionsInLevel!=null)
-		{
-			Iterator<IEExplosion> itExplosion = explosionsInLevel.iterator();
-			while(itExplosion.hasNext())
-			{
-				IEExplosion ex = itExplosion.next();
-				ex.doExplosionTick();
-				if(ex.isExplosionFinished)
-					itExplosion.remove();
-			}
 		}
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/GunpowderBarrelBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/GunpowderBarrelBlock.java
@@ -51,9 +51,12 @@ public class GunpowderBarrelBlock extends TntBlock
 	@Override
 	public void onCaughtFire(BlockState state, Level world, BlockPos pos, @org.jetbrains.annotations.Nullable Direction face, @org.jetbrains.annotations.Nullable LivingEntity igniter)
 	{
-		GunpowderBarrelEntity explosive = spawnExplosive(world, pos, state, igniter);
-		world.playSound(null, explosive.getX(), explosive.getY(), explosive.getZ(), SoundEvents.TNT_PRIMED, SoundSource.BLOCKS, 1.0F, 1.0F);
-		world.removeBlock(pos, false);
+		if(!world.isClientSide)
+		{
+			GunpowderBarrelEntity explosive = spawnExplosive(world, pos, state, igniter);
+			world.playSound(null, explosive.getX(), explosive.getY(), explosive.getZ(), SoundEvents.TNT_PRIMED, SoundSource.BLOCKS, 1.0F, 1.0F);
+			world.removeBlock(pos, false);
+		}
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/GunpowderBarrelBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/GunpowderBarrelBlock.java
@@ -8,7 +8,7 @@
 
 package blusunrize.immersiveengineering.common.blocks.wooden;
 
-import blusunrize.immersiveengineering.common.entities.IEExplosiveEntity;
+import blusunrize.immersiveengineering.common.entities.GunpowderBarrelEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.sounds.SoundEvents;
@@ -51,7 +51,7 @@ public class GunpowderBarrelBlock extends TntBlock
 	@Override
 	public void onCaughtFire(BlockState state, Level world, BlockPos pos, @org.jetbrains.annotations.Nullable Direction face, @org.jetbrains.annotations.Nullable LivingEntity igniter)
 	{
-		IEExplosiveEntity explosive = spawnExplosive(world, pos, state, igniter);
+		GunpowderBarrelEntity explosive = spawnExplosive(world, pos, state, igniter);
 		world.playSound(null, explosive.getX(), explosive.getY(), explosive.getZ(), SoundEvents.TNT_PRIMED, SoundSource.BLOCKS, 1.0F, 1.0F);
 		world.removeBlock(pos, false);
 	}
@@ -62,15 +62,14 @@ public class GunpowderBarrelBlock extends TntBlock
 		super.onBlockExploded(state, world, pos, explosion);
 		if(!world.isClientSide)
 		{
-			IEExplosiveEntity explosive = spawnExplosive(world, pos, state, explosion.getIndirectSourceEntity());
+			GunpowderBarrelEntity explosive = spawnExplosive(world, pos, state, explosion.getIndirectSourceEntity());
 			explosive.setFuse((short)(world.random.nextInt(explosive.getFuse()/4)+explosive.getFuse()/8));
 		}
 	}
 
-	private IEExplosiveEntity spawnExplosive(Level world, BlockPos pos, BlockState state, @Nullable LivingEntity igniter)
+	private GunpowderBarrelEntity spawnExplosive(Level world, BlockPos pos, BlockState state, @Nullable LivingEntity igniter)
 	{
-		IEExplosiveEntity explosive = new IEExplosiveEntity(world, pos, igniter, state, 5);
-		explosive.setDropChance(1);
+		GunpowderBarrelEntity explosive = new GunpowderBarrelEntity(world, pos, igniter, state, 8);
 		world.addFreshEntity(explosive);
 		return explosive;
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
@@ -167,11 +167,12 @@ public class GunpowderBarrelEntity extends PrimedTnt
 		if(newFuse < 0)
 		{
 			this.discard();
-			Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY()+(getBbHeight()/16f), getZ(), isFlaming);
-			if(!EventHooks.onExplosionStart(level(), explosion))
-			{
-				explosion.explode();
-				explosion.finalizeExplosion(true);
+			if(!this.level().isClientSide()) {
+				Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY() + (getBbHeight() / 16f), getZ(), isFlaming);
+				if (!EventHooks.onExplosionStart(level(), explosion)) {
+					explosion.explode();
+					explosion.finalizeExplosion(true);
+				}
 			}
 		}
 		else

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
@@ -55,8 +55,6 @@ public class GunpowderBarrelEntity extends PrimedTnt
 	{
 		super(IEEntityTypes.EXPLOSIVE.get(), world);
 		this.setPos(pos.getX()+.5, pos.getY()+.5, pos.getZ()+.5);
-		double jumpingDirection = world.random.nextDouble()*2*Math.PI;
-		this.setDeltaMovement(-Math.sin(jumpingDirection)*0.02D, 0.2, -Math.cos(jumpingDirection)*0.02D);
 		this.setFuse(80);
 		this.xo = getX();
 		this.yo = getY();
@@ -168,7 +166,7 @@ public class GunpowderBarrelEntity extends PrimedTnt
 		{
 			this.discard();
 			if(!this.level().isClientSide()) {
-				Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY() + (getBbHeight() / 16f), getZ(), isFlaming);
+				Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY(), getZ(), isFlaming);
 				if (!EventHooks.onExplosionStart(level(), explosion)) {
 					explosion.explode();
 					explosion.finalizeExplosion(true);

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
@@ -9,7 +9,7 @@
 package blusunrize.immersiveengineering.common.entities;
 
 import blusunrize.immersiveengineering.common.register.IEEntityTypes;
-import blusunrize.immersiveengineering.common.util.IEExplosion;
+import blusunrize.immersiveengineering.common.util.DirectionalMiningExplosion;
 import blusunrize.immersiveengineering.mixin.accessors.TNTEntityAccess;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
@@ -35,24 +35,23 @@ import net.neoforged.neoforge.event.EventHooks;
 
 import javax.annotation.Nonnull;
 
-public class IEExplosiveEntity extends PrimedTnt
+public class GunpowderBarrelEntity extends PrimedTnt
 {
 	private float size;
 	private Explosion.BlockInteraction mode = BlockInteraction.DESTROY;
 	private boolean isFlaming = false;
-	private float explosionDropChance;
 	public BlockState block;
 	private Component name;
 
-	private static final EntityDataAccessor<BlockState> dataMarker_block = SynchedEntityData.defineId(IEExplosiveEntity.class, EntityDataSerializers.BLOCK_STATE);
-	private static final EntityDataAccessor<Integer> dataMarker_fuse = SynchedEntityData.defineId(IEExplosiveEntity.class, EntityDataSerializers.INT);
+	private static final EntityDataAccessor<BlockState> dataMarker_block = SynchedEntityData.defineId(GunpowderBarrelEntity.class, EntityDataSerializers.BLOCK_STATE);
+	private static final EntityDataAccessor<Integer> dataMarker_fuse = SynchedEntityData.defineId(GunpowderBarrelEntity.class, EntityDataSerializers.INT);
 
-	public IEExplosiveEntity(EntityType<IEExplosiveEntity> type, Level world)
+	public GunpowderBarrelEntity(EntityType<GunpowderBarrelEntity> type, Level world)
 	{
 		super(type, world);
 	}
 
-	public IEExplosiveEntity(Level world, BlockPos pos, LivingEntity igniter, BlockState blockstate, float size)
+	public GunpowderBarrelEntity(Level world, BlockPos pos, LivingEntity igniter, BlockState blockstate, float size)
 	{
 		super(IEEntityTypes.EXPLOSIVE.get(), world);
 		this.setPos(pos.getX()+.5, pos.getY()+.5, pos.getZ()+.5);
@@ -65,25 +64,18 @@ public class IEExplosiveEntity extends PrimedTnt
 		((TNTEntityAccess)this).setOwner(igniter);
 		this.size = size;
 		this.block = blockstate;
-		this.explosionDropChance = 1/size;
 		this.setBlockSynced();
 	}
 
-	public IEExplosiveEntity setMode(BlockInteraction smoke)
+	public GunpowderBarrelEntity setMode(BlockInteraction smoke)
 	{
 		this.mode = smoke;
 		return this;
 	}
 
-	public IEExplosiveEntity setFlaming(boolean fire)
+	public GunpowderBarrelEntity setFlaming(boolean fire)
 	{
 		this.isFlaming = fire;
-		return this;
-	}
-
-	public IEExplosiveEntity setDropChance(float chance)
-	{
-		this.explosionDropChance = chance;
 		return this;
 	}
 
@@ -175,9 +167,7 @@ public class IEExplosiveEntity extends PrimedTnt
 		if(newFuse <= 0)
 		{
 			this.discard();
-
-			Explosion explosion = new IEExplosion(level(), this, getX(), getY()+(getBbHeight()/16f), getZ(), size, isFlaming, mode)
-					.setDropChance(explosionDropChance);
+			Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY()+(getBbHeight()/16f), getZ(), size, isFlaming);
 			if(!EventHooks.onExplosionStart(level(), explosion))
 			{
 				explosion.explode();

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
@@ -167,7 +167,7 @@ public class GunpowderBarrelEntity extends PrimedTnt
 		if(newFuse < 0)
 		{
 			this.discard();
-			Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY()+(getBbHeight()/16f), getZ(), size, isFlaming);
+			Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY()+(getBbHeight()/16f), getZ(), isFlaming);
 			if(!EventHooks.onExplosionStart(level(), explosion))
 			{
 				explosion.explode();

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
@@ -164,7 +164,7 @@ public class GunpowderBarrelEntity extends PrimedTnt
 		}
 		int newFuse = this.getFuse()-1;
 		this.setFuse(newFuse);
-		if(newFuse <= 0)
+		if(newFuse < 0)
 		{
 			this.discard();
 			Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY()+(getBbHeight()/16f), getZ(), size, isFlaming);

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
@@ -165,12 +165,11 @@ public class GunpowderBarrelEntity extends PrimedTnt
 		if(newFuse < 0)
 		{
 			this.discard();
-			if(!this.level().isClientSide()) {
-				Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY(), getZ(), isFlaming);
-				if (!EventHooks.onExplosionStart(level(), explosion)) {
-					explosion.explode();
-					explosion.finalizeExplosion(true);
-				}
+			Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY(), getZ(), isFlaming);
+			if(!EventHooks.onExplosionStart(level(), explosion))
+			{
+				if(!this.level().isClientSide()) explosion.explode();
+				explosion.finalizeExplosion(true);
 			}
 		}
 		else

--- a/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/entities/GunpowderBarrelEntity.java
@@ -164,13 +164,13 @@ public class GunpowderBarrelEntity extends PrimedTnt
 		this.setFuse(newFuse);
 		if(newFuse < 0)
 		{
-			this.discard();
 			Explosion explosion = new DirectionalMiningExplosion(level(), this, getX(), getY(), getZ(), isFlaming);
 			if(!EventHooks.onExplosionStart(level(), explosion))
 			{
 				if(!this.level().isClientSide()) explosion.explode();
 				explosion.finalizeExplosion(true);
 			}
+			this.discard();
 		}
 		else
 		{

--- a/src/main/java/blusunrize/immersiveengineering/common/register/IEEntityTypes.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/register/IEEntityTypes.java
@@ -21,7 +21,6 @@ import net.minecraft.world.entity.MobCategory;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.core.Holder;
 
 import java.util.function.Supplier;
 
@@ -40,9 +39,9 @@ public class IEEntityTypes
 			() -> Builder.<FluorescentTubeEntity>of(FluorescentTubeEntity::new, MobCategory.MISC)
 					.sized(FluorescentTubeEntity.TUBE_LENGTH/2, 1+FluorescentTubeEntity.TUBE_LENGTH/2)
 	);
-	public static final DeferredHolder<EntityType<?>, EntityType<IEExplosiveEntity>> EXPLOSIVE = register(
+	public static final DeferredHolder<EntityType<?>, EntityType<GunpowderBarrelEntity>> EXPLOSIVE = register(
 			"explosive",
-			() -> Builder.<IEExplosiveEntity>of(IEExplosiveEntity::new, MobCategory.MISC)
+			() -> Builder.<GunpowderBarrelEntity>of(GunpowderBarrelEntity::new, MobCategory.MISC)
 					.fireImmune()
 					.sized(0.98F, 0.98F)
 	);

--- a/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
@@ -42,14 +42,14 @@ public class DirectionalMiningExplosion extends Explosion
 {
 	private static final int SIZE = 8;
 	private static final int SCAN = SIZE-1;
-	private static final float BLASTING_LENGTH = 150;
-	private static final float SUBSURFACE_LENGTH = 300;
+	private static final float BLASTING_LENGTH = 80;
+	private static final float SUBSURFACE_LENGTH = 175;
 	private static final int THIRD_VOLUME = (int)((1.0/3)*(4.0/3)*Math.PI*SIZE*SIZE*SIZE);
-	private static final int MIN_AIR = 3;
 	private static final float MAX_SHOCKWAVE_RESISTANCE = 0.4f;
 	private static final float MAX_SURFACE_RESISTANCE = 1.75f;
 	private static final float MAX_SUBSURFACE_RESISTANCE = 6f;
 	private static final float MAX_BLASTING_RESISTANCE = 25f;
+	private static final float BLASTING_SHAPING_RESISTANCE = 10000;
 
 	private final Level world;
 	private final DamageSource damageSource;
@@ -85,7 +85,8 @@ public class DirectionalMiningExplosion extends Explosion
 		// iteration to identify the basic characteristics of the explosion
 		// variables collated during the iteration
 		int totalBlocks = 0;
-		Vec3 openSpace =  new Vec3(0,0, 0);
+		float totalResistance = 0;
+		Vec3 weaknesses = new Vec3(0,0, 0);
 		BlockState cBlock;
 		FluidState cFluid;
 		// iterate over an area of size (2*(power-1)+1)^3 and collect the resistance of blocks in a sphere around our center
@@ -99,19 +100,21 @@ public class DirectionalMiningExplosion extends Explosion
 						cBlock = world.getBlockState(pos);
 						cFluid = world.getFluidState(pos);
 						if(!cBlock.isAir()||!cFluid.isEmpty())
-							totalBlocks+=1;
+						{
+							totalResistance += cBlock.getExplosionResistance(world, pos, this)+cFluid.getExplosionResistance(world, pos, this);
+							totalBlocks += 1;
+						}
 						if(cBlock.canBeReplaced()&&cFluid.isEmpty())
-							openSpace = openSpace.add(x == 0 ? 0 : 1.0 / x, y == 0 ? 0 : 1.0 / y, z == 0 ? 0 : 1.0 / z);
+							weaknesses = weaknesses.add(x == 0 ? 0 : 1.0 / x, y == 0 ? 0 : 1.0 / y, z == 0 ? 0 : 1.0 / z);
 					}
 				}
 		// establish the weakest direction and the length of the explosive step we should be taking
-		Vec3 step = openSpace.scale((0.5*SIZE+1-Math.sqrt(openSpace.length()/SIZE))/openSpace.length());
+		Vec3 step = weaknesses.scale((0.5*SIZE+1-Math.sqrt(weaknesses.length()/SIZE))/weaknesses.length());
 		// handle explosion based on criteria for explosions: either surface, subsurface, or blasting
-		int air = checkAir(centerBlock);
-		if(air<MIN_AIR&&openSpace.length()<BLASTING_LENGTH&&totalBlocks>=THIRD_VOLUME)
+		if(weaknesses.length()<BLASTING_LENGTH&&totalBlocks>=THIRD_VOLUME&&totalResistance<=BLASTING_SHAPING_RESISTANCE)
 			stagedExplosionDetonation(centerBlock, step, 0.4f * SIZE, 0.4f * SIZE, MAX_BLASTING_RESISTANCE, true);
-		else if(air<=MIN_AIR&&openSpace.length()<SUBSURFACE_LENGTH&&totalBlocks>=THIRD_VOLUME)
-			stagedExplosionDetonation(centerBlock, null, 3, SIZE*1.25f, MAX_SUBSURFACE_RESISTANCE, false);
+		else if(weaknesses.length()<SUBSURFACE_LENGTH&&totalBlocks>=THIRD_VOLUME)
+			stagedExplosionDetonation(centerBlock, null, 3, SIZE*1.375f, MAX_SUBSURFACE_RESISTANCE, false);
 		else
 			stagedExplosionDetonation(centerBlock, null, 2, SIZE*2, MAX_SURFACE_RESISTANCE, false);
 	}
@@ -237,14 +240,6 @@ public class DirectionalMiningExplosion extends Explosion
 				entity.hurt(damageSource, damage);
 				entity.setDeltaMovement(entity.getDeltaMovement().add(knockback/(x*x), knockback/(y*y), knockback/(z*z)));
 			}
-	}
-
-	private int checkAir(BlockPos pos)
-	{
-		int air = 0;
-		for (Direction direction : Direction.values())
-			air += world.getBlockState(pos.relative(direction)).getExplosionResistance(world, pos.relative(direction), this)<MAX_SHOCKWAVE_RESISTANCE?1:0;
-		return air;
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
@@ -65,7 +65,6 @@ public class DirectionalMiningExplosion extends Explosion
 		this.damageSource = world.damageSources().explosion(this);
 	}
 
-	@Override
 	/**
 	 * This method is the entry method for starting the explosion, and does most of the pre-explosion calculation to assess explosion dynamics.
 	 * First, a spherical area is scanned around the entity, and four properties are collected:
@@ -76,11 +75,12 @@ public class DirectionalMiningExplosion extends Explosion
 	 * These properties are then composed into a vector in which the explosion should propagate
 	 * Finally, a subtype (surface, subsurface, blasting) of explosion is selected based on these parameters, and DirectionalMiningExplosion#stagedExplosionDetonation() is called
 	 */
+	@Override
 	public void explode()
 	{
 		// variables used for the rest of the explosion
 		Vec3 center = center();
-		BlockPos centerBlock = new BlockPos((int)(center.x-0.5f), (int)(center.y-0.5f), (int)(center.z-0.5f));
+		BlockPos centerBlock = new BlockPos((int)(center.x-0.5f), (int)(center.y>0?(center.y+0.5f):(center.y-0.5f)), (int)(center.z-0.5f));
 		// iteration to identify the basic characteristics of the explosion
 		// variables collated during the iteration
 		int totalBlocks = 0;

--- a/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
@@ -17,7 +17,6 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.enchantment.ProtectionEnchantment;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.AABB;
@@ -37,6 +36,7 @@ public class DirectionalMiningExplosion extends Explosion
 	private static final float MAX_SUBSURFACE_RESISTANCE = 6f;
 	private static final float MAX_BLASTING_RESISTANCE = 25f;
 	private static final float BLASTING_SHAPING_RESISTANCE = 10000;
+	private static final int BASE_DAMAGE = (int)(0.375f*SIZE*SIZE*SIZE);
 
 	private final Level world;
 	private final DamageSource damageSource;
@@ -191,7 +191,10 @@ public class DirectionalMiningExplosion extends Explosion
 	}
 
 	/**
-	 * This code is copied and modified from the base explosion class because I don't care about fine-tuning it for a mining explosive
+	 * This code is copied and modified from the base explosion class because I don't care about fine-tuning the exact for a mining explosive
+	 * It ahs been partially modified to mostly fit the necessary parameters but is not rigorously defined like the other functions in this class
+	 * @param list List of entities to damage
+	 * @param intensity float intensity for the intensity of the shockwave
 	 */
 	private void damageEntities(List<Entity> list, float intensity)
 	{
@@ -205,17 +208,16 @@ public class DirectionalMiningExplosion extends Explosion
 				double z = entity.getZ()-center().z();
 				float length = (float)Math.sqrt(x*x+y*y+z*z);
 				if(length<intensity*SIZE) {
-					x = (x / length) * (x / length);
-					y = (y / length) * (y / length);
-					z = (z / length) * (z / length);
+					double x2 = (x / length);
+					double y2 = (y / length);
+					double z2 = (z / length);
 					// other useful variables
-					float exposed = getSeenPercent(center(), entity);
-					float damage = exposed * (float) ((SIZE * SIZE * SIZE) / (4 * Math.PI * length * length)) * intensity;
-					double knockback = (entity instanceof LivingEntity living) ? ProtectionEnchantment.getExplosionKnockbackAfterDampener(living, damage) : damage;
+					float damage = ((intensity*intensity*intensity)/(length * length)) * BASE_DAMAGE;
+					double knockback = Math.sqrt((entity instanceof LivingEntity living) ? ProtectionEnchantment.getExplosionKnockbackAfterDampener(living, damage) : damage);
 					// actually do damage & knockback
 					entity.hurt(damageSource, damage);
-					// TODO: Knockback was causing some lag issues, so was disabled. FIX!
-					//entity.setDeltaMovement(entity.getDeltaMovement().add(knockback / (x * x), knockback / (y * y), knockback / (z * z)));
+					entity.setDeltaMovement(entity.getDeltaMovement().add(org.joml.Math.clamp(-5f, 5f, x2*knockback), org.joml.Math.clamp(-5f, 5f, y2*knockback), org.joml.Math.clamp(-5f, 5f, z2*knockback)));
+					System.out.println(entity.getDeltaMovement().length());
 				}
 			}
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
@@ -96,7 +96,7 @@ public class DirectionalMiningExplosion extends Explosion
 						}
 						if (cBlock.canBeReplaced()&&cFluid.isEmpty()) {
 							weaknesses = weaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
-							blastWeaknesses = blastWeaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
+							if (length<SCAN-2) blastWeaknesses = blastWeaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
 						}
 					}
 				}
@@ -137,8 +137,8 @@ public class DirectionalMiningExplosion extends Explosion
 						scheduleBlockExplosion(center.offset(x, y, z), resistance, 0f);
 					else if (length<crater)
 						scheduleBlockExplosion(center.offset(x, y, z), resistance, 0.1f);
-					//else if(length<shock)
-						//scheduleBlockExplosion(center.offset(x, y, z), MAX_SHOCKWAVE_RESISTANCE, 0f);
+					else if(length<shock)
+						scheduleBlockExplosion(center.offset(x, y, z), MAX_SHOCKWAVE_RESISTANCE, 0f);
 				}
 		// handle entity damage from shockwave
 		List<Entity> damage = new ArrayList<>(world.getEntities(this.getDirectSourceEntity(),

--- a/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
@@ -94,11 +94,10 @@ public class DirectionalMiningExplosion extends Explosion
 							totalResistance += cBlock.getExplosionResistance(world, pos, this)+cFluid.getExplosionResistance(world, pos, this);
 							totalBlocks += 1;
 						}
-						if (cBlock.canBeReplaced()&&cFluid.isEmpty())
+						if (cBlock.canBeReplaced()&&cFluid.isEmpty()) {
 							weaknesses = weaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
-						if (length<SCAN-2 && (cBlock.canBeReplaced()&&cFluid.isEmpty())) blastWeaknesses = blastWeaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
-						/*if (length<SCAN-1) world.setBlockAndUpdate(centerBlock.offset(x, y, z), Blocks.BLUE_STAINED_GLASS.defaultBlockState());
-						else world.setBlockAndUpdate(centerBlock.offset(x, y, z), Blocks.LIME_STAINED_GLASS.defaultBlockState());*/
+							blastWeaknesses = blastWeaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
+						}
 					}
 				}
 		// establish the weakest direction and the length of the explosive step we should be taking

--- a/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.enchantment.ProtectionEnchantment;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.AABB;
@@ -73,29 +74,35 @@ public class DirectionalMiningExplosion extends Explosion
 		int totalBlocks = 0;
 		float totalResistance = 0;
 		Vec3 weaknesses = new Vec3(0,0, 0);
+		Vec3 blastWeaknesses = new Vec3(0,0, 0);
 		BlockState cBlock;
 		FluidState cFluid;
+		double length;
 		// iterate over an area of size (2*(power-1)+1)^3 and collect the resistance of blocks in a sphere around our center
 		for (int x=-SCAN;x<=SCAN;x++)
 			for (int y=-SCAN;y<=SCAN;y++)
 				for (int z=-SCAN;z<=SCAN;z++)
 				{
 					BlockPos pos = centerBlock.offset(x, y, z);
-					if (new Vec3(x, y, z).length()<=SCAN)
+					length = new Vec3(x, y, z).length();
+					if (length<=SCAN)
 					{
 						cBlock = world.getBlockState(pos);
 						cFluid = world.getFluidState(pos);
-						if(!cBlock.isAir()||!cFluid.isEmpty())
+						if (!cBlock.isAir()||!cFluid.isEmpty())
 						{
 							totalResistance += cBlock.getExplosionResistance(world, pos, this)+cFluid.getExplosionResistance(world, pos, this);
 							totalBlocks += 1;
 						}
-						if(cBlock.canBeReplaced()&&cFluid.isEmpty())
+						if (cBlock.canBeReplaced()&&cFluid.isEmpty())
 							weaknesses = weaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
+						if (length<SCAN-2 && (cBlock.canBeReplaced()&&cFluid.isEmpty())) blastWeaknesses = blastWeaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
+						/*if (length<SCAN-1) world.setBlockAndUpdate(centerBlock.offset(x, y, z), Blocks.BLUE_STAINED_GLASS.defaultBlockState());
+						else world.setBlockAndUpdate(centerBlock.offset(x, y, z), Blocks.LIME_STAINED_GLASS.defaultBlockState());*/
 					}
 				}
 		// establish the weakest direction and the length of the explosive step we should be taking
-		Vec3 step = weaknesses.scale((0.5*SIZE+1-Math.sqrt(weaknesses.length()/SIZE))/weaknesses.length());
+		Vec3 step = blastWeaknesses.scale((0.5*SIZE+1-Math.sqrt(blastWeaknesses.length()/SIZE))/blastWeaknesses.length());
 		// handle explosion based on criteria for explosions: either surface, subsurface, or blasting
 		if(weaknesses.length()<BLASTING_LENGTH&&totalBlocks>=THIRD_VOLUME&&totalResistance<=BLASTING_SHAPING_RESISTANCE)
 			stagedExplosionDetonation(centerBlock, step, 0.4f * SIZE, 0.4f * SIZE, MAX_BLASTING_RESISTANCE, true);
@@ -118,6 +125,8 @@ public class DirectionalMiningExplosion extends Explosion
 	 */
 	private void stagedExplosionDetonation(BlockPos center, Vec3 step, float crater, float shockwave, float resistance, boolean blasting)
 	{
+		// clear toBlow in case it has blocks still in it
+		this.clearToBlow();
 		// handle shockwave and crater block damage that come with any explosion
 		int shock = (int)shockwave;
 		for(int x = -shock; x <= shock; x++)
@@ -129,8 +138,8 @@ public class DirectionalMiningExplosion extends Explosion
 						scheduleBlockExplosion(center.offset(x, y, z), resistance, 0f);
 					else if (length<crater)
 						scheduleBlockExplosion(center.offset(x, y, z), resistance, 0.1f);
-					else if(length<shock)
-						scheduleBlockExplosion(center.offset(x, y, z), MAX_SHOCKWAVE_RESISTANCE, 0f);
+					//else if(length<shock)
+						//scheduleBlockExplosion(center.offset(x, y, z), MAX_SHOCKWAVE_RESISTANCE, 0f);
 				}
 		// handle entity damage from shockwave
 		List<Entity> damage = new ArrayList<>(world.getEntities(this.getDirectSourceEntity(),
@@ -206,7 +215,8 @@ public class DirectionalMiningExplosion extends Explosion
 					double knockback = (entity instanceof LivingEntity living) ? ProtectionEnchantment.getExplosionKnockbackAfterDampener(living, damage) : damage;
 					// actually do damage & knockback
 					entity.hurt(damageSource, damage);
-					entity.setDeltaMovement(entity.getDeltaMovement().add(knockback / (x * x), knockback / (y * y), knockback / (z * z)));
+					// TODO: Knockback was causing some lag issues, so was disabled. FIX!
+					//entity.setDeltaMovement(entity.getDeltaMovement().add(knockback / (x * x), knockback / (y * y), knockback / (z * z)));
 				}
 			}
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
@@ -9,29 +9,16 @@
 package blusunrize.immersiveengineering.common.util;
 
 import blusunrize.immersiveengineering.api.ApiUtils;
-import blusunrize.immersiveengineering.mixin.accessors.ExplosionAccess;
-import com.mojang.datafixers.util.Pair;
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.particles.ParticleTypes;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.ProtectionEnchantment;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.storage.loot.LootParams;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
@@ -60,7 +47,7 @@ public class DirectionalMiningExplosion extends Explosion
 	 */
 	public DirectionalMiningExplosion(Level world, Entity igniter, double x, double y, double z, boolean isFlaming)
 	{
-		super(world, igniter, x, y, z, SIZE, isFlaming, BlockInteraction.KEEP);
+		super(world, igniter, x, y, z, SIZE, isFlaming, BlockInteraction.DESTROY);
 		this.world = world;
 		this.damageSource = world.damageSources().explosion(this);
 	}
@@ -139,11 +126,11 @@ public class DirectionalMiningExplosion extends Explosion
 				{
 					double length = Math.sqrt(x*x+y*y+z*z);
 					if (length<crater-0.9f)
-						removeExplodedBlock(center.offset(x, y, z), resistance, 0f);
+						scheduleBlockExplosion(center.offset(x, y, z), resistance, 0f);
 					else if (length<crater)
-						removeExplodedBlock(center.offset(x, y, z), resistance, 0.1f);
+						scheduleBlockExplosion(center.offset(x, y, z), resistance, 0.1f);
 					else if(length<shock)
-						removeExplodedBlock(center.offset(x, y, z), MAX_SHOCKWAVE_RESISTANCE, 0f);
+						scheduleBlockExplosion(center.offset(x, y, z), MAX_SHOCKWAVE_RESISTANCE, 0f);
 				}
 		// handle entity damage from shockwave
 		List<Entity> damage = new ArrayList<>(world.getEntities(this.getDirectSourceEntity(),
@@ -162,9 +149,9 @@ public class DirectionalMiningExplosion extends Explosion
 					{
 						int length = (int)Math.sqrt(x*x+y*y+z*z);
 						if (length<blast1-0.9f)
-							removeExplodedBlock(centerOffset.offset(x, y, z), resistance, 0f);
+							scheduleBlockExplosion(centerOffset.offset(x, y, z), resistance, 0f);
 						else if (length<blast1)
-							removeExplodedBlock(centerOffset.offset(x, y, z), resistance, 0.1f);
+							scheduleBlockExplosion(centerOffset.offset(x, y, z), resistance, 0.1f);
 					}
 			// second explosion propagation sphere
 			centerOffset = center.offset((int)step.x()*2, (int)step.y()*2, (int)step.z()*2);
@@ -175,42 +162,24 @@ public class DirectionalMiningExplosion extends Explosion
 					{
 						int length = (int)Math.sqrt(x*x+y*y+z*z);
 						if (length<blast2-0.9f)
-							removeExplodedBlock(centerOffset.offset(x, y, z), resistance, 0f);
+							scheduleBlockExplosion(centerOffset.offset(x, y, z), resistance, 0f);
 						else if (length<blast2)
-							removeExplodedBlock(centerOffset.offset(x, y, z), resistance, 0.1f);
+							scheduleBlockExplosion(centerOffset.offset(x, y, z), resistance, 0.1f);
 					}
 		}
 	}
 
 	/**
-	 * This method removes blocks that were exploded by a DirectionalMiningExplosion, including BEs and special blocks
-	 * BE drops are dropped alongside the other block drops, and are all popped without silk touch
+	 * This method queues up blocks to be destroyed in the super method Explosion#finalizeExplosion at a given chance & under a given resistance
 	 * @param pos BlockPos position at which to remove the block
 	 * @param resistance float maximum blast resistance that can be removed at this position
 	 * @param chance float chance not to remove the block
 	 */
-	private void removeExplodedBlock(BlockPos pos, float resistance, float chance)
+	private void scheduleBlockExplosion(BlockPos pos, float resistance, float chance)
 	{
-		ObjectArrayList<Pair<ItemStack, BlockPos>> objectarraylist = new ObjectArrayList<>();
 		BlockState state = this.world.getBlockState(pos);
-
 		if(!state.isAir()&&state.getExplosionResistance(world, pos, this)<=resistance&&ApiUtils.RANDOM.nextFloat()>chance)
-		{
-			if(this.world instanceof ServerLevel&&state.canDropFromExplosion(this.world, pos, this))
-			{
-				BlockEntity tile = this.world.getBlockEntity(pos);
-				LootParams.Builder lootCtx = new LootParams.Builder((ServerLevel)this.world)
-						.withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(pos))
-						.withParameter(LootContextParams.TOOL, ItemStack.EMPTY)
-						.withOptionalParameter(LootContextParams.BLOCK_ENTITY, tile);
-				state.getDrops(lootCtx).forEach((stack) -> {
-					ExplosionAccess.callAddOrAppendStack(objectarraylist, stack, pos);
-				});
-				state.onBlockExploded(world, pos, this);
-			}
-		}
-		for(Pair<ItemStack, BlockPos> pair : objectarraylist)
-			Block.popResource(this.world, pair.getSecond(), pair.getFirst());
+			this.getToBlow().add(pos);
 	}
 
 	/**
@@ -240,14 +209,5 @@ public class DirectionalMiningExplosion extends Explosion
 					entity.setDeltaMovement(entity.getDeltaMovement().add(knockback / (x * x), knockback / (y * y), knockback / (z * z)));
 				}
 			}
-	}
-
-	@Override
-	public void finalizeExplosion(boolean spawnParticles)
-	{
-		Vec3 pos = center();
-		if(this.world.isClientSide)
-			this.world.playLocalSound(pos.x, pos.y, pos.z, SoundEvents.GENERIC_EXPLODE, SoundSource.NEUTRAL, 4.0F, (1.0F+(ApiUtils.RANDOM.nextFloat()-ApiUtils.RANDOM.nextFloat())*0.2F)*0.7F, true);
-		this.world.addParticle(ParticleTypes.EXPLOSION_EMITTER, pos.x, pos.y, pos.z, 1.0D, 0.0D, 0.0D);
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/DirectionalMiningExplosion.java
@@ -13,7 +13,6 @@ import blusunrize.immersiveengineering.mixin.accessors.ExplosionAccess;
 import com.mojang.datafixers.util.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
@@ -105,7 +104,7 @@ public class DirectionalMiningExplosion extends Explosion
 							totalBlocks += 1;
 						}
 						if(cBlock.canBeReplaced()&&cFluid.isEmpty())
-							weaknesses = weaknesses.add(x == 0 ? 0 : 1.0 / x, y == 0 ? 0 : 1.0 / y, z == 0 ? 0 : 1.0 / z);
+							weaknesses = weaknesses.add(x==0?0: 1.0/x, y==0?0: 1.0/y, z==0?0: 1.0/z);
 					}
 				}
 		// establish the weakest direction and the length of the explosive step we should be taking
@@ -150,7 +149,6 @@ public class DirectionalMiningExplosion extends Explosion
 		List<Entity> damage = new ArrayList<>(world.getEntities(this.getDirectSourceEntity(),
 				new AABB(center.getX()-shock, center.getY()-shock, center.getZ()-shock,
 						 center.getX()+shock, center.getY()+shock, center.getZ()+shock)));
-		damage = damage.stream().filter(e -> center().distanceTo(e.position())<=shock).filter(e -> !(e instanceof ItemEntity)).toList();
 		damageEntities(damage, shockwave/SIZE);
 		// handle directional explosions that come with a buried explosive barrel
 		if(blasting)
@@ -185,7 +183,7 @@ public class DirectionalMiningExplosion extends Explosion
 	}
 
 	/**
-	 * This method removes a block that was exploded by a DirectionalMiningExplosion, including BEs and special blocks
+	 * This method removes blocks that were exploded by a DirectionalMiningExplosion, including BEs and special blocks
 	 * BE drops are dropped alongside the other block drops, and are all popped without silk touch
 	 * @param pos BlockPos position at which to remove the block
 	 * @param resistance float maximum blast resistance that can be removed at this position
@@ -215,30 +213,32 @@ public class DirectionalMiningExplosion extends Explosion
 			Block.popResource(this.world, pair.getSecond(), pair.getFirst());
 	}
 
-	/*
+	/**
 	 * This code is copied and modified from the base explosion class because I don't care about fine-tuning it for a mining explosive
 	 */
 	private void damageEntities(List<Entity> list, float intensity)
 	{
 		net.neoforged.neoforge.event.EventHooks.onExplosionDetonate(this.world, this, list, SIZE*2);
 		for(Entity entity : list)
-			if(!entity.ignoreExplosion(this))
+			if(!entity.ignoreExplosion(this)&&!(entity instanceof ItemEntity))
 			{
 				// relative distance
 				double x = entity.getX()-center().x();
 				double y = entity.getY()+entity.getBbHeight()/2-center().y();
 				double z = entity.getZ()-center().z();
 				float length = (float)Math.sqrt(x*x+y*y+z*z);
-				x = (x/length)*(x/length);
-				y = (y/length)*(y/length);
-				z = (z/length)*(z/length);
-				// other useful variables
-				float exposed = getSeenPercent(center(), entity);
-				float damage = exposed*(float)((SIZE*SIZE*SIZE)/(4*Math.PI*length*length))*intensity;
-				double knockback = (entity instanceof LivingEntity living)?ProtectionEnchantment.getExplosionKnockbackAfterDampener(living, damage): damage;
-				// actually do damage & knockback
-				entity.hurt(damageSource, damage);
-				entity.setDeltaMovement(entity.getDeltaMovement().add(knockback/(x*x), knockback/(y*y), knockback/(z*z)));
+				if(length<intensity*SIZE) {
+					x = (x / length) * (x / length);
+					y = (y / length) * (y / length);
+					z = (z / length) * (z / length);
+					// other useful variables
+					float exposed = getSeenPercent(center(), entity);
+					float damage = exposed * (float) ((SIZE * SIZE * SIZE) / (4 * Math.PI * length * length)) * intensity;
+					double knockback = (entity instanceof LivingEntity living) ? ProtectionEnchantment.getExplosionKnockbackAfterDampener(living, damage) : damage;
+					// actually do damage & knockback
+					entity.hurt(damageSource, damage);
+					entity.setDeltaMovement(entity.getDeltaMovement().add(knockback / (x * x), knockback / (y * y), knockback / (z * z)));
+				}
 			}
 	}
 


### PR DESCRIPTION
The intent of this PR is to make the gunpowder barrel a useful tool for dealing with large volumes of rock.

As a part of this PR, gunpowder barrels are:
 - Instant explosions once again
 - Directional explosions that are biased against the direction with the most "hardness"
 - More powerful than TNT because they are actual bombs and not "gunpowder mixed with sand"
 - Better for antipersonnel damage when on the surface, but better at breaking rocks when inside rock


Fixes #5904, Fixes #3692, Fixes #6068
