### PR TITLE
Add missing potion recipes for Thick & Mundane potions

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/crafting/PotionHelper.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/crafting/PotionHelper.java
@@ -46,11 +46,10 @@ public class PotionHelper
 	{
 		// Vanilla
 		for(Mix<Potion> mixPredicate : PotionBrewingAccess.getConversions())
-			if(mixPredicate.to!=Potions.MUNDANE&&mixPredicate.to!=Potions.THICK)
-				out.apply(
-						mixPredicate.to, mixPredicate.from,
-						new IngredientWithSize(((PotionMixAccessor)mixPredicate).getIngredient())
-				);
+			out.apply(
+					mixPredicate.to, mixPredicate.from,
+					new IngredientWithSize(((PotionMixAccessor)mixPredicate).getIngredient())
+			);
 
 		// Modded
 		for(IBrewingRecipe recipe : BrewingRecipeRegistry.getRecipes())


### PR DESCRIPTION
Other mods sometimes use Mundane Potion, and I was thinking about using it as a solvent in PE at some point. It would be nice if it could be produced via the Mixer rather than having to add some other recipe for it.