### PR TITLE
Fix Fluid Router GUI crash

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/gui/FluidSorterScreen.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/FluidSorterScreen.java
@@ -30,6 +30,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.FluidUtil;
@@ -155,7 +156,10 @@ public class FluidSorterScreen extends IEContainerScreen<FluidSorterMenu>
 		tag.putInt("filter_side", side);
 		tag.putInt("filter_slot", slot);
 		if(fluid!=null)
-			tag.put("filter", fluid.save(provider));
+			if(fluid == FluidStack.EMPTY || fluid.getFluid() == Fluids.EMPTY)
+				tag.remove("filter");
+			else
+				tag.put("filter", fluid.save(provider));
 		sendUpdateToServer(tag);
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/FluidSorterMenu.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/FluidSorterMenu.java
@@ -8,6 +8,7 @@
 
 package blusunrize.immersiveengineering.common.gui;
 
+import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.utils.DirectionUtils;
 import blusunrize.immersiveengineering.common.blocks.wooden.FluidSorterBlockEntity;
 import blusunrize.immersiveengineering.common.gui.sync.GenericContainerData;
@@ -16,11 +17,14 @@ import blusunrize.immersiveengineering.common.gui.sync.GetterAndSetter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.fml.LogicalSide;
+import net.neoforged.neoforge.common.util.LogicalSidedProvider;
 import net.neoforged.neoforge.fluids.FluidStack;
 
 import javax.annotation.Nonnull;
@@ -86,7 +90,8 @@ public class FluidSorterMenu extends IEContainerMenu
 			int side = message.getInt("filter_side");
 			int slot = message.getInt("filter_slot");
 			FluidStack newFilter = FluidStack.parseOptional(
-					Minecraft.getInstance().level.registryAccess(),
+					((MinecraftServer)LogicalSidedProvider.WORKQUEUE.get(LogicalSide.SERVER)).overworld()
+							.registryAccess(),
 					message.getCompound("filter")
 			);
 			if(!newFilter.isEmpty())

--- a/src/main/java/blusunrize/immersiveengineering/common/gui/FluidSorterMenu.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/gui/FluidSorterMenu.java
@@ -8,24 +8,20 @@
 
 package blusunrize.immersiveengineering.common.gui;
 
-import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.utils.DirectionUtils;
 import blusunrize.immersiveengineering.common.blocks.wooden.FluidSorterBlockEntity;
 import blusunrize.immersiveengineering.common.gui.sync.GenericContainerData;
 import blusunrize.immersiveengineering.common.gui.sync.GenericDataSerializers;
 import blusunrize.immersiveengineering.common.gui.sync.GetterAndSetter;
-import net.minecraft.client.Minecraft;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
-import net.neoforged.fml.LogicalSide;
-import net.neoforged.neoforge.common.util.LogicalSidedProvider;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -87,13 +83,11 @@ public class FluidSorterMenu extends IEContainerMenu
 		}
 		if(message.contains("filter_side", Tag.TAG_INT))
 		{
+			var currentServer = ServerLifecycleHooks.getCurrentServer();
+			if(null == currentServer) return;
 			int side = message.getInt("filter_side");
 			int slot = message.getInt("filter_slot");
-			FluidStack newFilter = FluidStack.parseOptional(
-					((MinecraftServer)LogicalSidedProvider.WORKQUEUE.get(LogicalSide.SERVER)).overworld()
-							.registryAccess(),
-					message.getCompound("filter")
-			);
+			FluidStack newFilter = FluidStack.parseOptional(currentServer.registryAccess(), message.getCompound("filter"));
 			if(!newFilter.isEmpty())
 				newFilter.setAmount(1); // Not strictly necessary, but also doesn't hurt
 			this.filters.get(side).get(slot).set(newFilter);


### PR DESCRIPTION
Fix #6172 by adding check for Empty fluid in `setFluidInSlot`
Fix Fluid Router not working on remote world (Multiplayer)
