### PR TITLE
Patching a (non)critical exploit with the coke oven

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/logic/CokeOvenLogic.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/multiblocks/logic/CokeOvenLogic.java
@@ -83,6 +83,7 @@ public class CokeOvenLogic implements IMultiblockLogic<State>, IServerTickableCo
 			{
 				state.process = 0;
 				state.processMax = 0;
+				active = false;
 			}
 			else
 			{


### PR DESCRIPTION
Patches a (non)critical exploit that allowed the player to ignore the process timer for the coke oven.

# Bug Report

Thanks to Muddykat for producing this video and steps to reproduce.

(As noted by others, the video is a dead link now, so I removed it. I'll do better for the next time, as it doesn't really need to be replaced now.)

**Steps to Reproduce:**
1. Insert a valid item into the Coke Oven.
2. Remove it and insert a new valid item within one tick (using hotkeys or hoppers).
3. The oven consumes the item and produces the output instantly.

**Expected:**
Recipe progress should reset with new input, and processing should take the intended duration.

**Actual:**
Recipe completes instantly using the new input.

Here's my own analysis of what's happening here, based on some logs I set up, broken up by tick. Please take it with a grain of salt as I'm not familiar with IE's recipe system.

(each tick is represented by the logging statements between "active: ---- process: ----")


<img width="720" height="334" alt="image" src="https://github.com/user-attachments/assets/aae596ee-f6f4-4e4f-adf6-22107d2f206a" />
-# The logs showing how the multiblock stays "active" for one tick despite not having an input.



Tick 1: The input is given. At the time, the multiblock **is** active (but active here is IE's variable for "active before tick"). The recipe starts, and the counter is set (for coal, what I tested with, it's 6000). There's a tick of delay with my logging system as I'm logging before the change, not after it, for simplicity.

Tick 2: Process is greater than zero, process count is decremented. **Log: 6000** Actually: **5999**

Tick 3: **The input was removed.** Process was greater than 0, so it checks to see if the input is empty. It is empty. Process is set to 0. **Log: 5999** Actually: **0**

Tick 4: ***This is the really important part.*** The multiblock is still **"active"** even though the input is empty. Hm, that's odd, isn't it? What were to happen if an input were to be inserted at the beginning of this tick?

`if process > 0` is ignored because process **is** 0. We skip straight to the else clause for this statement which checks if the multiblock is active (ie, active before this tick). **It's still active!** 

The recipe handler then goes through the checks of processing the recipe (getting output from input, properly inserting items into the output stack, properly generating creosote, ensuring there is no overflow, etc).

**In short:**

The entire recipe processing system is predicated on the notion that the preceding system to compare processing times to the actual recipe is respected, **and that no erroneous values of 0 are returned.** In fact the recipe processing system seems to rely on 0's being passed at the proper times.

Since you can trick the system into setting the process time to 0 for you, and then insert an item on that same tick, you can circumvent the process handler entirely.

# Code Description

When there is no input in the oven, it should no longer be active. That was the only change I found necessary to patch this bug.

1. I did test to ensure that items are processed as normal. That hasn't changed, and still works perfectly.
2. The only externality, if you will, of this PR is that there won't be a sound queued on the tick after the input is removed from the oven (the last tick when the oven has an item is the last tick for sound queuing here). I see this as a nonissue, but wanted you to be aware in case you really wanted this feature.

Thank you kindly for your time. 
