### PR TITLE
Significantly Improve Performance of Early Generators

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/render/tile/WatermillRenderer.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/render/tile/WatermillRenderer.java
@@ -46,7 +46,7 @@ public class WatermillRenderer extends IEBlockEntityRenderer<WatermillBlockEntit
 		transform.translate(.5, .5, .5);
 		if(tile.getFacing().getAxis()==Axis.X)
 			transform.mulPose(new Quaternionf().rotateY(Mth.HALF_PI));
-		float wheelRotation = Mth.TWO_PI*(tile.rotation+partialTicks*(float)tile.perTick);
+		float wheelRotation = (float)(Mth.TWO_PI*(tile.getRotation()+partialTicks*tile.getSpeed()));
 		transform.mulPose(new Quaternionf().rotateZ(wheelRotation));
 		transform.translate(-.5, -.5, -.5);
 		MODEL_BUFFER.render(RenderType.cutoutMipped(), combinedLightIn, combinedOverlayIn, bufferIn, transform);

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/ThermoelectricGenBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/ThermoelectricGenBlockEntity.java
@@ -61,7 +61,10 @@ public class ThermoelectricGenBlockEntity extends IEBaseBlockEntity implements I
 		{
 			IEnergyStorage forSide = energyWrappers.get(fd).getCapability();
 			if(forSide!=null)
+			{
 				amount -= forSide.receiveEnergy(amount, false);
+				if(amount<=0)return;
+			}
 		}
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/WatermillBlockEntity.java
@@ -106,7 +106,7 @@ public class WatermillBlockEntity extends IEBaseBlockEntity implements IEServerT
 	@Override
 	public void tickServer()
 	{
-		if(dynamo!=null&&dynamo.getCapability()!=null&&powerOut>0)
+		if(dynamo!=null&&powerOut>0&&dynamo.getCapability()!=null)
 		{
 			dynamo.getCapability().inputRotation(powerOut);
 			if(level.getGameTime()%1024==((getBlockPos().getX()^getBlockPos().getZ())&1023))


### PR DESCRIPTION
Improves thermoelectric generator performance by a minor amount, but the main meat is the waterwheel rewrite.

Waterwheels have an ~order of magnitude performance increase expected for flowing wheels, or ~50x for completely stationary wheels. This comes mainly from not checking the torque every tick, but instead on update.
Old code: [spark profile](https://spark.lucko.me/8mEnPoMrgN)    
New code, running estimate: [spark profile](https://spark.lucko.me/u7gMlCsCW7)    
New code, perfectly stationary: [spark profile](https://spark.lucko.me/3J7geZCtwN)    