### PR TITLE
Skip potions without registry keys in recipe generation

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/common/crafting/PotionRecipeGenerators.java
+++ b/src/main/java/blusunrize/immersiveengineering/common/crafting/PotionRecipeGenerators.java
@@ -81,6 +81,11 @@ public class PotionRecipeGenerators
 		};
 
 		PotionHelper.applyToAllPotionRecipes((out, in, reagent) -> {
+			if(out.unwrapKey().isEmpty())
+			{
+				IELogger.logger.warn("Skipping potion without registry key in bottling/bullet recipe generation");
+				return;
+			}
 			if(!bottleRecipes.containsKey(out))
 				bottleRecipes.put(out, toBottleRecipe.apply(out));
 			if(!bulletRecipes.containsKey(out))
@@ -89,10 +94,9 @@ public class PotionRecipeGenerators
 		bottleRecipes.put(Potions.WATER, toBottleRecipe.apply(Potions.WATER));
 		IELogger.logger.info(
 				"Recipes for potions: "+bottleRecipes.keySet().stream()
-						.map(h -> h.unwrapKey().orElseThrow().location().toString())
+						.map(h -> h.unwrapKey().map(k -> k.location().toString()).orElse("unknown"))
 						.collect(Collectors.joining(", "))
 		);
-		;
 
 		List<BottlingMachineRecipe> ret = new ArrayList<>(
 				bottleRecipes.values().stream()
@@ -107,7 +111,13 @@ public class PotionRecipeGenerators
 			Holder<Potion> output, Holder<Potion> input, IngredientWithSize reagent, Map<Potion, List<MixerRecipe>> all
 	)
 	{
-		ResourceLocation outputID = output.unwrapKey().orElseThrow().location();
+		var outputKey = output.unwrapKey();
+		if(outputKey.isEmpty())
+		{
+			IELogger.logger.warn("Skipping potion without registry key in mixer recipe generation");
+			return;
+		}
+		ResourceLocation outputID = outputKey.get().location();
 		if(!BLACKLIST.contains(outputID.toString()))
 		{
 			List<MixerRecipe> existing = all.computeIfAbsent(output.value(), p -> new ArrayList<>());


### PR DESCRIPTION
Fixes #6364.

When another mod registers a potion brewing recipe using a `Holder.direct()` (no registry key) instead of a proper `Holder.Reference`, `PotionRecipeGenerators` crashes with `NoSuchElementException` at the `unwrapKey().orElseThrow()` calls. This causes a `Failed to encode packet 'clientbound/minecraft:update_recipes'` error that disconnects clients from the server.

This PR adds defensive checks in three places:
- **`getPotionBottlingRecipes()` callback** — skips potions without registry keys before adding bottling/bullet recipes
- **`getPotionBottlingRecipes()` logging** — uses `orElse("unknown")` instead of `orElseThrow()`
- **`registerPotionRecipe()`** — early-returns for potions without registry keys

All skipped potions log a warning for debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)