### PR TITLE
Lighting and major rendering performance fixes for multiblocks

### DIFF
--- a/src/main/java/blusunrize/immersiveengineering/client/models/split/AbstractSplitModel.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/split/AbstractSplitModel.java
@@ -18,6 +18,7 @@ import malte0811.modelsplitter.SplitModel;
 import malte0811.modelsplitter.math.ModelSplitterVec3i;
 import malte0811.modelsplitter.model.OBJModel;
 import malte0811.modelsplitter.model.Polygon;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelState;
@@ -27,6 +28,8 @@ import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.model.data.ModelData;
+import net.neoforged.neoforge.common.util.TriState;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.util.*;
@@ -38,10 +41,25 @@ public abstract class AbstractSplitModel<T extends BakedModel> extends Composite
 	@Nonnull
 	private final Vec3i size;
 
-	public AbstractSplitModel(T base, Vec3i size)
+	public AbstractSplitModel(T base, @NotNull Vec3i size)
 	{
 		super(base);
 		this.size = size;
+	}
+
+	// Ambient occlusion assumes normal cube lighting, which conflicts with shading
+	// Bake into split quads. Turn it off for these models.
+	@Override
+	public boolean useAmbientOcclusion()
+	{
+		return false;
+	}
+
+	@Nonnull
+	@Override
+	public TriState useAmbientOcclusion(BlockState state, ModelData data, RenderType renderType)
+	{
+		return TriState.FALSE;
 	}
 
 	@Nonnull

--- a/src/main/java/blusunrize/immersiveengineering/client/models/split/BakedBasicSplitModel.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/split/BakedBasicSplitModel.java
@@ -13,6 +13,7 @@ import blusunrize.immersiveengineering.api.IEApi;
 import blusunrize.immersiveengineering.api.IEProperties.Model;
 import blusunrize.immersiveengineering.api.utils.ResettableLazy;
 import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
@@ -22,6 +23,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.client.model.data.ModelData;
 
@@ -63,15 +65,23 @@ public class BakedBasicSplitModel extends AbstractSplitModel<BakedModel>
 	{
 		BlockPos offset = extraData.get(Model.SUBMODEL_OFFSET);
 		if(offset!=null)
+		{
+			// Split parts aren't full cubes, so they don't have real sides to cull by. Only
+			// answer the "give me everything" request, not each individual face - otherwise the
+			// geometry gets rendered multiple times.
+			if(side!=null)
+				return ImmutableList.of();
 			return splitModels.get().getOrDefault(offset, ImmutableList.of());
+		}
 		else
 			return base.getQuads(state, side, rand, extraData, layer);
 	}
 
 	@Nonnull
 	@Override
-	public ItemTransforms getTransforms()
+	public BakedModel applyTransform(@Nonnull ItemDisplayContext transformType, @Nonnull PoseStack poseStack, boolean applyLeftHandTransform)
 	{
-		return itemTransforms;
+		itemTransforms.getTransform(transformType).apply(applyLeftHandTransform, poseStack);
+		return this;
 	}
 }

--- a/src/main/java/blusunrize/immersiveengineering/client/models/split/BakedDynamicSplitModel.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/split/BakedDynamicSplitModel.java
@@ -46,12 +46,15 @@ public class BakedDynamicSplitModel<K, T extends ICacheKeyProvider<K> & BakedMod
 	{
 		super(base, size);
 		this.subModelCache = CacheBuilder.newBuilder()
-				.maximumSize(10)
-				.expireAfterAccess(1, TimeUnit.MINUTES)
+				.maximumSize(64)
+				.expireAfterAccess(10, TimeUnit.MINUTES)
 				.build(CacheLoader.from(key -> {
 					List<BakedQuad> baseQuads = base.getQuads(key);
 					return split(baseQuads, parts, transform);
 				}));
+		// Register with the reload cache so resource pack reloads actually clear data.
+		// Cache size increased since the old settings caused constant re-splitting.
+		WEAK_INSTANCES.add(this);
 	}
 
 	@Override
@@ -60,7 +63,9 @@ public class BakedDynamicSplitModel<K, T extends ICacheKeyProvider<K> & BakedMod
 		BlockPos offset = data.get(Model.SUBMODEL_OFFSET);
 		if(offset==null)
 			return super.getQuads(state, side, rand, data, renderType);
-		K key = base.getKey(state, side, rand, data, renderType);
+		if(side!=null)
+			return ImmutableList.of();
+		K key = base.getKey(state, null, rand, data, renderType);
 		if(key==null)
 			return ImmutableList.of();
 		return subModelCache.getUnchecked(key).getOrDefault(offset, ImmutableList.of());

--- a/src/main/java/blusunrize/immersiveengineering/client/models/split/PolygonUtils.java
+++ b/src/main/java/blusunrize/immersiveengineering/client/models/split/PolygonUtils.java
@@ -80,7 +80,36 @@ public class PolygonUtils
 
 	public static BakedQuad toBakedQuad(Polygon<ExtraQuadData> poly, ModelState transform)
 	{
-		return toBakedQuad(poly.getPoints(), poly.getTexture(), transform.getRotation().blockCenterToCorner(), true, true);
+		// Split models can't rely on vanilla's per-quad lighting, since it picks a single flat
+		// direction for the whole quad and that doesn't work well on curved/angled surfaces.
+		// Bake own smooth shading and skylight into each quad instead.
+		BakedQuad quad = toBakedQuad(poly.getPoints(), poly.getTexture(), transform.getRotation().blockCenterToCorner(), true, false);
+		bakeSplitLighting(quad);
+		return quad;
+	}
+
+	private static void bakeSplitLighting(BakedQuad quad)
+	{
+		final int stride = DefaultVertexFormat.BLOCK.getVertexSize()/4;
+		final int colorOffset = getOffset(VertexFormatElement.COLOR);
+		final int lightOffset = getOffset(VertexFormatElement.UV2);
+		final int normalOffset = getOffset(VertexFormatElement.NORMAL);
+		int[] verts = quad.getVertices();
+		for(int v = 0; v < 4; ++v)
+		{
+			final int base = v*stride;
+			final int packedNormal = verts[base+normalOffset];
+			final float nx = ((byte)packedNormal)/127f;
+			final float ny = ((byte)(packedNormal >> 8))/127f;
+			final float nz = ((byte)(packedNormal >> 16))/127f;
+			final float shade = Math.min(nx*nx*0.6f+ny*ny*((3+ny)/4f)+nz*nz*0.8f, 1);
+			final int c = verts[base+colorOffset];
+			final int r = Math.min((int)((c&255)*shade), 255);
+			final int g = Math.min((int)(((c>>8)&255)*shade), 255);
+			final int b = Math.min((int)(((c>>16)&255)*shade), 255);
+			verts[base+colorOffset] = r|(g<<8)|(b<<16)|(c&0xFF000000);
+			verts[base+lightOffset] = 0xF00000;
+		}
 	}
 
 	public static BakedQuad toBakedQuad(List<Vertex> points, ExtraQuadData data, Transformation rotation, boolean absoluteUV, boolean shade)


### PR DESCRIPTION
Fix lighting artifacts and duplicate rendering on split multiblocks

Large multiblocks built from split models (excavator, crusher, etc.) rendered their geometry as much as 7 times over. Fixed, along with a stale-cache bug that kept old geometry around after a resource reload.


Already proved working in Immersive Technology 1.20.1/1.21.1, and Immersive Fixes mixins for IE 1.20.1.