### PR TITLE
Fix GuiReactiveList Text-Scrolling being Too Fast

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/gui/elements/GuiReactiveList.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/gui/elements/GuiReactiveList.java
@@ -46,7 +46,7 @@ public class GuiReactiveList<E> extends Button
 	private int maxOffset;
 
 	private int targetEntry = -1;
-	private int hoverTimer = 0;
+	private float hoverTimer = 0;
 
 	public GuiReactiveList(int x, int y, int w, int h, IIEPressable<? extends GuiReactiveList> handler, Supplier<List<E>> entries, Function<E, String> toStringFunction)
 	{
@@ -151,7 +151,7 @@ public class GuiReactiveList<E> extends Button
 					hoverTimer = 0;
 				}
 				else
-					hoverTimer++;
+					hoverTimer += 0.5f * partialTicks;
 				col = this.textColorHovered;
 			}
 			if(j > entries.size()-1)
@@ -162,7 +162,7 @@ public class GuiReactiveList<E> extends Button
 			{
 				if(selectionHover&&hoverTimer > 20)
 				{
-					int textOffset = (hoverTimer/10)%(s.length());
+					int textOffset = (int) ((hoverTimer/10)%(s.length()));
 					s = s.substring(textOffset)+" "+s.substring(0, textOffset);
 				}
 				s = fr.plainSubstrByWidth(s, strWidth);


### PR DESCRIPTION
Regardless of FPS count the Speed now stays constant and is neither too fast nor too slow.

---
Basicly copied from https://github.com/TwistedGate/ImmersivePetroleum/commit/e0941ebb3357d0c92b0da67df207a4ac3e374687