### PR TITLE
Update manual for clarity & more information

### DIFF
--- a/src/main/resources/assets/immersiveengineering/manual/en_us/alloy_kiln.txt
+++ b/src/main/resources/assets/immersiveengineering/manual/en_us/alloy_kiln.txt
@@ -1,6 +1,9 @@
 Alloy Kiln
 Mixin' Metals
-<&recipe>The Alloy Kiln is a simple furnace made out of heat resistant sandstone and bricks. Within it, temperatures are high enough to allow metals to be melted into a fluid state and mixed, creating an <link;basic_metal_products;alloy;alloys>.
-This allows the creation of important alloys like Electrum and Constantan without the tedious mixing of dusts.<np>
-<&multiblock>To form the Kiln, arrange 8 of the Kiln Bricks in a 2x2x2 cube, as shown above, and rightclick one of the sides' blocks with an Engineer's Hammer.<np>
+<&recipe>The Alloy Kiln is a simple, fuel-burning furnace made of sandstone and bricks.<br>
+Within it, temperatures are high enough to allow metals to be melted and mixed into an <link;basic_metal_products;alloy;alloys>.<br>
+This allows the creation of important alloys like Electrum and Constantan without the tedious and expensive crushing and mixing of dusts.<br>
+The Alloy Kiln is §lnot§r automateable. All in- and outputs must be arranged manually through its GUI.<br>
+To automate the creation of alloys, the <link;arc_furnace;Arc Furnace;> or the <link;crusher;Crusher;> combined with an <link;assembler;Assembler;> can be used.<np>
+<&multiblock>To form the Alloy Kiln, arrange 8 of the kiln bricks in a 2x2x2 cube, and rightclick the top right block on any side with an Engineer's Hammer.<np>
 <&insulating_glass>The alloy kiln is also essential in the creation of §2insulating glass§r, a component used in the construction of <link;basic_wiring;high-voltage architecture;connector_recipes>.

--- a/src/main/resources/assets/immersiveengineering/manual/en_us/coke_oven.txt
+++ b/src/main/resources/assets/immersiveengineering/manual/en_us/coke_oven.txt
@@ -3,7 +3,7 @@ Purity in Pyrolysis
 <&recipe>The Coke Oven is the first important machine on the engineer's journey.<br>
 The brick oven heats up fuels in a low-oxygen environment, pyrolyzing them into a more carbon-rich version, such as §2Coal Coke§r, or §2Charcoal§r.<np>
 A byproduct of this process is <link;industrial_fluids;Creosote Oil;creosote_oil>, which is used as a <link;treated_wood;preservative for wood>. This preserved wood serves as a basic construction material all throughout.<br>
-The coking process is §oslow§r, but works in batches, allowing up to §216 pieces of coal§r or §28 wooden logs§r to be processed at the same time.
+The coking process is §oslow§r, but works in batches, allowing up to §216 pieces of coal§r or §28 wooden logs§r to be processed at once.<br>
 As such, it's recommended to build multiple ovens and stock them with enough fuel to be efficient.<br>
 The Coke Oven can be automated to facilitate a more industrial scale of fuel and oil production.<br>
 Items can be inserted and extracted by use of hoppers or <link;conveyor_belts;conveyor belts;conveyor_extract_recipe>.<br>

--- a/src/main/resources/assets/immersiveengineering/manual/en_us/crude_blast_furnace.txt
+++ b/src/main/resources/assets/immersiveengineering/manual/en_us/crude_blast_furnace.txt
@@ -1,6 +1,6 @@
 Crude Blast Furnace
 Simple Steel
-<&block>The Crude Blast Furnace is used to increase the carbon contents in iron, turning it into TD LINK STEEL.<br>
+<&block>The Crude Blast Furnace is used to increase the carbon contents in iron, turning it into <link;basic_metal_products;steel;alloys>.<br>
  To achieve this, only pure, high-carbon fuels may be used for the furnace, such as <link;coke_oven;coal coke and charcoal>.<np>
 <&outputs>Along with steel, the furnace will also create <link;industrial_byproducts;slag;slag>, which you must remove or the furnace will cease to function.<br>
 While it is technically a waste product, there are various ways to recycle it, such as <link;slag_products;brick construction> or <link;concrete;concrete>.<np>

--- a/src/main/resources/assets/immersiveengineering/manual/en_us/feedthrough_insulators.txt
+++ b/src/main/resources/assets/immersiveengineering/manual/en_us/feedthrough_insulators.txt
@@ -4,4 +4,5 @@ Hole In The Wall Tavern
 With the careful application of terracotta insulation, a solid conduit can be constructed inside of these materials to conduct power.<br>
 The Feedthrough Insulator allows two connectors to be merged across one meter walls, and cannot connect more than one wire per connector.<br>
 They can be created with any "normal" solid block in the middle, by right-clicking either of two connectors with an Engineer's Hammer.<br>
+Power throughput is limited to the maximum wire throughput, as they do not need to connect to machines.<br>
 Non-structural connectors can be used to create feedthrough insulators for the corresponding wire type.

--- a/src/main/resources/assets/immersiveengineering/manual/en_us/fluid_pump.txt
+++ b/src/main/resources/assets/immersiveengineering/manual/en_us/fluid_pump.txt
@@ -3,7 +3,7 @@ The Pressure is On
 <&pump_recipe>Fluid Pumps are used to move and pressurize fluids, both within and without pipe systems.<br>
 Fluids will only be pumped from <link;storage_barrels;fluid barrels> or <link;storage_minecarts;minecarts;fluid_storage> if the tank and pump have connections on that side.<br>
 Using the Engineer's Hammer on the faces of the lower half of the pump will change the connection between input, output, and blocked.<br>
-When given a redstone signal, the fluid pump will extract at low power. Right-clicking it with an Engineer's Screwdriver will invert this behavior.<br>
-Providing a fluid pump with flux will engage the high pressure pump and significantly increase the transfer rate.<br>
-When placed against pools of fluid in the world, pumps will suck up the fluid into their internal tank from their inputs. Water can be pumped in the same way it can be picked up with a bucket.<br>
+When given a redstone signal, the fluid pump will extract at one bucket per second. Right-clicking it with an Engineer's Screwdriver will invert this behavior.<br>
+Providing a fluid pump with flux and a redstone signal will engage the high pressure pump and increase the transfer rate by twenty times.<br>
+When placed against pools of fluid in the world and provided flux, pumps will suck up the fluid into their internal tank from their inputs. Water can be pumped in the same way it can be picked up with a bucket.<br>
 Fluids that are picked up will be replaced with cobblestone to the amount of flowing fluids in the world. This behavior can be toggled off and on by using an Engineer's Hammer on the pump's top while sneaking.

--- a/src/main/resources/assets/immersiveengineering/manual/en_us/redstone_probe.txt
+++ b/src/main/resources/assets/immersiveengineering/manual/en_us/redstone_probe.txt
@@ -15,6 +15,6 @@ A comparator at the electrodes at the top will send a signal reflecting the inte
 §lSqueezer: §rOutputs a signal relative to the fill of the inventory.
 §lFermenter: §rOutputs a signal relative to the fill of the inventory.
 §lMixer: §rOutputs a signal relative to the fill of the inventory.<np>
-§lExcavator: §rOutputs a signal relative to the remaining ore in the vein.<br>
+§lExcavator: §rOutputs a signal relative to the remaining ore in all accessible veins.<br>
 <br>
 For more detailed analysis of the various multiblocks, their inventories, energy- and fluid storages, consider using the <link;machine_interface;Machine Interface> instead.


### PR DESCRIPTION
 - Fix #6319
 - Fix up alloy kiln entry for forming information & the fact that it is not automatable
 - Fix excavator info in redstone probe entry
 - Add missing link in CBF entry
 - Minor wording changes for spacing in coke oven entry
 - Specify throughput limit of feedthroughs in their entry