### PR TITLE
Noisy tool cleanup

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/tool/INoisyTool.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/tool/INoisyTool.java
@@ -12,6 +12,9 @@ import net.minecraft.core.Holder;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.item.ItemStack;
 
+/**
+ * An interface for Items (not ItemStacks, that would be stupid), no guarantees if it is used for non-Items.
+ */
 public interface INoisyTool
 {
 	Holder<SoundEvent> getIdleSound(ItemStack stack);
@@ -22,7 +25,7 @@ public interface INoisyTool
 	 * Due to lacking information on sound duration, the duration is hard coded. Any Fading sounds need to be <b>more</b> than <b>1.0s</b> in duration.
 	 * The sound cuts off after <b>1.0s</b>, but a little bit of excess duration (>~0.01s) is required for the noisy tool sound stage machine to work correctly
 	 *
-	 * @param stack
+	 * @param stack The stack of the INoisyTool, makes the sound stack sensitive if desired.
 	 * @return fading sound
 	 */
 	Holder<SoundEvent> getFadingSound(ItemStack stack);
@@ -33,7 +36,7 @@ public interface INoisyTool
 	 * Having a too small excess duration leads to notable gaps in the audio when transitioning, which is why the default attack sounds have ~0.06s extra.
 	 * Cause they used to be 0.35s and then it caused issues.. Take heed ^^
 	 *
-	 * @param stack
+	 * @param stack The stack of the INoisyTool, makes the sound stack sensitive if desired.
 	 * @return attack sound
 	 */
 	Holder<SoundEvent> getAttackSound(ItemStack stack);
@@ -45,7 +48,7 @@ public interface INoisyTool
 	/**
 	 * Checks if the stack item is a NoisyTool and is able to make noise.
 	 *
-	 * @param stack
+	 * @param stack the ItemStack to check. May be any ItemStack.
 	 * @return true if the stack item is a NoisyTool and is able to make noise.
 	 */
 	static boolean isAbleNoisyTool(ItemStack stack)
@@ -62,8 +65,8 @@ public interface INoisyTool
 	 * <p>
 	 * This check also assumes, that it has already been checked and confirmed, that the stacks are not identical
 	 *
-	 * @param mainStack
-	 * @param otherStack
+	 * @param mainStack the main stack of the comparison. Selects the Item to compare against
+	 * @param otherStack the stack mainStack is compared against
 	 * @return true if stacks are considered the same stack. By default: if stacks  produce the same sounds.
 	 */
 	default boolean noisySameStack(ItemStack mainStack, ItemStack otherStack)

--- a/src/api/java/blusunrize/immersiveengineering/api/tool/INoisyTool.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/tool/INoisyTool.java
@@ -14,8 +14,6 @@ import net.minecraft.world.item.ItemStack;
 
 public interface INoisyTool
 {
-	static final float TEST_VOLUME_ADJUSTMENT = 1.0f; //TODO: temporary measure, remove after settling on a volume for the PR and re-adjusting the sounds themselves
-
 	Holder<SoundEvent> getIdleSound(ItemStack stack);
 
 	Holder<SoundEvent> getBusySound(ItemStack stack);
@@ -44,6 +42,12 @@ public interface INoisyTool
 
 	boolean ableToMakeNoise(ItemStack stack);
 
+	/**
+	 * Checks if the stack item is a NoisyTool and is able to make noise.
+	 *
+	 * @param stack
+	 * @return true if the stack item is a NoisyTool and is able to make noise.
+	 */
 	static boolean isAbleNoisyTool(ItemStack stack)
 	{
 		return stack.getItem() instanceof INoisyTool noisyTool&&noisyTool.ableToMakeNoise(stack);
@@ -53,9 +57,9 @@ public interface INoisyTool
 	 * When an ItemStack gets modified server side (i.e. takes damage, changes tags (i.e. uses fuel), etc.), it creates a new ItemStack on the client side.
 	 * There is no unreasonably involved way to check if the new ItemStack is actually just the old ItemStack, but modified.
 	 * So this for these cases, this default implementation checks the next best thing: Item equality and sound equality.
-	 *
+	 * <p>
 	 * It is encouraged to override this with a simpler check.
-	 *
+	 * <p>
 	 * This check also assumes, that it has already been checked and confirmed, that the stacks are not identical
 	 *
 	 * @param mainStack

--- a/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundGroup.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundGroup.java
@@ -71,11 +71,11 @@ public class NoisyToolSoundGroup
 
 	private boolean checkItemMatch(ItemStack handItemStack)
 	{
-		if (noisyToolStack == handItemStack)
+		if(noisyToolStack==handItemStack)
 		{
 			return true;
 		}
-		else if (noisyToolItem.noisySameStack(noisyToolStack, handItemStack))
+		else if(noisyToolItem.noisySameStack(noisyToolStack, handItemStack))
 		{
 			noisyToolStack = handItemStack;
 			return true;
@@ -103,18 +103,37 @@ public class NoisyToolSoundGroup
 		return switchMotorState(motorOn, false, true);
 	}
 
+	/**
+	 * @param motorOn
+	 * @param attack
+	 * @param propagate true if switching the motor state should propagate to updateHarvestState.
+	 *                  Do take care that calls to updateHarvestState from here don't create loops (i.e. set propagate to false in the call)
+	 * @return
+	 */
 	private boolean switchMotorState(boolean motorOn, boolean attack, boolean propagate)
 	{
-		ToolMotorState newMotorState = motorOn?
-				(attack?
-						ATTACK
-						: (currentTargetPos==null?
-						(currentMotorState==BUSY||currentMotorState==FADING?
-								FADING
-								: IDLE)
-						: BUSY))
-				: OFF;
+		ToolMotorState newMotorState;
+		if(motorOn)
+			if(attack)
+				newMotorState = ATTACK;
+			else if(currentTargetPos!=null)
+				newMotorState = BUSY;
+			else if(currentMotorState==BUSY||currentMotorState==FADING)
+				newMotorState = FADING;
+			else
+				newMotorState = IDLE;
+		else
+			newMotorState = OFF;
 
+		/**
+		 * don't do anything if
+		 * a) newMotorStats already currentMotorState AND newMotorState isn't ATTACK
+		 * 		->	simply keep playing the same sound, UNLESS it's an attack, then play a new attack sound
+		 * b) propagate is true and currentMotorState is ATTACK and newMotorState isn't ATTACK
+		 * 		->	currentMotorState ATTACK is a special case. It is generally left in NoisyToolMotorSoundFinite::updateCoordinates
+		 * 			HOWEVER, if propagate is false, this method was triggered by harvesting (i.e. updateHarvestState), so we DO continue in this method
+		 * 			and change currentMotorState, so the harvest sound runs along the motor busy sound, and not the motor attack sound
+		 */
 		if((currentMotorState==newMotorState||(propagate&&currentMotorState==ATTACK))&&newMotorState!=ATTACK)
 			return false;
 
@@ -137,7 +156,8 @@ public class NoisyToolSoundGroup
 				break;
 			case ATTACK:
 				if(propagate)
-					updateHarvestState(null, false); // todo: check if this is really necessary. Not that it hurts.
+					// this SHOULD already be updated implicitly by stopping harvesting (because you can't harvest while attacking), but better safe than sorry
+					updateHarvestState(null, false);
 				play(new NoisyToolMotorSoundFinite(noisyToolItem.getAttackSound(noisyToolStack).value(), newMotorState, ATTACK_DURATION));
 				break;
 		}
@@ -149,6 +169,12 @@ public class NoisyToolSoundGroup
 		return updateHarvestState(newTargetPos, true);
 	}
 
+	/**
+	 * @param newTargetPos
+	 * @param propagate    true if updating the HarvestState should propagate to switchMotorState
+	 *                     Do take care that calls to updateHarvestState from here don't create loops (i.e. set propagate to false in the call)
+	 * @return
+	 */
 	private boolean updateHarvestState(@Nullable BlockPos newTargetPos, boolean propagate)
 	{
 		groupLastTickHelper = noisyToolHolder.level().getGameTime();
@@ -192,13 +218,19 @@ public class NoisyToolSoundGroup
 		{
 			super(sound);
 
-			this.x = noisyToolHolder.getX();
-			this.y = noisyToolHolder.getY()+0.5d; //todo: get tool coordinates?
-			this.z = noisyToolHolder.getZ();
+			updateCoordinates();
 			this.state = state;
-			this.volume = INoisyTool.TEST_VOLUME_ADJUSTMENT; //TODO: remove me
 		}
 
+		/**
+		 * This is just a very dumb, but quick and easy approximation of the tool position. Which is fine 99.9% of the time.
+		 * Notably it is even less accurate during diving or elytra flight, basically anytime where the player is not upright.
+		 * Also might mess with mods that mess with player scale/positioning?
+		 * It's possible to get the actual tool coordinates from the renderer,
+		 * but that would require a bunch of extra handling and tracking for generally very little gain.
+		 * Plus it might just be aggravating in first person. Or super awesome.
+		 * I'll leave it as a TODO.
+		 */
 		protected void updateCoordinates()
 		{
 			this.x = noisyToolHolder.getX();
@@ -274,7 +306,6 @@ public class NoisyToolSoundGroup
 			this.y = targetBlockPos.getY()+0.5d;
 			this.z = targetBlockPos.getZ()+0.5d;
 			this.looping = true;
-			this.volume = INoisyTool.TEST_VOLUME_ADJUSTMENT; //TODO: remove me
 		}
 
 		@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundGroup.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundGroup.java
@@ -104,11 +104,11 @@ public class NoisyToolSoundGroup
 	}
 
 	/**
-	 * @param motorOn
-	 * @param attack
+	 * @param motorOn   true if the motor is supposed to be on.
+	 * @param attack    true if there is supposed to be an attack. Currently irrelevant if the motor isn't on.
 	 * @param propagate true if switching the motor state should propagate to updateHarvestState.
 	 *                  Do take care that calls to updateHarvestState from here don't create loops (i.e. set propagate to false in the call)
-	 * @return
+	 * @return true if a new motor sound has been played. This is generally the case when the currenMotorState changes, but for more detail see the comments in the code.
 	 */
 	private boolean switchMotorState(boolean motorOn, boolean attack, boolean propagate)
 	{
@@ -125,7 +125,7 @@ public class NoisyToolSoundGroup
 		else
 			newMotorState = OFF;
 
-		/**
+		/*
 		 * don't do anything if
 		 * a) newMotorStats already currentMotorState AND newMotorState isn't ATTACK
 		 * 		->	simply keep playing the same sound, UNLESS it's an attack, then play a new attack sound
@@ -170,10 +170,10 @@ public class NoisyToolSoundGroup
 	}
 
 	/**
-	 * @param newTargetPos
+	 * @param newTargetPos the new target block for the harvest sound. Nullable, to shut off the harvest sound (see NoisyToolHarvestSound::tick).
 	 * @param propagate    true if updating the HarvestState should propagate to switchMotorState
 	 *                     Do take care that calls to updateHarvestState from here don't create loops (i.e. set propagate to false in the call)
-	 * @return
+	 * @return true if currentTargetPos changed, even if to null.
 	 */
 	private boolean updateHarvestState(@Nullable BlockPos newTargetPos, boolean propagate)
 	{

--- a/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundHandler.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.EventBusSubscriber.Bus;
@@ -125,10 +126,10 @@ public class NoisyToolSoundHandler
 			ntsg.triggerAttack();
 	}
 
-	@SubscribeEvent
+	@SubscribeEvent // event not cancelable, so no issues
 	public static void toolHeldCheck(Post ev)
 	{
-		if(ev.getEntity() instanceof LivingEntity noisyToolHolder) //todo
+		if(ev.getEntity() instanceof LivingEntity noisyToolHolder)
 		{
 			if(!noisyToolHolder.level().isClientSide()) // client side only
 				return;
@@ -143,7 +144,7 @@ public class NoisyToolSoundHandler
 		}
 	}
 
-	@SubscribeEvent
+	@SubscribeEvent(priority = EventPriority.LOWEST) //lowest priority, because if the event got cancelled, we don't wanna play the sound
 	public static void harvestCheck(LeftClickBlock ev)
 	{
 		if(INoisyTool.isAbleNoisyTool(ev.getItemStack()))
@@ -165,17 +166,21 @@ public class NoisyToolSoundHandler
 		}
 	}
 
-	@SubscribeEvent
+	@OnlyIn(Dist.CLIENT)
+	@SubscribeEvent(priority = EventPriority.LOWEST) //lowest priority, because if the event got cancelled, we don't wanna play the sound
 	public static void clientSideAttackCheck(AttackEntityEvent ev)
 	{
-		Player player = ev.getEntity();
-		if (INoisyTool.isAbleNoisyTool(player.getItemBySlot(EquipmentSlot.MAINHAND)))
+		if(ev.getTarget() instanceof LivingEntity) // a) for parity with LivingIncomingDamageEvent, b) MCs extra attack sounds also only happen on LivingEntities
 		{
-			handleAttack(player);
+			Player player = ev.getEntity();
+			if(player.level().isClientSide()&&INoisyTool.isAbleNoisyTool(player.getItemBySlot(EquipmentSlot.MAINHAND)))
+			{
+				handleAttack(player);
+			}
 		}
 	}
 
-	@SubscribeEvent
+	@SubscribeEvent(priority = EventPriority.HIGHEST) //highest priority, because if the damage get's cancelled, it still was an attack
 	public static void serverSideAttackCheck(LivingIncomingDamageEvent ev)
 	{
 		// no null check for ev.getSource, because ev.getSource() is never null according to intelliJ: "Method 'getSource' inherits container annotation, thus 'non-null'"
@@ -208,7 +213,15 @@ public class NoisyToolSoundHandler
 		}
 	}
 
-	@OnlyIn(Dist.CLIENT)
+	/**
+	 * Clear the list when exiting a level so it doesn't get carried over into other levels.
+	 * Currently it is not checked if entities in the list still are tracked in game, they are only removed when they stop being tracked.
+	 * This means better cleaning up when the player leaves the level, just to be sure no trash accumulates.
+	 * <p>
+	 * Also, left in server side, too, for safety, even though the server shouldn't build up any nTSGs anyways.
+	 *
+	 * @param ev
+	 */
 	@SubscribeEvent
 	public static void leaveLevel(Unload ev)
 	{

--- a/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundHandler.java
@@ -21,7 +21,6 @@ import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.LogicalSide;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.EventBusSubscriber.Bus;
 import net.neoforged.neoforge.event.entity.EntityLeaveLevelEvent;
@@ -59,7 +58,7 @@ public class NoisyToolSoundHandler
 	/**
 	 * For the given entity and slot: creates or returns an existing sound group, or null, if there should be none.
 	 * Turns off sound groups that are obsolete and removes them from the mapping.
-	 * This should generally be the only point where NoisyToolSoundGroups are accessed through.
+	 * This should generally be the only point through which NoisyToolSoundGroups are accessed.
 	 *
 	 * @param entity
 	 * @param slot
@@ -150,7 +149,7 @@ public class NoisyToolSoundHandler
 		if(INoisyTool.isAbleNoisyTool(ev.getItemStack()))
 		{
 			LivingEntity noisyToolHolder = ev.getEntity();
-			if(noisyToolHolder instanceof Player player&&player.isCreative()) // skip for creative players, remote creative players don't send stop/abort on block break
+			if(noisyToolHolder instanceof Player player&&player.isCreative()) // skip for creative players, because remote creative players don't send stop/abort on block break
 			{
 				return;
 			}
@@ -179,7 +178,7 @@ public class NoisyToolSoundHandler
 	@SubscribeEvent
 	public static void serverSideAttackCheck(LivingIncomingDamageEvent ev)
 	{
-		// ev.getSource() is never null according to intelliJ: "Method 'getSource' inherits container annotation, thus 'non-null'"
+		// no null check for ev.getSource, because ev.getSource() is never null according to intelliJ: "Method 'getSource' inherits container annotation, thus 'non-null'"
 		// All I see are final fields and no annotations, but should be the same thing.
 		// if stuff burns some day down the line because that changes, here's a place to check, I guess
 		if(ev.getSource().getEntity() instanceof LivingEntity noisyToolHolder&&INoisyTool.isAbleNoisyTool(noisyToolHolder.getItemBySlot(EquipmentSlot.MAINHAND)))

--- a/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundHandler.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/sound/NoisyToolSoundHandler.java
@@ -41,7 +41,7 @@ import static blusunrize.immersiveengineering.ImmersiveEngineering.MODID;
 @EventBusSubscriber(modid = MODID, bus = Bus.GAME)
 public class NoisyToolSoundHandler
 {
-	private static Map<LivingEntity, Map<EquipmentSlot, NoisyToolSoundGroup>> noisyToolSoundGroups = new HashMap<>();
+	private static final Map<LivingEntity, Map<EquipmentSlot, NoisyToolSoundGroup>> noisyToolSoundGroups = new HashMap<>();
 
 	private static Map<EquipmentSlot, NoisyToolSoundGroup> getSafeNTSGs(LivingEntity entity)
 	{
@@ -61,8 +61,8 @@ public class NoisyToolSoundHandler
 	 * Turns off sound groups that are obsolete and removes them from the mapping.
 	 * This should generally be the only point through which NoisyToolSoundGroups are accessed.
 	 *
-	 * @param entity
-	 * @param slot
+	 * @param entity the entity that's supposed to receive a NTSG
+	 * @param slot the entities EquipmentSlot. <b>Must</b> be a Type.HAND type
 	 * @return a NoisyToolSoundGroup for the given slot or null, if the provided slot does not hold a suitable item
 	 */
 	@Nullable
@@ -197,7 +197,9 @@ public class NoisyToolSoundHandler
 	 * handles stopping the sound instances and unlisting the sound group when the entity is removed
 	 * consider checking entity.isRemoved() in the ticking sound instances (see MinecartSoundInstance.tick())
 	 *
-	 * @param ev
+	 * only handled clientside because the server shouldn't have any NTSGS to begin with.
+	 *
+	 * @param ev the EntityLeaveLevelEvent event
 	 */
 	@OnlyIn(Dist.CLIENT)
 	@SubscribeEvent
@@ -218,9 +220,9 @@ public class NoisyToolSoundHandler
 	 * Currently it is not checked if entities in the list still are tracked in game, they are only removed when they stop being tracked.
 	 * This means better cleaning up when the player leaves the level, just to be sure no trash accumulates.
 	 * <p>
-	 * Also, left in server side, too, for safety, even though the server shouldn't build up any nTSGs anyways.
+	 * Also, left in server side, too, for safety, even though the server shouldn't build up any NTSGs anyways.
 	 *
-	 * @param ev
+	 * @param ev the Unload event
 	 */
 	@SubscribeEvent
 	public static void leaveLevel(Unload ev)


### PR DESCRIPTION
Gave the recently pulled code for NoisyTools a clean-up pass to get rid of in-dev code and add a bunch of comments so next time someone has to look at this, they don't have to break their brain quite so much.
Fixed some minor issues along the way.