### PR TITLE
Fix Diesel Generator burning fuel for too short of time, closes #6203

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/logic/DieselGeneratorLogic.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/logic/DieselGeneratorLogic.java
@@ -96,7 +96,7 @@ public class DieselGeneratorLogic
 					{
 						if(!active)
 							active = true;
-						state.consumeTick = 10*(int)(fluidConsumed/toConsume);
+						state.consumeTick = (int)(10*(fluidConsumed/toConsume));
 					}
 					else if(active)
 						active = false;


### PR DESCRIPTION
Fixes preemptive cast to int when calculating how long the generator should run on small amounts of fuel.

If the generator did not consume the full amount of `toConsume` then `state.consumeTick` would be truncated to 0, causing the generator to consume fuel again on the next tick.

Now the generator will calculate the correct amount of ticks to run for given a partial amount of fuel.

Fixes #6203 