### PR TITLE
Fix crash due to empty array

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/IEApi.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/IEApi.java
@@ -98,8 +98,9 @@ public class IEApi
 
 	public static ItemStack getPreferredStackbyMod(ItemStack[] array)
 	{
+		if (array.length == 0) throw new RuntimeException("Empty Array!");
 		return getPreferredElementbyMod(Arrays.stream(array), stack -> Registry.ITEM.getKey(stack.getItem()))
-				.orElseThrow(() -> new RuntimeException("Empty array?"));
+				.orElseThrow(() -> new RuntimeException("getPreferredElementbyMod did not return a valid ItemStack"));
 	}
 
 	public static boolean isAllowedInCrate(ItemStack stack)

--- a/src/api/java/blusunrize/immersiveengineering/api/crafting/IERecipeSerializer.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/crafting/IERecipeSerializer.java
@@ -49,6 +49,9 @@ public abstract class IERecipeSerializer<R extends Recipe<?>> implements RecipeS
 		if(outputObject.isJsonObject()&&outputObject.getAsJsonObject().has("item"))
 			return Lazy.of(() -> ShapedRecipe.itemStackFromJson(outputObject.getAsJsonObject()));
 		IngredientWithSize outgredient = IngredientWithSize.deserialize(outputObject);
+		if (outgredient.hasNoMatchingItems() || (outgredient.getMatchingStacks().length == 0)) {
+			throw new RuntimeException("Outgredient "+outgredient+" has no matching items");
+		}
 		return Lazy.of(() -> IEApi.getPreferredStackbyMod(outgredient.getMatchingStacks()));
 	}
 


### PR DESCRIPTION
This patch fixes https://github.com/BluSunrize/ImmersiveEngineering/issues/5290 , where the game will crash due to empty array passed to getPreferredStackbyMod.

The change is really simple, just by throwing an exception earlier in the chain, minecraft's server init logic is able to catch it and keep running. I'm not really 100% sure of the reason why, I just know that it works

This fix is particularly important for the pack I have recently released, Forever Factory, since it will always crash on world creation with the "Skyblock" preset, where with this patch, it never crashes.

**Steps to verify the PR fix:** 
1. Download [Forever Factory](https://www.curseforge.com/minecraft/modpacks/forever-factory)
2. Create new world, select "Skyblock" on world type
3. Observe the crash
4. Replace the IE jar with one compiled with this PR
5. Create new world again
6. World generates without crashing client

I am not sure if 1.19.2 is still supported, but I hope an exception can be made to fix this critical issue that strongly affects my modpack.

I am also open to further change requests if this PR is not satisfactory.

Have a nice day :)