### PR TITLE
Fix a crash caused by villager trades returning an air item

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/world/Villages.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/world/Villages.java
@@ -410,7 +410,7 @@ public class Villages
 		public MerchantOffer getOffer(@Nullable Entity trader, @Nonnull RandomSource rand)
 		{
 			ItemStack buying = this.lazyItem.apply(trader!=null?trader.level(): null);
-			return this.outline.generateOffer(buying, priceInfo, rand, maxUses, xp, priceMultiplier);
+			return buying.is(Items.AIR) ? null : this.outline.generateOffer(buying, priceInfo, rand, maxUses, xp, priceMultiplier);
 		}
 	}
 


### PR DESCRIPTION
This is a bandaid fix for #6123 #6109 to filter out air trades. Full fix should be to resolve the correct registry access.