### PR TITLE
Fix Masterwork shader translation key

### DIFF
--- a/src/main/resources/assets/immersiveengineering/lang/cs_cz.json
+++ b/src/main/resources/assets/immersiveengineering/lang/cs_cz.json
@@ -305,7 +305,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Neobvyklý",
   "desc.immersiveengineering.info.shader.rarity.rare": "Vzácný",
   "desc.immersiveengineering.info.shader.rarity.epic": "Epický",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Mistrovské dílo",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Mistrovské dílo",
   "desc.immersiveengineering.info.shader.set": "Sada shaderů:",
   "desc.immersiveengineering.info.shader.reference": "Reference na populární kulturu:",
   "desc.immersiveengineering.info.shader.details": "Více informací:",

--- a/src/main/resources/assets/immersiveengineering/lang/de_de.json
+++ b/src/main/resources/assets/immersiveengineering/lang/de_de.json
@@ -175,7 +175,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Ungewöhnlich",
   "desc.immersiveengineering.info.shader.rarity.rare": "Selten",
   "desc.immersiveengineering.info.shader.rarity.epic": "Episch",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Meisterwerk",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Meisterwerk",
   "desc.immersiveengineering.info.shader.set": "Shader-Set:",
   "desc.immersiveengineering.info.shader.reference": "Verweis auf Popkultur:",
   "desc.immersiveengineering.info.shader.details": "Zusätzliche Info:",

--- a/src/main/resources/assets/immersiveengineering/lang/es_ar.json
+++ b/src/main/resources/assets/immersiveengineering/lang/es_ar.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Poco común",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra maestra",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra maestra",
   "desc.immersiveengineering.info.shader.set": "Conjunto de apariencias:",
   "desc.immersiveengineering.info.shader.reference": "Referencia a la cultura pop:",
   "desc.immersiveengineering.info.shader.details": "Información adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/es_cl.json
+++ b/src/main/resources/assets/immersiveengineering/lang/es_cl.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Poco común",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra maestra",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra maestra",
   "desc.immersiveengineering.info.shader.set": "Conjunto de apariencias:",
   "desc.immersiveengineering.info.shader.reference": "Referencia a la cultura pop:",
   "desc.immersiveengineering.info.shader.details": "Información adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/es_ec.json
+++ b/src/main/resources/assets/immersiveengineering/lang/es_ec.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Poco común",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra maestra",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra maestra",
   "desc.immersiveengineering.info.shader.set": "Conjunto de apariencias:",
   "desc.immersiveengineering.info.shader.reference": "Referencia a la cultura pop:",
   "desc.immersiveengineering.info.shader.details": "Información adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/es_es.json
+++ b/src/main/resources/assets/immersiveengineering/lang/es_es.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Poco común",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra maestra",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra maestra",
   "desc.immersiveengineering.info.shader.set": "Conjunto de apariencias:",
   "desc.immersiveengineering.info.shader.reference": "Referencia a la cultura pop:",
   "desc.immersiveengineering.info.shader.details": "Información adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/es_mx.json
+++ b/src/main/resources/assets/immersiveengineering/lang/es_mx.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Poco común",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra maestra",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra maestra",
   "desc.immersiveengineering.info.shader.set": "Conjunto de apariencias:",
   "desc.immersiveengineering.info.shader.reference": "Referencia a la cultura pop:",
   "desc.immersiveengineering.info.shader.details": "Información adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/es_uy.json
+++ b/src/main/resources/assets/immersiveengineering/lang/es_uy.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Poco común",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra maestra",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra maestra",
   "desc.immersiveengineering.info.shader.set": "Conjunto de apariencias:",
   "desc.immersiveengineering.info.shader.reference": "Referencia a la cultura pop:",
   "desc.immersiveengineering.info.shader.details": "Información adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/es_ve.json
+++ b/src/main/resources/assets/immersiveengineering/lang/es_ve.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Poco común",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra maestra",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra maestra",
   "desc.immersiveengineering.info.shader.set": "Conjunto de apariencias:",
   "desc.immersiveengineering.info.shader.reference": "Referencia a la cultura pop:",
   "desc.immersiveengineering.info.shader.details": "Información adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/fr_fr.json
+++ b/src/main/resources/assets/immersiveengineering/lang/fr_fr.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Peu commun",
   "desc.immersiveengineering.info.shader.rarity.rare": "Rare",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épique",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Chef-d'œuvre",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Chef-d'œuvre",
   "desc.immersiveengineering.info.shader.set": "Ensemble de Shader :",
   "desc.immersiveengineering.info.shader.reference": "Référence à la culture Pop:",
   "desc.immersiveengineering.info.shader.details": "Infos supplémentaires :",

--- a/src/main/resources/assets/immersiveengineering/lang/it_it.json
+++ b/src/main/resources/assets/immersiveengineering/lang/it_it.json
@@ -293,7 +293,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Non Comune",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Epico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Capolavoro",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Capolavoro",
   "desc.immersiveengineering.info.shader.set": "Set di shader:",
   "desc.immersiveengineering.info.shader.reference": "Riferimento alla cultura popolare:",
   "desc.immersiveengineering.info.shader.details": "Ulteriori Informazioni:",

--- a/src/main/resources/assets/immersiveengineering/lang/ja_jp.json
+++ b/src/main/resources/assets/immersiveengineering/lang/ja_jp.json
@@ -322,7 +322,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "アンコモン",
   "desc.immersiveengineering.info.shader.rarity.rare": "レア",
   "desc.immersiveengineering.info.shader.rarity.epic": "エピック",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "マスターワーク",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "マスターワーク",
   "desc.immersiveengineering.info.shader.set": "ガジェットスキンセット:",
   "desc.immersiveengineering.info.shader.reference": "元ネタ:",
   "desc.immersiveengineering.info.shader.details": "追加情報:",

--- a/src/main/resources/assets/immersiveengineering/lang/ko_kr.json
+++ b/src/main/resources/assets/immersiveengineering/lang/ko_kr.json
@@ -292,7 +292,7 @@
 "desc.immersiveengineering.info.shader.rarity.uncommon":"언커먼",
 "desc.immersiveengineering.info.shader.rarity.rare":"레어",
 "desc.immersiveengineering.info.shader.rarity.epic":"에픽",
-"desc.immersiveengineering.info.shader.rarity.ie_masterwork":"마스터워크",
+"desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork":"마스터워크",
 "desc.immersiveengineering.info.shader.set":"셰이더 설정:",
 "desc.immersiveengineering.info.shader.reference":"참고 작품:",
 "desc.immersiveengineering.info.shader.details":"추가 정보:",

--- a/src/main/resources/assets/immersiveengineering/lang/pt_br.json
+++ b/src/main/resources/assets/immersiveengineering/lang/pt_br.json
@@ -289,7 +289,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Incomum",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra-prima",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra-prima",
   "desc.immersiveengineering.info.shader.set": "Camuflagem:",
   "desc.immersiveengineering.info.shader.reference": "Referência à Cultura Pop:",
   "desc.immersiveengineering.info.shader.details": "Informação Adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/pt_pt.json
+++ b/src/main/resources/assets/immersiveengineering/lang/pt_pt.json
@@ -283,7 +283,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Invulgar",
   "desc.immersiveengineering.info.shader.rarity.rare": "Raro",
   "desc.immersiveengineering.info.shader.rarity.epic": "Épico",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Obra-Mestre",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Obra-Mestre",
   "desc.immersiveengineering.info.shader.set": "Conjunto:",
   "desc.immersiveengineering.info.shader.reference": "Referência Cultural:",
   "desc.immersiveengineering.info.shader.details": "Info Adicional:",

--- a/src/main/resources/assets/immersiveengineering/lang/ru_ru.json
+++ b/src/main/resources/assets/immersiveengineering/lang/ru_ru.json
@@ -294,7 +294,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Необычный",
   "desc.immersiveengineering.info.shader.rarity.rare": "Редкий",
   "desc.immersiveengineering.info.shader.rarity.epic": "Эпический",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Шедевральный",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Шедевральный",
   "desc.immersiveengineering.info.shader.set": "§lНабор шейдеров§r:",
   "desc.immersiveengineering.info.shader.reference": "§lСсылка на попкультуру§r:",
   "desc.immersiveengineering.info.shader.details": "§lДополнительное инфо§r:",

--- a/src/main/resources/assets/immersiveengineering/lang/tr_tr.json
+++ b/src/main/resources/assets/immersiveengineering/lang/tr_tr.json
@@ -200,7 +200,7 @@
   "desc.immersiveengineering.info.shader.rarity.uncommon": "Yaygın Olmayan",
   "desc.immersiveengineering.info.shader.rarity.rare": "Nadir",
   "desc.immersiveengineering.info.shader.rarity.epic": "Epik",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Ustalık Eseri",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Ustalık Eseri",
   "desc.immersiveengineering.info.shader.set": "Gölgelendirici Seti:",
   "desc.immersiveengineering.info.shader.reference": "Popüler Kültüre Referans:",
   "desc.immersiveengineering.info.shader.details": "Ek Bilgi:",

--- a/src/main/resources/assets/immersiveengineering/lang/uk_ua.json
+++ b/src/main/resources/assets/immersiveengineering/lang/uk_ua.json
@@ -305,7 +305,7 @@
     "desc.immersiveengineering.info.shader.rarity.uncommon": "Незвичайний",
     "desc.immersiveengineering.info.shader.rarity.rare": "Рідкісний",
     "desc.immersiveengineering.info.shader.rarity.epic": "Епічний",
-    "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "Шедевральний",
+    "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "Шедевральний",
     "desc.immersiveengineering.info.shader.set": "Набір шейдерів:",
     "desc.immersiveengineering.info.shader.reference": "Посилання на попкультуру:",
     "desc.immersiveengineering.info.shader.details": "Додаткова інформація:",

--- a/src/main/resources/assets/immersiveengineering/lang/zh_cn.json
+++ b/src/main/resources/assets/immersiveengineering/lang/zh_cn.json
@@ -1373,7 +1373,7 @@
   "desc.immersiveengineering.info.shader.level": "等级：",
   "desc.immersiveengineering.info.shader.rarity.common": "常见",
   "desc.immersiveengineering.info.shader.rarity.epic": "史诗",
-  "desc.immersiveengineering.info.shader.rarity.ie_masterwork": "杰作",
+  "desc.immersiveengineering.info.shader.rarity.immersiveengineering_masterwork": "杰作",
   "desc.immersiveengineering.info.shader.rarity.rare": "稀有",
   "desc.immersiveengineering.info.shader.rarity.uncommon": "少见",
   "desc.immersiveengineering.info.shader.reference": "参考潮流文化：",


### PR DESCRIPTION
## Summary

- Update localized Masterwork shader rarity keys to match the NeoForge-generated key.
- Apply the key change to all 19 localized language files; the English resource already uses the canonical key.

## Why

The shader manual builds the rarity translation key from the NeoForge-added rarity name, which resolves to `immersiveengineering_masterwork`. Localized resources still used the older `ie_masterwork` key, causing Masterwork shaders to display the raw translation key.

## Verification

- `.\gradlew.bat processResources --console=plain` ✅
- `.\gradlew.bat compileJava test --console=plain` ✅
- `.\gradlew.bat runData --console=plain` ✅
- Manually tested the NeoForge 1.21.1 client: Engineer's Manual → Shader List displays `Level: Masterwork` for IKELOS, Crimson Lotus, and Ancient.

<img width="854" height="480" alt="2026-08-24_18 39 33" src="https://github.com/user-attachments/assets/a7c79949-0223-43df-8956-949cc16c4d7c" />

## Related issue

Fixes #6436