### PR TITLE
Fix #6125, floodlight fake lights disappearing as soon as placed

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/FakeLightBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/FakeLightBlock.java
@@ -96,8 +96,6 @@ public class FakeLightBlock extends IEEntityBlock<FakeLightBlockEntity>
 		public void onLoad()
 		{
 			super.onLoad();
-			if(floodlightCoords==null||!(Utils.getExistingTileEntity(level, floodlightCoords) instanceof FloodlightBlockEntity floodlight)||!floodlight.getIsActive())
-				level.removeBlock(getBlockPos(), false);
 			SpawnInterdictionHandler.addInterdictionTile(this);
 		}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/FakeLightBlock.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/FakeLightBlock.java
@@ -66,6 +66,7 @@ public class FakeLightBlock extends IEEntityBlock<FakeLightBlockEntity>
 	public static class FakeLightBlockEntity extends IEBaseBlockEntity implements ISpawnInterdiction
 	{
 		public BlockPos floodlightCoords = null;
+		public boolean firstTick = true;
 
 		public FakeLightBlockEntity(BlockPos pos, BlockState state)
 		{
@@ -96,7 +97,10 @@ public class FakeLightBlock extends IEEntityBlock<FakeLightBlockEntity>
 		public void onLoad()
 		{
 			super.onLoad();
-			SpawnInterdictionHandler.addInterdictionTile(this);
+			if(!firstTick&&(floodlightCoords==null||!(Utils.getExistingTileEntity(level, floodlightCoords) instanceof FloodlightBlockEntity floodlight)||!floodlight.getIsActive()))
+				level.removeBlock(getBlockPos(), false);
+			else
+				SpawnInterdictionHandler.addInterdictionTile(this);
 		}
 
 		@Override
@@ -113,6 +117,12 @@ public class FakeLightBlock extends IEEntityBlock<FakeLightBlockEntity>
 		{
 			if(floodlightCoords!=null)
 				nbt.put("floodlightCoords", NbtUtils.writeBlockPos(floodlightCoords));
+		}
+
+		public void setFloodlightCoords(BlockPos pos)
+		{
+			floodlightCoords = pos;
+			firstTick = false;
 		}
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/FloodlightBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/FloodlightBlockEntity.java
@@ -137,7 +137,7 @@ public class FloodlightBlockEntity extends ImmersiveConnectableBlockEntity imple
 				level.setBlock(cc, Misc.FAKE_LIGHT.defaultBlockState(), 2);
 				BlockEntity te = level.getBlockEntity(cc);
 				if(te instanceof FakeLightBlockEntity)
-					((FakeLightBlockEntity)te).floodlightCoords = getBlockPos();
+					((FakeLightBlockEntity)te).setFloodlightCoords(getBlockPos());
 				fakeLights.add(cc);
 				it.remove();
 			}


### PR DESCRIPTION
This makes sure floodlight blocks can't remove themselves _before_ the NBT is properly set on them