### PR TITLE
[1.20]Fix ArrayOutOfBoundsException Caused By Parallel Mod Loading

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/utils/SetRestrictedField.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/utils/SetRestrictedField.java
@@ -89,7 +89,7 @@ public class SetRestrictedField<T>
 		private final List<Pair<Exception, SetRestrictedField<?>>> fields = new ArrayList<>();
 		private TrackerState state = TrackerState.OPEN;
 
-		<T> SetRestrictedField<T> make()
+		synchronized <T> SetRestrictedField<T> make()
 		{
 			Preconditions.checkState(state!=TrackerState.LOCKED);
 			SetRestrictedField<T> result = new SetRestrictedField<>(this);


### PR DESCRIPTION
Because of the parallel mod construct and loading, extension using api have a chance to load IE api classes at the same time as IE does, and there's a rare chance that the make method is called multithreaded, causing an ArrayOutOfBoundsException.