### PR TITLE
Create centralized space to limit dye colors to only vanilla ones whe…

### DIFF
--- a/src/api/java/blusunrize/immersiveengineering/api/utils/SignalColors.java
+++ b/src/api/java/blusunrize/immersiveengineering/api/utils/SignalColors.java
@@ -1,0 +1,29 @@
+/*
+ * BluSunrize
+ * Copyright (c) 2025
+ *
+ * This code is licensed under "Blu's License of Common Sense"
+ * Details can be found in the license file in the root folder of this project
+ */
+
+package blusunrize.immersiveengineering.api.utils;
+
+import net.minecraft.world.item.DyeColor;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class SignalColors
+{
+
+	public static final int COUNT = 16;
+
+	public static Stream<DyeColor> colors() {
+		return Arrays.stream(DyeColor.values()).filter(it -> it.getId() < COUNT);
+	}
+
+	public static DyeColor[] colorsArray() {
+		return colors().toArray(DyeColor[]::new);
+	}
+
+}

--- a/src/main/java/blusunrize/immersiveengineering/client/gui/RadioTowerScreen.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/RadioTowerScreen.java
@@ -9,6 +9,7 @@
 package blusunrize.immersiveengineering.client.gui;
 
 import blusunrize.immersiveengineering.api.Lib;
+import blusunrize.immersiveengineering.api.utils.SignalColors;
 import blusunrize.immersiveengineering.client.gui.elements.GuiButtonIE;
 import blusunrize.immersiveengineering.client.gui.elements.GuiButtonIE.ButtonTexture;
 import blusunrize.immersiveengineering.client.gui.elements.ITooltipWidget;
@@ -135,8 +136,7 @@ public class RadioTowerScreen extends IEContainerScreen<RadioTowerMenu>
 				this::sendFrequencyToServer
 		));
 
-		for(final DyeColor color : DyeColor.values())
-		{
+		SignalColors.colors().forEach(color -> {
 			final int ordinal = color.ordinal();
 			this.addRenderableWidget(new SaveButton(
 					getGuiLeft()+12+(ordinal%8)*20,
@@ -158,7 +158,7 @@ public class RadioTowerScreen extends IEContainerScreen<RadioTowerMenu>
 						}
 					}
 			));
-		}
+		});
 	}
 
 	private void sendFrequencyToServer(int frq)

--- a/src/main/java/blusunrize/immersiveengineering/client/gui/elements/GuiButtonDyeColor.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/elements/GuiButtonDyeColor.java
@@ -8,6 +8,7 @@
 
 package blusunrize.immersiveengineering.client.gui.elements;
 
+import blusunrize.immersiveengineering.api.utils.SignalColors;
 import blusunrize.immersiveengineering.client.gui.elements.GuiButtonIE.ButtonTexture;
 import blusunrize.immersiveengineering.client.gui.elements.GuiButtonIE.IIEPressable;
 import blusunrize.immersiveengineering.client.utils.GuiHelper;
@@ -29,7 +30,7 @@ public class GuiButtonDyeColor extends GuiButtonState<DyeColor>
 		super(
 				x, y, 8, 8,
 				Component.nullToEmpty(name),
-				DyeColor.values(), color, allSame(DyeColor.values(), GuiButtonCheckbox.TEXTURE), handler, tooltip
+				SignalColors.colorsArray(), color, allSame(SignalColors.colorsArray(), GuiButtonCheckbox.TEXTURE), handler, tooltip
 		);
 	}
 
@@ -41,7 +42,7 @@ public class GuiButtonDyeColor extends GuiButtonState<DyeColor>
 		super(
 				x, y, w, h,
 				Component.empty(),
-				DyeColor.values(), color, allSame(DyeColor.values(), texture), handler, tooltip
+				SignalColors.colorsArray(), color, allSame(SignalColors.colorsArray(), texture), handler, tooltip
 		);
 	}
 

--- a/src/main/java/blusunrize/immersiveengineering/client/gui/elements/GuiButtonLogicCircuitRegister.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/elements/GuiButtonLogicCircuitRegister.java
@@ -9,6 +9,7 @@
 package blusunrize.immersiveengineering.client.gui.elements;
 
 import blusunrize.immersiveengineering.api.tool.LogicCircuitHandler.LogicCircuitRegister;
+import blusunrize.immersiveengineering.api.utils.SignalColors;
 import blusunrize.immersiveengineering.client.gui.elements.GuiButtonIE.ButtonTexture;
 import blusunrize.immersiveengineering.client.gui.elements.GuiButtonIE.IIEPressable;
 import blusunrize.immersiveengineering.client.utils.GuiHelper;
@@ -83,11 +84,10 @@ public class GuiButtonLogicCircuitRegister extends GuiButtonState<LogicCircuitRe
 
 	static
 	{
-		for(DyeColor dye : DyeColor.values())
-		{
+		SignalColors.colors().forEach(dye -> {
 			String transl = I18n.get("color.minecraft."+dye.getName()).toLowerCase(Locale.ROOT);
 			SPLIT_BY_INITIAL.get(transl.charAt(0)).add(dye.getId());
-		}
+		});
 	}
 
 	@Override

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/RedstoneSwitchboardBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/RedstoneSwitchboardBlockEntity.java
@@ -12,6 +12,7 @@ import blusunrize.immersiveengineering.ImmersiveEngineering;
 import blusunrize.immersiveengineering.api.IEProperties;
 import blusunrize.immersiveengineering.api.Lib;
 import blusunrize.immersiveengineering.api.TargetingInfo;
+import blusunrize.immersiveengineering.api.utils.SignalColors;
 import blusunrize.immersiveengineering.api.utils.shapes.CachedVoxelShapes;
 import blusunrize.immersiveengineering.api.utils.shapes.ShapeUtils;
 import blusunrize.immersiveengineering.api.wires.Connection;
@@ -120,8 +121,9 @@ public class RedstoneSwitchboardBlockEntity extends ImmersiveConnectableBlockEnt
 	{
 		if(cp.index()==RIGHT_INDEX)
 		{
-			for(DyeColor dye : DyeColor.values())
-				signals[dye.getId()] = (byte)Math.max(signals[dye.getId()], this.output[dye.getId()]);
+			SignalColors.colors().forEach(dye ->
+					signals[dye.getId()] = (byte)Math.max(signals[dye.getId()], this.output[dye.getId()])
+			);
 			this.rsDirty = false;
 		}
 	}

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/LogicUnitBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/LogicUnitBlockEntity.java
@@ -14,6 +14,7 @@ import blusunrize.immersiveengineering.api.tool.LogicCircuitHandler.LogicCircuit
 import blusunrize.immersiveengineering.api.tool.LogicCircuitHandler.LogicCircuitRegister;
 import blusunrize.immersiveengineering.api.utils.DirectionUtils;
 import blusunrize.immersiveengineering.api.utils.ResettableLazy;
+import blusunrize.immersiveengineering.api.utils.SignalColors;
 import blusunrize.immersiveengineering.api.wires.redstone.CapabilityRedstoneNetwork;
 import blusunrize.immersiveengineering.api.wires.redstone.CapabilityRedstoneNetwork.RedstoneBundleConnection;
 import blusunrize.immersiveengineering.common.blocks.BlockCapabilityRegistration.BECapabilityRegistrar;
@@ -53,15 +54,14 @@ import java.util.stream.Stream;
 public class LogicUnitBlockEntity extends IEBaseBlockEntity implements IIEInventory, IBlockEntityDrop,
 		IInteractionObjectIE<LogicUnitBlockEntity>, IStateBasedDirectional, ILogicCircuitHandler
 {
-	private final static int SIZE_COLORS = DyeColor.values().length;
-	private final static int SIZE_REGISTERS = LogicCircuitRegister.values().length-SIZE_COLORS;
+	private final static int SIZE_REGISTERS = LogicCircuitRegister.values().length-SignalColors.COUNT;
 	public static final int NUM_SLOTS = 10;
 
 	private final NonNullList<ItemStack> inventory = NonNullList.withSize(NUM_SLOTS, ItemStack.EMPTY);
 
 	private final Map<Direction, boolean[]> inputs = new EnumMap<>(Direction.class);
 	private final boolean[] registers = new boolean[SIZE_REGISTERS];
-	private final boolean[] outputs = new boolean[SIZE_COLORS];
+	private final boolean[] outputs = new boolean[SignalColors.COUNT];
 
 	public LogicUnitBlockEntity(BlockPos pos, BlockState state)
 	{
@@ -164,7 +164,7 @@ public class LogicUnitBlockEntity extends IEBaseBlockEntity implements IIEInvent
 
 	private void updateOutputs()
 	{
-		boolean[] outPre = Arrays.copyOf(outputs, SIZE_COLORS);
+		boolean[] outPre = Arrays.copyOf(outputs, SignalColors.COUNT);
 		Arrays.fill(registers, false);
 		Arrays.fill(outputs, false);
 		getInstructions().forEachOrdered(instruction -> instruction.apply(this));
@@ -194,9 +194,9 @@ public class LogicUnitBlockEntity extends IEBaseBlockEntity implements IIEInvent
 				@Override
 				public void onChange(byte[] externalInputs, Direction side)
 				{
-					boolean[] sideInputs = inputs.getOrDefault(side, new boolean[SIZE_COLORS]);
-					boolean[] preInput = Arrays.copyOf(sideInputs, SIZE_COLORS);
-					for(int i = 0; i < SIZE_COLORS; i++)
+					boolean[] sideInputs = inputs.getOrDefault(side, new boolean[SignalColors.COUNT]);
+					boolean[] preInput = Arrays.copyOf(sideInputs, SignalColors.COUNT);
+					for(int i = 0; i < SignalColors.COUNT; i++)
 						sideInputs[i] = externalInputs[i] > 0;
 					// if the input changed, update and run circuits
 					if(!Arrays.equals(preInput, sideInputs))
@@ -210,9 +210,10 @@ public class LogicUnitBlockEntity extends IEBaseBlockEntity implements IIEInvent
 				@Override
 				public void updateInput(byte[] signals, Direction side)
 				{
-					for(DyeColor dye : DyeColor.values())
+					SignalColors.colors().forEach(dye -> {
 						if(outputs[dye.getId()])
 							signals[dye.getId()] = (byte)15;
+					});
 				}
 			};
 			redstoneCaps.put(f, forSide);
@@ -228,9 +229,9 @@ public class LogicUnitBlockEntity extends IEBaseBlockEntity implements IIEInvent
 	}
 
 	private final ResettableLazy<boolean[]> combinedInputs = new ResettableLazy<>(() -> {
-		boolean[] ret = new boolean[SIZE_COLORS];
+		boolean[] ret = new boolean[SignalColors.COUNT];
 		for(boolean[] side : this.inputs.values())
-			for(int i = 0; i < SIZE_COLORS; ++i)
+			for(int i = 0; i < SignalColors.COUNT; ++i)
 				ret[i] |= side[i];
 		return ret;
 	});
@@ -238,17 +239,17 @@ public class LogicUnitBlockEntity extends IEBaseBlockEntity implements IIEInvent
 	@Override
 	public boolean getLogicCircuitRegister(LogicCircuitRegister register)
 	{
-		if(register.ordinal() < SIZE_COLORS)
+		if(register.ordinal() < SignalColors.COUNT)
 			return combinedInputs.get()[register.ordinal()];
-		return this.registers[register.ordinal()-SIZE_COLORS];
+		return this.registers[register.ordinal()-SignalColors.COUNT];
 	}
 
 	@Override
 	public void setLogicCircuitRegister(LogicCircuitRegister register, boolean state)
 	{
-		if(register.ordinal() < SIZE_COLORS)
+		if(register.ordinal() < SignalColors.COUNT)
 			this.outputs[register.ordinal()] = state;
 		else
-			this.registers[register.ordinal()-SIZE_COLORS] = state;
+			this.registers[register.ordinal()-SignalColors.COUNT] = state;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/MachineInterfaceBlockEntity.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/blocks/wooden/MachineInterfaceBlockEntity.java
@@ -13,6 +13,7 @@ import blusunrize.immersiveengineering.api.IEProperties;
 import blusunrize.immersiveengineering.api.Lib;
 import blusunrize.immersiveengineering.api.tool.MachineInterfaceHandler.IMachineInterfaceConnection;
 import blusunrize.immersiveengineering.api.tool.MachineInterfaceHandler.MachineCheckImplementation;
+import blusunrize.immersiveengineering.api.utils.SignalColors;
 import blusunrize.immersiveengineering.api.wires.redstone.CapabilityRedstoneNetwork;
 import blusunrize.immersiveengineering.api.wires.redstone.CapabilityRedstoneNetwork.RedstoneBundleConnection;
 import blusunrize.immersiveengineering.common.blocks.BlockCapabilityRegistration.BECapabilityRegistrar;
@@ -52,7 +53,7 @@ public class MachineInterfaceBlockEntity extends IEBaseBlockEntity implements IE
 
 	public List<MachineInterfaceConfig<?>> configurations = new ArrayList<>();
 
-	private final int[] outputs = new int[DyeColor.values().length];
+	private final int[] outputs = new int[SignalColors.COUNT];
 
 	public DyeColor inputColor = DyeColor.WHITE;
 	private byte inputSignalStrength = 0;
@@ -157,8 +158,9 @@ public class MachineInterfaceBlockEntity extends IEBaseBlockEntity implements IE
 		@Override
 		public void updateInput(byte[] signals, Direction side)
 		{
-			for(DyeColor dye : DyeColor.values())
-				signals[dye.getId()] = (byte)outputs[dye.getId()];
+			SignalColors.colors().forEach(dye ->
+				signals[dye.getId()] = (byte)outputs[dye.getId()]
+			);
 		}
 	};
 

--- a/src/main/java/blusunrize/immersiveengineering/common/util/Utils.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/util/Utils.java
@@ -128,9 +128,9 @@ public class Utils
 		if(stack.isEmpty())
 			return null;
 		if(stack.is(Tags.Items.DYES))
-			for(Entry<TagKey<Item>, DyeColor> entry : DYES_BY_TAG.entrySet())
-				if(stack.is(entry.getKey()))
-					return entry.getValue();
+			for(DyeColor color : DyeColor.values())
+				if(stack.is(color.getTag()))
+					return color;
 		return null;
 	}
 


### PR DESCRIPTION
This PR fixes two issues that occur when playing with mods that add more dye colors:
- the changes in `Utils.java` allow these new dyes to color conveyors and balloons
- all other changes limit the dye colors used for signaling to the vanilla ones, even if others are present.

Especially the second change allows it to work with mods like dye depot without simply crashing on startup in many different ways.
What this PR does not fix and is in no way the responsibility of IE is missing data & assets for chutes and sheet metals.
I have still allowed them to be automatically created by looping through `DyeColors.values()` instead of only using vanilla colors here. This is in order for other mods, specifically [Dye The World](https://github.com/PssbleTrngle/DyeTheWorld) to add these assets and data and allow this compatibility